### PR TITLE
Logical Ops: Allows logicalNot to be chained

### DIFF
--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -37,6 +37,16 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
     const a = dl.tensor1d([1, NaN, 0], 'bool');
     expectArraysClose(dl.logicalNot(a), [0, boolNaN, 1]);
   });
+  it('Tests chaining in Tensor1D', () => {
+    let a = dl.tensor1d([1, 0, 0], 'bool');
+    expectArraysClose(a.logicalNot(), [0, 1, 1]);
+
+    a = dl.tensor1d([0, 0, 0], 'bool');
+    expectArraysClose(a.logicalNot(), [1, 1, 1]);
+
+    a = dl.tensor1d([1, 1], 'bool');
+    expectArraysClose(a.logicalNot(), [0, 0]);
+  });
 
   it('Tensor2D', () => {
     let a = dl.tensor2d([[1, 0, 1], [0, 0, 0]], [2, 3], 'bool');

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -42,8 +42,7 @@ export class TensorBuffer<R extends Rank> {
 
   private strides: number[];
 
-  constructor(
-      shape: ShapeMap[R], public dtype: DataType, values: TypedArray) {
+  constructor(shape: ShapeMap[R], public dtype: DataType, values: TypedArray) {
     if (values != null) {
       const n = values.length;
       const size = util.sizeFromShape(shape);
@@ -670,6 +669,10 @@ export class Tensor<R extends Rank = Rank> {
   logicalOr(x: Tensor): Tensor {
     this.throwIfDisposed();
     return ops.logicalOr(this, x);
+  }
+  logicalNot<T extends Tensor>(this: T): T {
+    this.throwIfDisposed();
+    return ops.logicalNot(this);
   }
   logicalXor(x: Tensor): Tensor {
     this.throwIfDisposed();


### PR DESCRIPTION
This PR allows `tf.logicalNot` to be chained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/932)
<!-- Reviewable:end -->
