### PR TITLE
Make core tests reusable

### DIFF
--- a/src/debug_mode_test.ts
+++ b/src/debug_mode_test.ts
@@ -22,11 +22,11 @@ import * as util from './util';
 
 describeWithFlags('debug on', ALL_ENVS, () => {
   beforeAll(() => {
-    dl.ENV.set('DEBUG', true);
+    tf.ENV.set('DEBUG', true);
   });
 
   afterAll(() => {
-    dl.ENV.set('DEBUG', false);
+    tf.ENV.set('DEBUG', false);
   });
 
   it('debug mode does not error when no nans', () => {
@@ -66,7 +66,7 @@ describeWithFlags('debug on', ALL_ENVS, () => {
 
 describeWithFlags('debug off', ALL_ENVS, () => {
   beforeAll(() => {
-    dl.ENV.set('DEBUG', false);
+    tf.ENV.set('DEBUG', false);
   });
 
   it('no errors where there are nans, and debug mode is disabled', () => {

--- a/src/debug_mode_test.ts
+++ b/src/debug_mode_test.ts
@@ -20,11 +20,15 @@ import * as dl from './index';
 import {ALL_ENVS, describeWithFlags, expectArraysClose} from './test_util';
 import * as util from './util';
 
-const ALL_ENVS_DEBUG = ALL_ENVS.map(env => Object.assign({'DEBUG': true}, env));
-const ALL_ENVS_NO_DEBUG =
-    ALL_ENVS.map(env => Object.assign({'DEBUG': false}, env));
+describeWithFlags('debug on', ALL_ENVS, () => {
+  beforeAll(() => {
+    dl.ENV.set('DEBUG', true);
+  });
 
-describeWithFlags('debug on', ALL_ENVS_DEBUG, () => {
+  afterAll(() => {
+    dl.ENV.set('DEBUG', false);
+  });
+
   it('debug mode does not error when no nans', () => {
     const a = dl.tensor1d([2, -1, 0, 3]);
     const res = dl.relu(a);
@@ -60,7 +64,11 @@ describeWithFlags('debug on', ALL_ENVS_DEBUG, () => {
   });
 });
 
-describeWithFlags('debug off', ALL_ENVS_NO_DEBUG, () => {
+describeWithFlags('debug off', ALL_ENVS, () => {
+  beforeAll(() => {
+    dl.ENV.set('DEBUG', false);
+  });
+
   it('no errors where there are nans, and debug mode is disabled', () => {
     const a = dl.tensor1d([2, NaN]);
     const res = dl.relu(a);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -83,9 +83,7 @@ export class Engine implements TensorManager {
   private scopeStack: ScopeState[];
   private profiler: Profiler;
 
-  constructor(
-      private backend: KernelBackend, private customBackend: boolean,
-      public safeMode: boolean) {
+  constructor(private backend: KernelBackend, public safeMode: boolean) {
     // Create a default outer scope.
     this.activeScope = {keep: [], track: []};
     this.scopeStack = [this.activeScope];
@@ -287,11 +285,7 @@ export class Engine implements TensorManager {
     });
   }
 
-  dispose() {
-    if (this.customBackend) {
-      this.backend.dispose();
-    }
-  }
+  dispose() {}
 
   /**
    * Returns gradients of `f` with respect to each of the `xs`. The gradients

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -47,7 +47,7 @@ export interface Features {
   'WEBGL_FLOAT_TEXTURE_ENABLED'?: boolean;
   // Whether WEBGL_get_buffer_sub_data_async is enabled.
   'WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'?: boolean;
-  'BACKEND'?: BackendType;
+  'BACKEND'?: string;
 }
 
 export const URL_PROPERTIES: URLProperty[] = [
@@ -190,18 +190,12 @@ function isWebGLGetBufferSubDataAsyncExtensionEnabled(webGLVersion: number) {
   return isEnabled;
 }
 
-/** @docalias 'webgl'|'cpu' */
-export type BackendType = 'webgl'|'cpu'|string;
-
-/** List of currently supported backends ordered by preference. */
-const SUPPORTED_BACKENDS: BackendType[] = ['webgl', 'cpu'];
-
 export class Environment {
   private features: Features = {};
   private globalEngine: Engine;
-  private BACKEND_REGISTRY: {[id: string]: KernelBackend} = {};
-  private backends: {[id: string]: KernelBackend} = this.BACKEND_REGISTRY;
-  private currentBackendType: BackendType;
+  private registry:
+      {[id: string]: {backend: KernelBackend, priority: number}} = {};
+  private currentBackendType: string;
 
   constructor(features?: Features) {
     if (features != null) {
@@ -226,8 +220,8 @@ export class Environment {
    *     will automatically clean up intermediate tensors.
    */
   @doc({heading: 'Environment'})
-  static setBackend(backendType: BackendType, safeMode = false) {
-    if (!(backendType in ENV.backends)) {
+  static setBackend(backendType: string, safeMode = false) {
+    if (!(backendType in ENV.registry)) {
       throw new Error(`Backend type '${backendType}' not found in registry`);
     }
     ENV.initBackend(backendType, safeMode);
@@ -238,7 +232,7 @@ export class Environment {
    * for creating tensors and executing operations on those tensors.
    */
   @doc({heading: 'Environment'})
-  static getBackend(): BackendType {
+  static getBackend(): string {
     ENV.initDefaultBackend();
     return ENV.currentBackendType;
   }
@@ -278,14 +272,19 @@ export class Environment {
     this.features[feature] = value;
   }
 
-  getBestBackendType(): BackendType {
-    for (let i = 0; i < SUPPORTED_BACKENDS.length; ++i) {
-      const backendId = SUPPORTED_BACKENDS[i];
-      if (backendId in this.backends) {
-        return backendId;
-      }
+  getBestBackendType(): string {
+    if (Object.keys(this.registry).length === 0) {
+      throw new Error('No backend found in registry.');
     }
-    throw new Error('No backend found in registry.');
+    const sortedBackends = Object.keys(this.registry)
+                               .map(name => {
+                                 return {name, entry: this.registry[name]};
+                               })
+                               .sort((a, b) => {
+                                 // Highest priority comes first.
+                                 return b.entry.priority - a.entry.priority;
+                               });
+    return sortedBackends[0].name;
   }
 
   private evaluateFeature<K extends keyof Features>(feature: K): Features[K] {
@@ -322,9 +321,7 @@ export class Environment {
   }
 
   setFeatures(features: Features) {
-    this.reset();
     this.features = features;
-    this.backends = {};
   }
 
   reset() {
@@ -333,49 +330,25 @@ export class Environment {
       this.globalEngine.dispose();
       this.globalEngine = null;
     }
-    if (this.backends !== this.BACKEND_REGISTRY) {
-      for (const name in this.backends) {
-        this.backends[name].dispose();
-      }
-      this.backends = this.BACKEND_REGISTRY;
-    }
   }
 
-  private initBackend(backend?: BackendType|KernelBackend, safeMode = false) {
+  private initBackend(backend?: string|KernelBackend, safeMode = false) {
     let customBackend = false;
     if (typeof backend === 'string') {
       this.currentBackendType = backend;
       backend = ENV.findBackend(backend);
     } else {
       customBackend = true;
-      this.currentBackendType = 'custom' as BackendType;
+      this.currentBackendType = 'custom';
     }
     this.globalEngine = new Engine(backend, customBackend, safeMode);
   }
 
-  findBackend(name: BackendType): KernelBackend {
-    return this.backends[name];
-  }
-
-  /**
-   * Adds a custom backend. Usually used in tests to simulate different
-   * environments.
-   *
-   * @param factory: The backend factory function. When called, it should return
-   *     an instance of the backend.
-   * @return False if the creation/registration failed. True otherwise.
-   */
-  addCustomBackend(name: BackendType, factory: () => KernelBackend): boolean {
-    if (name in this.backends) {
-      throw new Error(`${name} backend was already registered`);
+  findBackend(name: string): KernelBackend {
+    if (!(name in this.registry)) {
+      return null;
     }
-    try {
-      const backend = factory();
-      this.backends[name] = backend;
-      return true;
-    } catch (err) {
-      return false;
-    }
+    return this.registry[name].backend;
   }
 
   /**
@@ -385,19 +358,31 @@ export class Environment {
    *
    * @param factory: The backend factory function. When called, it should
    * return an instance of the backend.
+   * @param priority The priority of the backend (higher = more important).
+   *     In case multiple backends are registered, `getBestBackendType` uses
+   *     priority to find the best backend. Defaults to 3.
    * @return False if the creation/registration failed. True otherwise.
    */
-  registerBackend(name: BackendType, factory: () => KernelBackend): boolean {
-    if (name in this.BACKEND_REGISTRY) {
-      throw new Error(`${name} backend was already registered as global`);
+  registerBackend(name: string, factory: () => KernelBackend, priority = 3):
+      boolean {
+    if (name in this.registry) {
+      throw new Error(`${name} backend was already registered`);
     }
     try {
       const backend = factory();
-      this.BACKEND_REGISTRY[name] = backend;
+      this.registry[name] = {backend, priority};
       return true;
     } catch (err) {
       return false;
     }
+  }
+
+  removeBackend(name: string): void {
+    if (!(name in this.registry)) {
+      throw new Error(`${name} backend not found in registry`);
+    }
+    this.registry[name].backend.dispose();
+    delete this.registry[name];
   }
 
   get engine(): Engine {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -363,7 +363,7 @@ export class Environment {
   registerBackend(name: string, factory: () => KernelBackend, priority = 1):
       boolean {
     if (name in this.registry) {
-      throw new Error(`${name} backend was already registered`);
+      console.warn(`${name} backend was already registered`);
     }
     try {
       const backend = factory();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -195,7 +195,7 @@ export class Environment {
   private globalEngine: Engine;
   private registry:
       {[id: string]: {backend: KernelBackend, priority: number}} = {};
-  private currentBackendType: string;
+  private currentBackend: string;
 
   constructor(features?: Features) {
     if (features != null) {
@@ -234,7 +234,7 @@ export class Environment {
   @doc({heading: 'Environment'})
   static getBackend(): string {
     ENV.initDefaultBackend();
-    return ENV.currentBackendType;
+    return ENV.currentBackend;
   }
 
   /**
@@ -332,16 +332,13 @@ export class Environment {
     }
   }
 
-  private initBackend(backend?: string|KernelBackend, safeMode = false) {
-    let customBackend = false;
-    if (typeof backend === 'string') {
-      this.currentBackendType = backend;
-      backend = ENV.findBackend(backend);
-    } else {
-      customBackend = true;
-      this.currentBackendType = 'custom';
+  private initBackend(backendType?: string, safeMode = false) {
+    this.currentBackend = backendType;
+    if (this.globalEngine != null) {
+      this.globalEngine.dispose();
     }
-    this.globalEngine = new Engine(backend, customBackend, safeMode);
+    const backend = ENV.findBackend(backendType);
+    this.globalEngine = new Engine(backend, safeMode);
   }
 
   findBackend(name: string): KernelBackend {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -357,10 +357,10 @@ export class Environment {
    * return an instance of the backend.
    * @param priority The priority of the backend (higher = more important).
    *     In case multiple backends are registered, `getBestBackendType` uses
-   *     priority to find the best backend. Defaults to 3.
+   *     priority to find the best backend. Defaults to 1.
    * @return False if the creation/registration failed. True otherwise.
    */
-  registerBackend(name: string, factory: () => KernelBackend, priority = 3):
+  registerBackend(name: string, factory: () => KernelBackend, priority = 1):
       boolean {
     if (name in this.registry) {
       throw new Error(`${name} backend was already registered`);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -370,6 +370,7 @@ export class Environment {
       this.registry[name] = {backend, priority};
       return true;
     } catch (err) {
+      console.warn(err.message);
       return false;
     }
   }

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -237,13 +237,6 @@ describe('Backend', () => {
     ENV.removeBackend('custom-cpu');
   });
 
-  it('double registration fails', () => {
-    ENV.registerBackend('custom-cpu', () => new MathBackendCPU());
-    expect(() => ENV.registerBackend('custom-cpu', () => new MathBackendCPU()))
-        .toThrowError();
-    ENV.removeBackend('custom-cpu');
-  });
-
   it('webgl not supported, falls back to cpu', () => {
     ENV.setFeatures({'WEBGL_VERSION': 0});
     ENV.registerBackend('custom-cpu', () => new MathBackendCPU(), 3);

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -20,8 +20,9 @@ import {ENV, Environment, Features} from './environment';
 import {KernelBackend} from './kernels/backend';
 import {MathBackendCPU} from './kernels/backend_cpu';
 import {MathBackendWebGL} from './kernels/backend_webgl';
+import {describeWithFlags, WEBGL_ENVS} from './test_util';
 
-describe('disjoint query timer enabled', () => {
+describeWithFlags('disjoint query timer enabled', WEBGL_ENVS, () => {
   afterEach(() => {
     ENV.reset();
   });
@@ -83,90 +84,93 @@ describe('disjoint query timer enabled', () => {
   });
 });
 
-describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
-  afterEach(() => {
-    ENV.reset();
-  });
+describeWithFlags(
+    'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', WEBGL_ENVS, () => {
+      afterEach(() => {
+        ENV.reset();
+      });
 
-  it('disjoint query timer disabled', () => {
-    const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 0};
+      it('disjoint query timer disabled', () => {
+        const features:
+            Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 0};
 
-    const env = new Environment(features);
+        const env = new Environment(features);
 
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'))
-        .toBe(false);
-  });
+        expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'))
+            .toBe(false);
+      });
 
-  it('disjoint query timer enabled, mobile', () => {
-    const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
-    spyOn(device_util, 'isMobile').and.returnValue(true);
+      it('disjoint query timer enabled, mobile', () => {
+        const features:
+            Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
+        spyOn(device_util, 'isMobile').and.returnValue(true);
 
-    const env = new Environment(features);
+        const env = new Environment(features);
 
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'))
-        .toBe(false);
-  });
+        expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'))
+            .toBe(false);
+      });
 
-  it('disjoint query timer enabled, not mobile', () => {
-    const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
-    spyOn(device_util, 'isMobile').and.returnValue(false);
+      it('disjoint query timer enabled, not mobile', () => {
+        const features:
+            Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
+        spyOn(device_util, 'isMobile').and.returnValue(false);
 
-    const env = new Environment(features);
+        const env = new Environment(features);
 
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE')).toBe(true);
-  });
-});
-
-describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
-  afterEach(() => {
-    ENV.reset();
-  });
-
-  beforeEach(() => {
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl2') {
-          return {
-            getExtension: (extensionName: string) => {
-              if (extensionName === 'WEBGL_get_buffer_sub_data_async') {
-                return {};
-              } else if (extensionName === 'WEBGL_lose_context') {
-                return {loseContext: () => {}};
-              }
-              return null;
-            }
-          };
-        }
-        return null;
-      }
+        expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'))
+            .toBe(true);
+      });
     });
-  });
 
-  it('WebGL 2 enabled', () => {
-    const features: Features = {'WEBGL_VERSION': 2};
+describeWithFlags(
+    'WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', WEBGL_ENVS, () => {
+      afterEach(() => {
+        ENV.reset();
+      });
 
-    const env = new Environment(features);
+      beforeEach(() => {
+        spyOn(document, 'createElement').and.returnValue({
+          getContext: (context: string) => {
+            if (context === 'webgl2') {
+              return {
+                getExtension: (extensionName: string) => {
+                  if (extensionName === 'WEBGL_get_buffer_sub_data_async') {
+                    return {};
+                  } else if (extensionName === 'WEBGL_lose_context') {
+                    return {loseContext: () => {}};
+                  }
+                  return null;
+                }
+              };
+            }
+            return null;
+          }
+        });
+      });
 
-    // TODO(nsthorat): Expect true when we fix
-    // https://github.com/PAIR-code/deeplearnjs/issues/848
-    expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
-        .toBe(false);
-  });
+      it('WebGL 2 enabled', () => {
+        const features: Features = {'WEBGL_VERSION': 2};
 
-  it('WebGL 1 disabled', () => {
-    const features: Features = {'WEBGL_VERSION': 1};
+        const env = new Environment(features);
 
-    const env = new Environment(features);
+        // TODO(nsthorat): Expect true when we fix
+        // https://github.com/PAIR-code/deeplearnjs/issues/848
+        expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
+            .toBe(false);
+      });
 
-    expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
-        .toBe(false);
-  });
-});
+      it('WebGL 1 disabled', () => {
+        const features: Features = {'WEBGL_VERSION': 1};
 
-describe('WebGL version', () => {
+        const env = new Environment(features);
+
+        expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
+            .toBe(false);
+      });
+    });
+
+describeWithFlags('WebGL version', WEBGL_ENVS, () => {
   afterEach(() => {
     ENV.reset();
   });
@@ -222,34 +226,22 @@ describe('Backend', () => {
     ENV.reset();
   });
 
-  it('default ENV has cpu and webgl, and webgl is the best available', () => {
-    expect(ENV.findBackend('webgl') != null).toBe(true);
-    expect(ENV.findBackend('cpu') != null).toBe(true);
-    expect(ENV.getBestBackendType()).toBe('webgl');
-  });
-
-  it('custom webgl registration', () => {
-    const features:
-        Features = {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2};
-    ENV.setFeatures(features);
-
+  it('custom cpu registration', () => {
     let backend: KernelBackend;
-    ENV.registerBackend('custom-webgl', () => {
-      backend = new MathBackendWebGL();
+    ENV.registerBackend('custom-cpu', () => {
+      backend = new MathBackendCPU();
       return backend;
     });
 
-    expect(ENV.findBackend('custom-webgl')).toBe(backend);
-    ENV.removeBackend('custom-webgl');
+    expect(ENV.findBackend('custom-cpu')).toBe(backend);
+    ENV.removeBackend('custom-cpu');
   });
 
   it('double registration fails', () => {
-    ENV.setFeatures({'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2});
-    ENV.registerBackend('custom-webgl', () => new MathBackendWebGL());
-    expect(
-        () => ENV.registerBackend('custom-webgl', () => new MathBackendWebGL()))
+    ENV.registerBackend('custom-cpu', () => new MathBackendCPU());
+    expect(() => ENV.registerBackend('custom-cpu', () => new MathBackendCPU()))
         .toThrowError();
-    ENV.removeBackend('custom-webgl');
+    ENV.removeBackend('custom-cpu');
   });
 
   it('webgl not supported, falls back to cpu', () => {

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -1558,4 +1558,4 @@ export class MathBackendCPU implements KernelBackend {
   dispose() {}
 }
 
-ENV.registerBackend('cpu', () => new MathBackendCPU());
+ENV.registerBackend('cpu', () => new MathBackendCPU(), 1 /* priority */);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -890,7 +890,7 @@ export class MathBackendWebGL implements KernelBackend {
       return gpgpu_math.compileProgram(
           this.gpgpu, program, inputsData, outputData);
     });
-
+    console.log(binary.source);
     const shouldTimeProgram = this.activeTimers != null;
     let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
@@ -910,6 +910,9 @@ export class MathBackendWebGL implements KernelBackend {
       GPGPUBinary {
     if (!(key in this.binaryCache)) {
       this.binaryCache[key] = getBinary();
+      console.log('Not reusing cache');
+    } else {
+      console.log('!!!!!!!!!!!!!!!!!! Reusing cache!!');
     }
     return this.binaryCache[key];
   }
@@ -993,7 +996,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 }
 
-ENV.registerBackend('webgl', () => new MathBackendWebGL());
+ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);
 
 function float32ToTypedArray<D extends DataType>(
     a: Float32Array, dtype: D): DataTypeMap[D] {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -890,7 +890,6 @@ export class MathBackendWebGL implements KernelBackend {
       return gpgpu_math.compileProgram(
           this.gpgpu, program, inputsData, outputData);
     });
-    console.log(binary.source);
     const shouldTimeProgram = this.activeTimers != null;
     let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
@@ -910,9 +909,6 @@ export class MathBackendWebGL implements KernelBackend {
       GPGPUBinary {
     if (!(key in this.binaryCache)) {
       this.binaryCache[key] = getBinary();
-      console.log('Not reusing cache');
-    } else {
-      console.log('!!!!!!!!!!!!!!!!!! Reusing cache!!');
     }
     return this.binaryCache[key];
   }

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -190,7 +190,7 @@ export class GPGPUContext {
             this.gl, rows, columns));
   }
 
-  private firstProgram = true;
+  private vertexAttrsAreBound = false;
 
   public createProgram(fragmentShaderSource: string): WebGLProgram {
     this.throwIfDisposed();
@@ -205,10 +205,9 @@ export class GPGPUContext {
     if (this.autoDebugValidate) {
       webgl_util.validateProgram(gl, program);
     }
-    if (this.firstProgram) {
-      this.firstProgram = false;
+    if (!this.vertexAttrsAreBound) {
       this.setProgram(program);
-      gpgpu_util.bindVertexProgramAttributeStreams(
+      this.vertexAttrsAreBound = gpgpu_util.bindVertexProgramAttributeStreams(
           gl, this.program, this.vertexBuffer);
     }
     return program;

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -172,41 +172,42 @@ describeWithFlags('GPGPUContext setOutputMatrixTexture', WEBGL_ENVS, () => {
   });
 });
 
-describe('GPGPUContext setOutputPackedMatrixTexture', () => {
-  let gpgpu: GPGPUContext;
-  let texture: WebGLTexture;
+describeWithFlags(
+    'GPGPUContext setOutputPackedMatrixTexture', WEBGL_ENVS, () => {
+      let gpgpu: GPGPUContext;
+      let texture: WebGLTexture;
 
-  beforeEach(() => {
-    gpgpu = new GPGPUContext();
-    gpgpu.enableAutomaticDebugValidation(true);
-  });
+      beforeEach(() => {
+        gpgpu = new GPGPUContext();
+        gpgpu.enableAutomaticDebugValidation(true);
+      });
 
-  afterEach(() => {
-    if (texture != null) {
-      gpgpu.deleteMatrixTexture(texture);
-    }
-    gpgpu.dispose();
-  });
+      afterEach(() => {
+        if (texture != null) {
+          gpgpu.deleteMatrixTexture(texture);
+        }
+        gpgpu.dispose();
+      });
 
-  it('sets the output texture property to the output texture', () => {
-    texture = gpgpu.createPackedMatrixTexture(1, 1);
-    gpgpu.setOutputPackedMatrixTexture(texture, 1, 1);
-    expect(gpgpu.outputTexture).toBe(texture);
-  });
+      it('sets the output texture property to the output texture', () => {
+        texture = gpgpu.createPackedMatrixTexture(1, 1);
+        gpgpu.setOutputPackedMatrixTexture(texture, 1, 1);
+        expect(gpgpu.outputTexture).toBe(texture);
+      });
 
-  it('sets the gl viewport to the output packed texture dimensions', () => {
-    const columns = 456;
-    const rows = 123;
-    texture = gpgpu.createPackedMatrixTexture(rows, columns);
-    gpgpu.setOutputPackedMatrixTexture(texture, rows, columns);
-    const [width, height] =
-        tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
-    const expected = new Int32Array([0, 0, width, height]);
-    expect(gpgpu.gl.getParameter(gpgpu.gl.VIEWPORT)).toEqual(expected);
-  });
-});
+      it('sets the gl viewport to the output packed texture dimensions', () => {
+        const columns = 456;
+        const rows = 123;
+        texture = gpgpu.createPackedMatrixTexture(rows, columns);
+        gpgpu.setOutputPackedMatrixTexture(texture, rows, columns);
+        const [width, height] =
+            tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
+        const expected = new Int32Array([0, 0, width, height]);
+        expect(gpgpu.gl.getParameter(gpgpu.gl.VIEWPORT)).toEqual(expected);
+      });
+    });
 
-describe('GPGPUContext setOutputMatrixWriteRegion', () => {
+describeWithFlags('GPGPUContext setOutputMatrixWriteRegion', WEBGL_ENVS, () => {
   let gpgpu: GPGPUContext;
   let program: WebGLProgram;
   let output: WebGLTexture;
@@ -280,7 +281,7 @@ describe('GPGPUContext setOutputMatrixWriteRegion', () => {
   });
 });
 
-describe('GPGPUContext', () => {
+describeWithFlags('GPGPUContext', WEBGL_ENVS, () => {
   let gpgpu: GPGPUContext;
 
   beforeEach(() => {

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -64,11 +64,7 @@ describeWithFlags('GPGPUContext downloadMatrixFromTexture', WEBGL_ENVS, () => {
   });
 });
 
-const FLOAT_ENVS = [
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-];
-describeWithFlags('GPGPUContext color texture with float', FLOAT_ENVS, () => {
+describeWithFlags('GPGPUContext color texture with float', WEBGL_ENVS, () => {
   let gpgpu: GPGPUContext;
   let texture: WebGLTexture;
 
@@ -90,31 +86,32 @@ describeWithFlags('GPGPUContext color texture with float', FLOAT_ENVS, () => {
   });
 });
 
-const BYTE_ENV = [{'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}];
-describeWithFlags('GPGPUContext color texture with byte', BYTE_ENV, () => {
-  let gpgpu: GPGPUContext;
-  let texture: WebGLTexture;
+describeWithFlags(
+    'GPGPUContext color texture with byte',
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false}, () => {
+      let gpgpu: GPGPUContext;
+      let texture: WebGLTexture;
 
-  afterEach(() => {
-    gpgpu.deleteMatrixTexture(texture);
-    gpgpu.dispose();
-  });
+      afterEach(() => {
+        gpgpu.deleteMatrixTexture(texture);
+        gpgpu.dispose();
+      });
 
-  it('basic', () => {
-    gpgpu = new GPGPUContext();
-    gpgpu.enableAutomaticDebugValidation(true);
-    texture = gpgpu.createMatrixTexture(1, 1);
+      it('basic', () => {
+        gpgpu = new GPGPUContext();
+        gpgpu.enableAutomaticDebugValidation(true);
+        texture = gpgpu.createMatrixTexture(1, 1);
 
-    gpgpu.setOutputMatrixTexture(texture, 1, 1);
-    const uintArray = tex_util.encodeFloatArray(new Float32Array([0.123]));
-    gpgpu.gl.clearColor(
-        uintArray[0] / 255, uintArray[1] / 255, uintArray[2] / 255,
-        uintArray[3] / 255);
-    gpgpu.gl.clear(gpgpu.gl.COLOR_BUFFER_BIT);
-    const result = gpgpu.downloadMatrixFromTexture(texture, 1, 1);
-    expectNumbersClose(result[0], 0.123);
-  });
-});
+        gpgpu.setOutputMatrixTexture(texture, 1, 1);
+        const uintArray = tex_util.encodeFloatArray(new Float32Array([0.123]));
+        gpgpu.gl.clearColor(
+            uintArray[0] / 255, uintArray[1] / 255, uintArray[2] / 255,
+            uintArray[3] / 255);
+        gpgpu.gl.clear(gpgpu.gl.COLOR_BUFFER_BIT);
+        const result = gpgpu.downloadMatrixFromTexture(texture, 1, 1);
+        expectNumbersClose(result[0], 0.123);
+      });
+    });
 
 describeWithFlags('GPGPUContext setOutputMatrixTexture', WEBGL_ENVS, () => {
   let gpgpu: GPGPUContext;

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -173,16 +173,17 @@ export function createPackedMatrixTexture(
 
 export function bindVertexProgramAttributeStreams(
     gl: WebGLRenderingContext, program: WebGLProgram,
-    vertexBuffer: WebGLBuffer) {
+    vertexBuffer: WebGLBuffer): boolean {
   const posOffset = 0;               // x is the first buffer element
   const uvOffset = 3 * 4;            // uv comes after [x y z]
   const stride = (3 * 4) + (2 * 4);  // xyz + uv, each entry is 4-byte float.
   webgl_util.callAndCheck(
       gl, () => gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer));
-  webgl_util.bindVertexBufferToProgramAttribute(
+  const success = webgl_util.bindVertexBufferToProgramAttribute(
       gl, program, 'clipSpacePos', vertexBuffer, 3, stride, posOffset);
-  webgl_util.bindVertexBufferToProgramAttribute(
-      gl, program, 'uv', vertexBuffer, 2, stride, uvOffset);
+  return success &&
+      webgl_util.bindVertexBufferToProgramAttribute(
+          gl, program, 'uv', vertexBuffer, 2, stride, uvOffset);
 }
 
 export function uploadPixelDataToTexture(

--- a/src/kernels/webgl/gpgpu_util_test.ts
+++ b/src/kernels/webgl/gpgpu_util_test.ts
@@ -15,10 +15,11 @@
  * =============================================================================
  */
 
+import {describeWithFlags, WEBGL_ENVS} from '../../test_util';
 import {GPGPUContext} from './gpgpu_context';
 import * as gpgpu_util from './gpgpu_util';
 
-describe('gpgpu_util createWebGLContext', () => {
+describeWithFlags('gpgpu_util createWebGLContext', WEBGL_ENVS, () => {
   let gpgpu: GPGPUContext;
 
   beforeEach(() => {
@@ -54,7 +55,7 @@ describe('gpgpu_util createWebGLContext', () => {
   });
 });
 
-describe('gpgpu_util createMatrixTexture', () => {
+describeWithFlags('gpgpu_util createMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const tex = gpgpu_util.createMatrixTexture(gpgpu.gl, 32, 32);
@@ -86,7 +87,7 @@ describe('gpgpu_util createMatrixTexture', () => {
   });
 });
 
-describe('gpgpu_util createPackedMatrixTexture', () => {
+describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const tex = gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 32, 32);

--- a/src/kernels/webgl/logical_gpu.ts
+++ b/src/kernels/webgl/logical_gpu.ts
@@ -53,9 +53,10 @@ export class WhereProgram implements GPGPUProgram {
 
     this.userCode = `
       void main() {
-        ${dtype} resRC = getOutputCoords();
+        ${dtype} resRC = int(resultUV.y * 4.0);
         float cVal = getC(${cCoords});
-        if (cVal >= 1.0) {
+        if (cVal >= -0.1) { setOutput(float(resRC)); }
+        else if (cVal >= 1.0) {
           setOutput(getA(${abCoords}));
         } else {
           setOutput(getB(${abCoords}));

--- a/src/kernels/webgl/logical_gpu.ts
+++ b/src/kernels/webgl/logical_gpu.ts
@@ -53,10 +53,9 @@ export class WhereProgram implements GPGPUProgram {
 
     this.userCode = `
       void main() {
-        ${dtype} resRC = int(resultUV.y * 4.0);
+        ${dtype} resRC = getOutputCoords();
         float cVal = getC(${cCoords});
-        if (cVal >= -0.1) { setOutput(float(resRC)); }
-        else if (cVal >= 1.0) {
+        if (cVal >= 1.0) {
           setOutput(getA(${abCoords}));
         } else {
           setOutput(getB(${abCoords}));

--- a/src/kernels/webgl/mulmat_packed_gpu_test.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu_test.ts
@@ -15,12 +15,13 @@
  * =============================================================================
  */
 
-import {expectArraysClose, expectNumbersClose} from '../../test_util';
+// tslint:disable-next-line:max-line-length
+import {describeWithFlags, expectArraysClose, expectNumbersClose, WEBGL_ENVS} from '../../test_util';
 import {GPGPUContext} from './gpgpu_context';
 import * as mulmat_packed_gpu from './mulmat_packed_gpu';
 import {MatrixOrientation} from './mulmat_packed_gpu';
 
-describe('mulmat_packed_gpu (1x1 * 1x1)', () => {
+describeWithFlags('mulmat_packed_gpu (1x1 * 1x1)', WEBGL_ENVS, () => {
   it('returns a 1x1 matrix', () => {
     const a = new Float32Array([0]);
     const b = new Float32Array([0]);
@@ -78,7 +79,7 @@ describe('mulmat_packed_gpu (1x1 * 1x1)', () => {
   });
 });
 
-describe('mulmat_packed_gpu (dot product)', () => {
+describeWithFlags('mulmat_packed_gpu (dot product)', WEBGL_ENVS, () => {
   it('returns a 1x1 matrix', () => {
     const a = new Float32Array(5);
     const b = new Float32Array(5);
@@ -142,7 +143,7 @@ function cpuMul2x2(a: Float32Array, b: Float32Array): Float32Array {
   return result;
 }
 
-describe('mulmat_packed_gpu (2x2 * 2x2)', () => {
+describeWithFlags('mulmat_packed_gpu (2x2 * 2x2)', WEBGL_ENVS, () => {
   it('returns a 2x2 matrix', () => {
     const a = new Float32Array([0, 0, 0, 0]);
     const b = new Float32Array([0, 0, 0, 0]);
@@ -200,7 +201,7 @@ describe('mulmat_packed_gpu (2x2 * 2x2)', () => {
   });
 });
 
-describe('mulmat_packed_gpu (different shapes)', () => {
+describeWithFlags('mulmat_packed_gpu (different shapes)', WEBGL_ENVS, () => {
   it('returns a 4x1 when multiplying a 4x4 with a 4x1', () => {
     const a = new Float32Array(16);
     const b = new Float32Array(4);
@@ -253,7 +254,7 @@ describe('mulmat_packed_gpu (different shapes)', () => {
   });
 });
 
-describe('mulmat_packed_gpu (large matrices)', () => {
+describeWithFlags('mulmat_packed_gpu (large matrices)', WEBGL_ENVS, () => {
   it('returns 128x128 when multiplying 2 128x128s', () => {
     const a = new Float32Array(128 * 128);
     const b = new Float32Array(128 * 128);
@@ -272,7 +273,7 @@ describe('mulmat_packed_gpu (large matrices)', () => {
   });
 });
 
-describe('mulmat_packed_gpu (multiple matrices)', () => {
+describeWithFlags('mulmat_packed_gpu (multiple matrices)', WEBGL_ENVS, () => {
   it('4x2 * 2x12 * 12x1 === 4x1', () => {
     const aData = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]);
     const bData = new Float32Array([
@@ -323,7 +324,7 @@ describe('mulmat_packed_gpu (multiple matrices)', () => {
   });
 });
 
-describe('mulmat_packed_gpu A * B^t', () => {
+describeWithFlags('mulmat_packed_gpu A * B^t', WEBGL_ENVS, () => {
   it('1x1 * 1x1', () => {
     const a = new Float32Array([2]);
     const b = new Float32Array([3]);
@@ -371,7 +372,7 @@ describe('mulmat_packed_gpu A * B^t', () => {
   });
 });
 
-describe('mulmat_packed_gpu (transposed versions)', () => {
+describeWithFlags('mulmat_packed_gpu (transposed versions)', WEBGL_ENVS, () => {
   it('A * B^t', () => {
     const a = new Float32Array([1, 2, 3, 4, 5, 6]);
     const b = new Float32Array([1, 0, 2, 4, 3, 0]);

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -251,12 +251,12 @@ export function createFramebuffer(gl: WebGLRenderingContext): WebGLFramebuffer {
 export function bindVertexBufferToProgramAttribute(
     gl: WebGLRenderingContext, program: WebGLProgram, attribute: string,
     buffer: WebGLBuffer, arrayEntriesPerItem: number, itemStrideInBytes: number,
-    itemOffsetInBytes: number) {
+    itemOffsetInBytes: number): boolean {
   const loc = gl.getAttribLocation(program, attribute);
   if (loc === -1) {
     // The GPU compiler decided to strip out this attribute because it's unused,
     // thus no need to bind.
-    return;
+    return false;
   }
   callAndCheck(gl, () => gl.bindBuffer(gl.ARRAY_BUFFER, buffer));
   callAndCheck(
@@ -265,6 +265,7 @@ export function bindVertexBufferToProgramAttribute(
           loc, arrayEntriesPerItem, gl.FLOAT, false, itemStrideInBytes,
           itemOffsetInBytes));
   callAndCheck(gl, () => gl.enableVertexAttribArray(loc));
+  return true;
 }
 
 export function bindTextureUnit(

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -15,61 +15,66 @@
  * =============================================================================
  */
 
+import {describeWithFlags, WEBGL_ENVS} from '../../test_util';
 import * as gpgpu_util from './gpgpu_util';
 import * as webgl_util from './webgl_util';
 
-describe('webgl_util getTextureShapeFromLogicalShape', () => {
-  let gl: WebGLRenderingContext;
+describeWithFlags(
+    'webgl_util getTextureShapeFromLogicalShape', WEBGL_ENVS, () => {
+      let gl: WebGLRenderingContext;
 
-  beforeEach(() => {
-    gl = gpgpu_util.createWebGLContext();
-  });
+      beforeEach(() => {
+        gl = gpgpu_util.createWebGLContext();
+      });
 
-  it('scalar', () => {
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, []);
-    expect(texShape).toEqual([1, 1]);
-  });
+      it('scalar', () => {
+        const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, []);
+        expect(texShape).toEqual([1, 1]);
+      });
 
-  it('1d', () => {
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [4]);
-    expect(texShape).toEqual([4, 1]);
-  });
+      it('1d', () => {
+        const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [4]);
+        expect(texShape).toEqual([4, 1]);
+      });
 
-  it('2d stays same', () => {
-    let texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [5, 2]);
-    expect(texShape).toEqual([5, 2]);
+      it('2d stays same', () => {
+        let texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [5, 2]);
+        expect(texShape).toEqual([5, 2]);
 
-    texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [5, 1]);
-    expect(texShape).toEqual([5, 1]);
+        texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [5, 1]);
+        expect(texShape).toEqual([5, 1]);
 
-    texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [1, 5]);
-    expect(texShape).toEqual([1, 5]);
-  });
+        texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [1, 5]);
+        expect(texShape).toEqual([1, 5]);
+      });
 
-  it('3d 2x3x4', () => {
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [2, 3, 4]);
-    expect(texShape).toEqual([2, 12]);
-  });
+      it('3d 2x3x4', () => {
+        const texShape =
+            webgl_util.getTextureShapeFromLogicalShape(gl, [2, 3, 4]);
+        expect(texShape).toEqual([2, 12]);
+      });
 
-  it('3d 2x1x4 got squeezed', () => {
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [2, 1, 4]);
-    expect(texShape).toEqual([2, 4]);
-  });
+      it('3d 2x1x4 got squeezed', () => {
+        const texShape =
+            webgl_util.getTextureShapeFromLogicalShape(gl, [2, 1, 4]);
+        expect(texShape).toEqual([2, 4]);
+      });
 
-  it('3d 1x8x2 got squeezed', () => {
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(gl, [1, 8, 2]);
-    expect(texShape).toEqual([8, 2]);
-  });
+      it('3d 1x8x2 got squeezed', () => {
+        const texShape =
+            webgl_util.getTextureShapeFromLogicalShape(gl, [1, 8, 2]);
+        expect(texShape).toEqual([8, 2]);
+      });
 
-  it('4d 1x8x1x3 got squeezed', () => {
-    const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(gl, [1, 8, 1, 3]);
-    expect(texShape).toEqual([8, 3]);
-  });
+      it('4d 1x8x1x3 got squeezed', () => {
+        const texShape =
+            webgl_util.getTextureShapeFromLogicalShape(gl, [1, 8, 1, 3]);
+        expect(texShape).toEqual([8, 3]);
+      });
 
-  it('4d 1x3x1x8 got squeezed', () => {
-    const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(gl, [1, 3, 1, 8]);
-    expect(texShape).toEqual([3, 8]);
-  });
-});
+      it('4d 1x3x1x8 got squeezed', () => {
+        const texShape =
+            webgl_util.getTextureShapeFromLogicalShape(gl, [1, 3, 1, 8]);
+        expect(texShape).toEqual([3, 8]);
+      });
+    });

--- a/src/ops/axis_util_test.ts
+++ b/src/ops/axis_util_test.ts
@@ -16,7 +16,8 @@
  */
 
 import * as dl from '../index';
-import {describeWithFlags, expectArraysClose} from '../test_util';
+import {CPU_ENVS, describeWithFlags, expectArraysClose} from '../test_util';
+
 import * as axis_util from './axis_util';
 
 describe('axis_util combineLocations', () => {
@@ -263,7 +264,7 @@ describe('axis_util parseAxisParam', () => {
   });
 });
 
-describeWithFlags('axis_util getUndoAxesPermutation', [{}], () => {
+describeWithFlags('axis_util getUndoAxesPermutation', CPU_ENVS, () => {
   it('4d axes', () => {
     const axes = [2, 0, 1, 3];
     expect(axis_util.getUndoAxesPermutation(axes)).toEqual([1, 2, 0, 3]);

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -60,8 +60,7 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
   });
 
   it('Tensor3D', () => {
-    let a =
-        tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let a = tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalNot(a), [0, 1, 0, 1, 1, 1]);
 
     a = tf.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -134,15 +133,12 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 
   it('Tensor3D', () => {
-    let a =
-        tf.tensor3d([[[1], [0], [1]], [[0], [0], [1]]], [2, 3, 1], 'bool');
-    let b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = tf.tensor3d([[[1], [0], [1]], [[0], [0], [1]]], [2, 3, 1], 'bool');
+    let b = tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalAnd(a, b), [0, 0, 1, 0, 0, 0]);
 
     a = tf.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -151,8 +147,7 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = tf.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
@@ -164,8 +159,7 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
         tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        tf.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
+    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
   });
 
   it('Tensor4D', () => {
@@ -185,14 +179,12 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     const a = tf.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        tf.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
+    expectArraysClose(tf.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
   });
   it('NaNs in Tensor4D', () => {
     const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 });
 
@@ -241,15 +233,12 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   it('Tensor3D', () => {
-    let a =
-        tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    let b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let b = tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalOr(a, b), [1, 0, 1, 1, 0, 0]);
 
     a = tf.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -258,21 +247,18 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = tf.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        tf.logicalOr(a, b), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0]);
+    expectArraysClose(tf.logicalOr(a, b), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0]);
   });
   it('NaNs in Tensor3D', () => {
     const a =
         tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        tf.logicalOr(a, b), [1, boolNaN, 1, 1, 0, boolNaN]);
+    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, 1, 0, boolNaN]);
   });
 
   it('Tensor4D', () => {
@@ -292,14 +278,12 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     const a = tf.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        tf.logicalOr(a, b), [1, 1, 0, 0, 1, 1, 1, 1]);
+    expectArraysClose(tf.logicalOr(a, b), [1, 1, 0, 0, 1, 1, 1, 1]);
   });
   it('NaNs in Tensor4D', () => {
     const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 
@@ -349,16 +333,13 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   // Tensor3D:
   it('Tensor3D', () => {
-    let a =
-        tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    let b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let b = tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalXor(a, b), [1, 0, 0, 1, 0, 0]);
 
     a = tf.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -367,8 +348,7 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = tf.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
@@ -380,8 +360,7 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
         tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        tf.logicalXor(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
+    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
   });
 
   // Tensor4D:
@@ -402,14 +381,12 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     const a = tf.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        tf.logicalXor(a, b), [0, 1, 0, 0, 1, 1, 1, 1]);
+    expectArraysClose(tf.logicalXor(a, b), [0, 1, 0, 0, 1, 1, 1, 1]);
   });
   it('NaNs in Tensor4D', () => {
     const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 
@@ -505,8 +482,7 @@ describeWithFlags('where', ALL_ENVS, () => {
 
     a = tf.tensor2d([[10, 10], [10, 10], [10, 10], [10, 10]], [4, 2]);
     b = tf.tensor2d([[5, 5], [5, 5], [5, 5], [5, 5]], [4, 2]);
-    expectArraysClose(
-        tf.where(c, a, b), [10, 10, 5, 5, 10, 10, 5, 5]);
+    expectArraysClose(tf.where(c, a, b), [10, 10, 5, 5, 10, 10, 5, 5]);
   });
 
   it('Tensor3D', () => {
@@ -562,8 +538,7 @@ describeWithFlags('where', ALL_ENVS, () => {
         [[[9], [9]], [[9], [9]], [[9], [9]], [[9], [9]]], [4, 2, 1]);
     b = tf.tensor3d(
         [[[8], [8]], [[8], [8]], [[8], [8]], [[8], [8]]], [4, 2, 1]);
-    expectArraysClose(
-        tf.where(c, a, b), [9, 9, 8, 8, 9, 9, 8, 8]);
+    expectArraysClose(tf.where(c, a, b), [9, 9, 8, 8, 9, 9, 8, 8]);
   });
 
   it('Tensor4D', () => {
@@ -615,7 +590,6 @@ describeWithFlags('where', ALL_ENVS, () => {
 
     a = tf.tensor4d([7, 7, 7, 7, 7, 7, 7, 7], [4, 2, 1, 1]);
     b = tf.tensor4d([3, 3, 3, 3, 3, 3, 3, 3], [4, 2, 1, 1]);
-    expectArraysClose(
-        tf.where(c, a, b), [7, 7, 3, 3, 7, 7, 3, 3]);
+    expectArraysClose(tf.where(c, a, b), [7, 7, 3, 3, 7, 7, 3, 3]);
   });
 });

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -382,16 +382,14 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
 });
 
 describeWithFlags('where', ALL_ENVS, () => {
-  // tslint:disable-next-line:ban
-  fit('Scalars.', () => {
+  it('Scalars.', () => {
     const a = dl.scalar(10);
     const b = dl.scalar(20);
     const c = dl.scalar(1, 'bool');
 
     expectArraysClose(dl.where(c, a, b), [10]);
   });
-  // tslint:disable-next-line:ban
-  fit('Tensor1D', () => {
+  it('Tensor1D', () => {
     const c = dl.tensor1d([1, 0, 1, 0], 'bool');
     const a = dl.tensor1d([10, 10, 10, 10]);
     const b = dl.tensor1d([20, 20, 20, 20]);

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -16,9 +16,9 @@
  */
 
 // tslint:disable-next-line:max-line-length
+import * as dl from '../index';
 import {ALL_ENVS, describeWithFlags, expectArraysClose} from '../test_util';
 import * as util from '../util';
-import * as dl from '../index';
 
 const boolNaN = util.getNaN('bool');
 
@@ -51,8 +51,7 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
   });
 
   it('Tensor3D', () => {
-    let a =
-        dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let a = dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(dl.logicalNot(a), [0, 1, 0, 1, 1, 1]);
 
     a = dl.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -125,15 +124,12 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = dl.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = dl.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        dl.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    expectArraysClose(dl.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 
   it('Tensor3D', () => {
-    let a =
-        dl.tensor3d([[[1], [0], [1]], [[0], [0], [1]]], [2, 3, 1], 'bool');
-    let b =
-        dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = dl.tensor3d([[[1], [0], [1]], [[0], [0], [1]]], [2, 3, 1], 'bool');
+    let b = dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(dl.logicalAnd(a, b), [0, 0, 1, 0, 0, 0]);
 
     a = dl.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -142,8 +138,7 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = dl.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
@@ -155,8 +150,7 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
         dl.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        dl.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
+    expectArraysClose(dl.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
   });
 
   it('Tensor4D', () => {
@@ -176,14 +170,12 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     const a = dl.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        dl.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
+    expectArraysClose(dl.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
   });
   it('NaNs in Tensor4D', () => {
     const a = dl.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        dl.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    expectArraysClose(dl.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 });
 
@@ -232,15 +224,12 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = dl.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = dl.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        dl.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(dl.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   it('Tensor3D', () => {
-    let a =
-        dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    let b =
-        dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let b = dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(dl.logicalOr(a, b), [1, 0, 1, 1, 0, 0]);
 
     a = dl.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -249,21 +238,18 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = dl.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        dl.logicalOr(a, b), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0]);
+    expectArraysClose(dl.logicalOr(a, b), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0]);
   });
   it('NaNs in Tensor3D', () => {
     const a =
         dl.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        dl.logicalOr(a, b), [1, boolNaN, 1, 1, 0, boolNaN]);
+    expectArraysClose(dl.logicalOr(a, b), [1, boolNaN, 1, 1, 0, boolNaN]);
   });
 
   it('Tensor4D', () => {
@@ -283,14 +269,12 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     const a = dl.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        dl.logicalOr(a, b), [1, 1, 0, 0, 1, 1, 1, 1]);
+    expectArraysClose(dl.logicalOr(a, b), [1, 1, 0, 0, 1, 1, 1, 1]);
   });
   it('NaNs in Tensor4D', () => {
     const a = dl.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        dl.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(dl.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 
@@ -340,16 +324,13 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
   it('NaNs in Tensor2D', () => {
     const a = dl.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
     const b = dl.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(
-        dl.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(dl.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   // Tensor3D:
   it('Tensor3D', () => {
-    let a =
-        dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    let b =
-        dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
+    let a = dl.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
+    let b = dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(dl.logicalXor(a, b), [1, 0, 0, 1, 0, 0]);
 
     a = dl.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
@@ -358,8 +339,7 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
   });
   it('broadcasting Tensor3D shapes', () => {
     const a = dl.tensor3d(
-        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
-        [2, 3, 2],
+        [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]], [2, 3, 2],
         'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
@@ -371,8 +351,7 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
         dl.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
     const b =
         dl.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(
-        dl.logicalXor(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
+    expectArraysClose(dl.logicalXor(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
   });
 
   // Tensor4D:
@@ -393,26 +372,26 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     const a = dl.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
-    expectArraysClose(
-        dl.logicalXor(a, b), [0, 1, 0, 0, 1, 1, 1, 1]);
+    expectArraysClose(dl.logicalXor(a, b), [0, 1, 0, 0, 1, 1, 1, 1]);
   });
   it('NaNs in Tensor4D', () => {
     const a = dl.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
     const b = dl.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(
-        dl.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
+    expectArraysClose(dl.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 
 describeWithFlags('where', ALL_ENVS, () => {
-  it('Scalars.', () => {
+  // tslint:disable-next-line:ban
+  fit('Scalars.', () => {
     const a = dl.scalar(10);
     const b = dl.scalar(20);
     const c = dl.scalar(1, 'bool');
 
     expectArraysClose(dl.where(c, a, b), [10]);
   });
-  it('Tensor1D', () => {
+  // tslint:disable-next-line:ban
+  fit('Tensor1D', () => {
     const c = dl.tensor1d([1, 0, 1, 0], 'bool');
     const a = dl.tensor1d([10, 10, 10, 10]);
     const b = dl.tensor1d([20, 20, 20, 20]);
@@ -496,8 +475,7 @@ describeWithFlags('where', ALL_ENVS, () => {
 
     a = dl.tensor2d([[10, 10], [10, 10], [10, 10], [10, 10]], [4, 2]);
     b = dl.tensor2d([[5, 5], [5, 5], [5, 5], [5, 5]], [4, 2]);
-    expectArraysClose(
-        dl.where(c, a, b), [10, 10, 5, 5, 10, 10, 5, 5]);
+    expectArraysClose(dl.where(c, a, b), [10, 10, 5, 5, 10, 10, 5, 5]);
   });
 
   it('Tensor3D', () => {
@@ -553,8 +531,7 @@ describeWithFlags('where', ALL_ENVS, () => {
         [[[9], [9]], [[9], [9]], [[9], [9]], [[9], [9]]], [4, 2, 1]);
     b = dl.tensor3d(
         [[[8], [8]], [[8], [8]], [[8], [8]], [[8], [8]]], [4, 2, 1]);
-    expectArraysClose(
-        dl.where(c, a, b), [9, 9, 8, 8, 9, 9, 8, 8]);
+    expectArraysClose(dl.where(c, a, b), [9, 9, 8, 8, 9, 9, 8, 8]);
   });
 
   it('Tensor4D', () => {
@@ -606,7 +583,6 @@ describeWithFlags('where', ALL_ENVS, () => {
 
     a = dl.tensor4d([7, 7, 7, 7, 7, 7, 7, 7], [4, 2, 1, 1]);
     b = dl.tensor4d([3, 3, 3, 3, 3, 3, 3, 3], [4, 2, 1, 1]);
-    expectArraysClose(
-        dl.where(c, a, b), [7, 7, 3, 3, 7, 7, 3, 3]);
+    expectArraysClose(dl.where(c, a, b), [7, 7, 3, 3, 7, 7, 3, 3]);
   });
 });

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -92,6 +92,10 @@ export function expectArraysClose(
   }
 }
 
+export function expectPromiseToFail(fn: () => Promise<{}>, done: DoneFn): void {
+  fn().then(() => done.fail(), () => done());
+}
+
 export function expectArraysEqual(
     actual: Tensor|TypedArray|number[],
     expected: Tensor|TypedArray|number[]|boolean[]) {

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -210,7 +210,6 @@ function executeTests(testName: string, tests: () => void, features: Features) {
     beforeEach(() => BEFORE_EACH(features));
     afterEach(() => AFTER_EACH(features));
     afterAll(() => AFTER_ALL(features));
-
     tests();
   });
 }

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -145,17 +145,16 @@ export function describeWithFlags(
   });
 }
 
-let BEFORE_ALL = (features: Features) => {
+let BEFORE_ALL = (features: Features) => {};
+let AFTER_ALL = (features: Features) => {};
+let BEFORE_EACH = (features: Features) => {
   ENV.registerBackend('test-webgl', () => new MathBackendWebGL());
   ENV.registerBackend('test-cpu', () => new MathBackendCPU());
 };
-let AFTER_ALL = (features: Features) => {
+let AFTER_EACH = (features: Features) => {
   ENV.removeBackend('test-webgl');
   ENV.removeBackend('test-cpu');
-  ENV.reset();
 };
-let BEFORE_EACH = (features: Features) => {};
-let AFTER_EACH = (features: Features) => {};
 
 let TEST_ENV_FEATURES: Features[] = [
   {
@@ -200,18 +199,25 @@ function executeTests(testName: string, tests: () => void, features: Features) {
       ENV.setFeatures(features);
       BEFORE_ALL(features);
     });
+
     beforeEach(() => {
+      BEFORE_EACH(features);
       if (features && features.BACKEND != null) {
         Environment.setBackend(features.BACKEND);
       }
       ENV.engine.startScope();
-      BEFORE_EACH(features);
     });
+
     afterEach(() => {
-      AFTER_EACH(features);
       ENV.engine.endScope(null);
+      AFTER_EACH(features);
     });
-    afterAll(() => AFTER_ALL(features));
+
+    afterAll(() => {
+      AFTER_ALL(features);
+      ENV.reset();
+    });
+
     tests();
   });
 }

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -145,16 +145,16 @@ export function describeWithFlags(
   });
 }
 
-let BEFORE_ALL = (features: Features) => {};
-let AFTER_ALL = (features: Features) => {};
-let BEFORE_EACH = (features: Features) => {
+let BEFORE_ALL = (features: Features) => {
   ENV.registerBackend('test-webgl', () => new MathBackendWebGL());
   ENV.registerBackend('test-cpu', () => new MathBackendCPU());
 };
-let AFTER_EACH = (features: Features) => {
+let AFTER_ALL = (features: Features) => {
   ENV.removeBackend('test-webgl');
   ENV.removeBackend('test-cpu');
 };
+let BEFORE_EACH = (features: Features) => {};
+let AFTER_EACH = (features: Features) => {};
 
 let TEST_ENV_FEATURES: Features[] = [
   {

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -154,15 +154,8 @@ let AFTER_ALL = (features: Features) => {
   ENV.removeBackend('test-cpu');
   ENV.reset();
 };
-let BEFORE_EACH = (features: Features) => {
-  if (features && features.BACKEND != null) {
-    Environment.setBackend(features.BACKEND);
-  }
-  ENV.engine.startScope();
-};
-let AFTER_EACH = (features: Features) => {
-  ENV.engine.endScope(null);
-};
+let BEFORE_EACH = (features: Features) => {};
+let AFTER_EACH = (features: Features) => {};
 
 let TEST_ENV_FEATURES: Features[] = [
   {
@@ -207,8 +200,17 @@ function executeTests(testName: string, tests: () => void, features: Features) {
       ENV.setFeatures(features);
       BEFORE_ALL(features);
     });
-    beforeEach(() => BEFORE_EACH(features));
-    afterEach(() => AFTER_EACH(features));
+    beforeEach(() => {
+      if (features && features.BACKEND != null) {
+        Environment.setBackend(features.BACKEND);
+      }
+      ENV.engine.startScope();
+      BEFORE_EACH(features);
+    });
+    afterEach(() => {
+      AFTER_EACH(features);
+      ENV.engine.endScope(null);
+    });
     afterAll(() => AFTER_ALL(features));
     tests();
   });


### PR DESCRIPTION
The goal of this PR is to make the core tests reusable across different backends.

- `describeWithFlags` instead of list of features, now takes constraints that need to be satisfied in order for the test to run.
- `ALL_ENVS` becomes `{}`, which means there are no constraints.
- `WEBGL_ENVS` becomes `{BACKEND: 'webgl'}` which means run this test only when the `BACKEND` environment feature is `webgl`. Likewise for `CPU_ENVS`.
- Adds the following user-facing API:
  - `tf.test_util.setBeforeAll`/`setBeforeEach(f)`
  - `tf.test_util.setAfterAll`/`setAfterEach(f)`
  - `tf.test_util.setTestEnvFeatures(listOfFeatures)`. An example list: `[{BACKEND: 'custom'}]`
- Constraints a few core tests to run only in WebGL, since they are using browser-specific API.
- `ENV.registerBackend()` now takes an optional priority number (defaults to 1), which is used by `getBestBackendType` to find the best backend.
- Splits `toPixels` tests into browser-specific (which use canvas) and non-browser specific

Also fixes a bug with vertex buffer attribute binding, which allows us to re-create webgl backends in beforeAll, instead of beforeEach, speeding up our tests by 3x.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/926)
<!-- Reviewable:end -->
