### PR TITLE
Add support for a tensor array of size 1 in concat.

### DIFF
--- a/src/ops/concat.ts
+++ b/src/ops/concat.ts
@@ -146,8 +146,11 @@ export class ConcatOps {
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
   @operation
   static concat<T extends Tensor>(tensors: T[], axis = 0): T {
-    util.assert(tensors.length >= 2, 'Pass at least two tensors to concat');
+    util.assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     let result = tensors[0];
+    if (tensors.length === 1) {
+      return result;
+    }
     const axes = parseAxisParam(axis, result.shape);
 
     for (let i = 1; i < tensors.length; ++i) {

--- a/src/ops/concat_test.ts
+++ b/src/ops/concat_test.ts
@@ -55,6 +55,13 @@ describeWithFlags('concat1d', ALL_ENVS, () => {
     const result = dl.concat1d([a, b, c, d]);
     expectArraysClose(result, [3, 5, 7, 9]);
   });
+
+  it('single tensor', () => {
+    const a = dl.tensor1d([3]);
+
+    const result = dl.concat1d([a]);
+    expectArraysClose(result, [3]);
+  });
 });
 
 describeWithFlags('concat2d', ALL_ENVS, () => {


### PR DESCRIPTION
Fixes tensorflow/tfjs#73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/938)
<!-- Reviewable:end -->
