### PR TITLE
UnaryOps: Add dl.round

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -108,6 +108,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
 
   ceil<T extends Tensor>(x: T): T;
   floor<T extends Tensor>(x: T): T;
+  round<T extends Tensor>(x: T): T;
 
   sign<T extends Tensor>(x: T): T;
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -606,6 +606,27 @@ export class MathBackendCPU implements KernelBackend {
     return Tensor.make(x.shape, {values: newValues}) as T;
   }
 
+  round<T extends Tensor>(x: T): T {
+    const values = x.dataSync();
+    const newValues = new Float32Array(values.length);
+    for (let i = 0; i < values.length; ++i) {
+      // The algorithm is based on banker's rounding.
+      const base = Math.floor(values[i]);
+      if (values[i] - base < 0.5) {
+        newValues[i] = Math.floor(values[i]);
+      } else if (values[i] - base > 0.5) {
+        newValues[i] = Math.ceil(values[i]);
+      } else {
+        if (base % 2.0 === 0.0) {
+          newValues[i] = base;
+        } else {
+          newValues[i] = base + 1.0;
+        }
+      }
+    }
+    return Tensor.make(x.shape, {values: newValues}) as T;
+  }  
+
   exp<T extends Tensor>(x: T): T {
     const values = x.dataSync();
     const newValues = new Float32Array(values.length);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -632,6 +632,11 @@ export class MathBackendWebGL implements KernelBackend {
   sign<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
     return this.compileAndRun(program, [x]) as T;
+  }    
+
+  round<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
+    return this.compileAndRun(program, [x]) as T;
   }
 
   exp<T extends Tensor>(x: T): T {

--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -97,6 +97,23 @@ export const SIGN = `
   return sign(x);
 `;
 
+export const ROUND = `
+  // OpenGL ES does not support round function.
+  // The algorithm is based on banker's rounding.
+  float base = floor(x);
+  if ((x - base) < 0.5) {
+    return floor(x);
+  } else if ((x - base) > 0.5){
+    return ceil(x);
+  } else {
+    if (mod(base, 2.0) == 0.0) {
+      return base;
+    } else {
+      return base + 1.0;
+    }
+  }
+`;
+
 export const EXP = `
   return exp(x);
 `;

--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -103,7 +103,7 @@ export const ROUND = `
   float base = floor(x);
   if ((x - base) < 0.5) {
     return floor(x);
-  } else if ((x - base) > 0.5){
+  } else if ((x - base) > 0.5) {
     return ceil(x);
   } else {
     if (mod(base, 2.0) == 0.0) {

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -123,6 +123,7 @@ export const neg = UnaryOps.neg;
 export const prelu = UnaryOps.prelu;
 export const relu = UnaryOps.relu;
 export const reciprocal = UnaryOps.reciprocal;
+export const round = UnaryOps.round;
 export const selu = UnaryOps.selu;
 export const sigmoid = UnaryOps.sigmoid;
 export const sin = UnaryOps.sin;

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -106,6 +106,28 @@ export class UnaryOps {
   }
 
   /**
+   * Computes round of input `Tensor` element-wise: `round(x)`.
+   * It implements banker's rounding as tf.round does.
+   *
+   * ```js
+   * const x = dl.tensor1d([.6, 1.1, -3.3]);
+   *
+   * x.round().print();  // or dl.round(x)
+   * ```
+   * @param x The input tensor.
+   */
+  @doc({heading: 'Operations', subheading: 'Basic math'})
+  @operation
+  static round<T extends Tensor>(x: T): T {
+    // TODO(nsthorat): Let gradients be null for cases where we want to stop
+    // backpropgation.
+    const grad = (dy: T) => {
+      return {x: () => ops.zerosLike(dy)};
+    };
+    return ENV.engine.runKernel(backend => backend.round(x), {x}, grad);
+  }  
+
+  /**
    * Computes exponential of the input `Tensor` element-wise. `e ^ x`
    *
    * ```js

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -107,7 +107,7 @@ export class UnaryOps {
 
   /**
    * Computes round of input `Tensor` element-wise: `round(x)`.
-   * It implements banker's rounding as tf.round does.
+   * It implements banker's rounding.
    *
    * ```js
    * const x = dl.tensor1d([.6, 1.1, -3.3]);

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -1720,6 +1720,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(gradients, [0]);
   });
+});
 
 describeWithFlags('round', ALL_ENVS, () => {
   it('basic', () => {
@@ -1771,5 +1772,4 @@ describeWithFlags('round', ALL_ENVS, () => {
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(gradients, [0, 0, 0, 0]);
   });
-});  
 });

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -1720,4 +1720,56 @@ describeWithFlags('clip', ALL_ENVS, () => {
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(gradients, [0]);
   });
+
+describeWithFlags('round', ALL_ENVS, () => {
+  it('basic', () => {
+    const a = dl.tensor1d([0.9, 2.5, 2.3, 1.5, -4.5]);
+    const r = dl.round(a);
+
+    expectNumbersClose(r.get(0), 1.0);
+    expectNumbersClose(r.get(1), 2.0);
+    expectNumbersClose(r.get(2), 2.0);
+    expectNumbersClose(r.get(3), 2.0);
+    expectNumbersClose(r.get(4), -4.0);
+  });
+
+  it('propagates NaNs', () => {
+    const a = dl.tensor1d([1.5, NaN, -1.4]);
+    const r = dl.round(a);
+    expectArraysClose(r, [2, NaN, -1]);
+  });
+
+  it('gradients: Scalar', () => {
+    const a = dl.scalar(5.2);
+    const dy = dl.scalar(3);
+
+    const gradients = dl.grad(a => dl.round(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0]);
+  });
+
+  it('gradients: Tensor1D', () => {
+    const a = dl.tensor1d([-1.1, 2.6, 3, -5.9]);
+    const dy = dl.tensor1d([1, 2, 3, 4]);
+
+    const gradients = dl.grad(a => dl.round(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0]);
+  });
+
+  it('gradients: Tensor2D', () => {
+    const a = dl.tensor2d([-3, 1, 2.2, 3], [2, 2]);
+    const dy = dl.tensor2d([1, 2, 3, 4], [2, 2]);
+
+    const gradients = dl.grad(a => dl.round(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0]);
+  });
+});  
 });


### PR DESCRIPTION
# Purpose

Add `dl.round`. As [tf.round](https://www.tensorflow.org/api_docs/python/tf/round) does, the algorithm is banker's rounding. 

see: https://github.com/PAIR-code/deeplearnjs/issues/894 and https://github.com/tensorflow/tfjs/issues/70

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/895)
<!-- Reviewable:end -->
