### PR TITLE
Update repository url of tfjs-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/PAIR-code/deeplearnjs.git"
+    "url": "https://github.com/tensorflow/tfjs-core.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
deeplearnjs is now moved to tfjs-core under TensorFlow organization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/914)
<!-- Reviewable:end -->
