### PR TITLE
Implement centered version of RMSProp optimizer

### DIFF
--- a/src/optimizers/optimizer_constructors.ts
+++ b/src/optimizers/optimizer_constructors.ts
@@ -100,12 +100,16 @@ export class OptimizerConstructors {
    * @param momentum The momentum to use for the RMSProp gradient descent
    * algorithm.
    * @param epsilon Small value to avoid zero denominator.
+   * @param centered If true, gradients are normalized by the estimated
+   * variance of the gradient.
    */
   @doc({heading: 'Training', subheading: 'Optimizers', namespace: 'train'})
   static rmsprop(
-      learningRate: number, decay = .9, momentum = 0.0, epsilon = 1e-8):
+      learningRate: number, decay = .9, momentum = 0.0, epsilon = 1e-8,
+      centered = false):
       RMSPropOptimizer {
-    return new RMSPropOptimizer(learningRate, decay, momentum, epsilon);
+    return new RMSPropOptimizer(learningRate, decay, momentum, epsilon,
+      centered);
   }
 
   /**

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -29,13 +29,15 @@ export class RMSPropOptimizer extends Optimizer {
   private decay: Scalar;
   private momentum: Scalar;
   private oneMinusDecay: Scalar;
+  private centered: boolean;
 
   private accumulatedMeanSquares: NamedVariableMap = {};
+  private accumulatedMeanGrads: NamedVariableMap = {};
   private accumulatedMoments: NamedVariableMap = {};
 
   constructor(
       protected learningRate: number, decay = 0.9, momentum = 0.0,
-      epsilon = 1e-8) {
+      epsilon = 1e-8, centered = false) {
     super();
 
     this.c = keep(scalar(learningRate));
@@ -43,9 +45,69 @@ export class RMSPropOptimizer extends Optimizer {
     this.decay = keep(scalar(decay));
     this.momentum = keep(scalar(momentum));
     this.oneMinusDecay = keep(scalar(1 - decay));
+    this.centered = centered;
   }
 
-  applyGradients(variableGradients: NamedVariableMap) {
+  // The centered version additionally maintains a moving (discounted) average
+  // of the gradients, and uses that average to estimate the variance.
+  private applyGradientsWithCentered(variableGradients: NamedVariableMap) {
+    for (const variableName in variableGradients) {
+      const value = ENV.engine.registeredVariables[variableName];
+      if (this.accumulatedMeanSquares[variableName] == null) {
+        const trainable = false;
+        tidy(() => {
+          this.accumulatedMeanSquares[variableName] =
+              zerosLike(value).variable(trainable);
+        });
+      }
+      if (this.accumulatedMeanGrads[variableName] == null) {
+        const trainable = false;
+        tidy(() => {
+          this.accumulatedMeanGrads[variableName] =
+              zerosLike(value).variable(trainable);
+        });
+      }
+      if (this.accumulatedMoments[variableName] == null) {
+        const trainable = false;
+        tidy(() => {
+          this.accumulatedMoments[variableName] =
+              zerosLike(value).variable(trainable);
+        });
+      }
+
+      const accumulatedMeanSquare = this.accumulatedMeanSquares[variableName];
+      const accumulatedMeanGrad = this.accumulatedMeanGrads[variableName];
+      const accumulatedMoments = this.accumulatedMoments[variableName];
+      const gradient = variableGradients[variableName];
+
+      tidy(() => {
+        const newAccumulatedMeanSquare =
+            this.decay.mul(accumulatedMeanSquare)
+                .add(this.oneMinusDecay.mul(gradient.square()));
+
+        const newAccumulatedMeanGrad =
+            this.decay.mul(accumulatedMeanGrad)
+                .add(this.oneMinusDecay.mul(gradient));
+
+        const newAccumulatedMoments =
+            this.momentum.mul(accumulatedMoments)
+                .add(this.c.mul(gradient).div(
+                    newAccumulatedMeanSquare.sub(
+                      newAccumulatedMeanGrad.square().add(
+                        this.epsilon)).sqrt()));
+
+        this.accumulatedMeanSquares[variableName].assign(
+            newAccumulatedMeanSquare);
+        this.accumulatedMeanGrads[variableName].assign(newAccumulatedMeanGrad);
+        this.accumulatedMoments[variableName].assign(newAccumulatedMoments);
+
+        const newValue = value.sub(newAccumulatedMoments);
+        value.assign(newValue);
+      });
+    }
+  }
+
+  private applyGradientsWithPlain(variableGradients: NamedVariableMap) {
     for (const variableName in variableGradients) {
       const value = ENV.engine.registeredVariables[variableName];
       if (this.accumulatedMeanSquares[variableName] == null) {
@@ -87,6 +149,14 @@ export class RMSPropOptimizer extends Optimizer {
     }
   }
 
+  applyGradients(variableGradients: NamedVariableMap) {
+    if (this.centered) {
+      this.applyGradientsWithCentered(variableGradients);
+    } else {
+      this.applyGradientsWithPlain(variableGradients);
+    }
+  }
+
   dispose() {
     this.c.dispose();
     this.epsilon.dispose();
@@ -96,6 +166,10 @@ export class RMSPropOptimizer extends Optimizer {
     if (this.accumulatedMeanSquares != null) {
       Object.keys(this.accumulatedMeanSquares)
           .forEach(name => this.accumulatedMeanSquares[name].dispose());
+    }
+    if (this.accumulatedMeanGrads != null) {
+      Object.keys(this.accumulatedMeanGrads)
+          .forEach(name => this.accumulatedMeanGrads[name].dispose());
     }
     if (this.accumulatedMoments != null) {
       Object.keys(this.accumulatedMoments)


### PR DESCRIPTION
# Purpose

Centered version of RMSProp normalizes the update by the moving average of the gradient. RMSPropOptimizer can receive `centered` parameter like [rmsprop in tensorflow](https://github.com/tensorflow/tensorflow/blob/r1.5/tensorflow/python/training/rmsprop.py#L20).
This is a followup of https://github.com/PAIR-code/deeplearnjs/pull/687#issuecomment-364771968

see: https://github.com/PAIR-code/deeplearnjs/issues/729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/880)
<!-- Reviewable:end -->
