### PR TITLE
Docs: Fixes greaterEqual documentation

### DIFF
--- a/src/ops/compare.ts
+++ b/src/ops/compare.ts
@@ -158,7 +158,7 @@ export class CompareOps {
   /**
    * Returns the truth value of (a >= b) element-wise. Supports broadcasting.
    *
-   * We also expose `greaterStrict` which has the same signature as this
+   * We also expose `greaterEqualStrict` which has the same signature as this
    * op and asserts that `a` and `b` are the same shape (does not broadcast).
    *
    * @param a The first input tensor.


### PR DESCRIPTION
This PR fixes `tf.greaterEqual` documentation where it references strict method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/933)
<!-- Reviewable:end -->
