### PR TITLE
Align webgl and cpu backend to be closer to TF

### DIFF
--- a/src/debug_mode_test.ts
+++ b/src/debug_mode_test.ts
@@ -16,9 +16,7 @@
  */
 
 import * as tf from './index';
-// tslint:disable-next-line:max-line-length
 import {ALL_ENVS, describeWithFlags, expectArraysClose} from './test_util';
-import * as util from './util';
 
 describeWithFlags('debug on', ALL_ENVS, () => {
   beforeAll(() => {
@@ -37,18 +35,6 @@ describeWithFlags('debug on', ALL_ENVS, () => {
 
   it('debug mode errors when there are nans, float32', () => {
     const a = tf.tensor1d([2, NaN]);
-    const f = () => tf.relu(a);
-    expect(f).toThrowError();
-  });
-
-  it('debug mode errors when there are nans, int32', () => {
-    const a = tf.tensor1d([2, util.NAN_INT32], 'int32');
-    const f = () => tf.relu(a);
-    expect(f).toThrowError();
-  });
-
-  it('debug mode errors when there are nans, bool', () => {
-    const a = tf.tensor1d([1, util.NAN_BOOL], 'bool');
     const f = () => tf.relu(a);
     expect(f).toThrowError();
   });

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from './index';
 // tslint:disable-next-line:max-line-length
-import {ALL_ENVS, describeWithFlags, expectArraysClose, expectArraysEqual, expectNumbersClose} from './test_util';
+import {ALL_ENVS, describeWithFlags, expectArraysClose, expectArraysEqual, expectNumbersClose, WEBGL_ENVS} from './test_util';
 
 describeWithFlags('tidy', ALL_ENVS, () => {
   it('returns Tensor', () => {
@@ -188,7 +188,7 @@ describeWithFlags('tidy', ALL_ENVS, () => {
   });
 });
 
-describeWithFlags('fromPixels + regular math op', ALL_ENVS, () => {
+describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
   it('debug mode does not error when no nans', () => {
     const pixels = new ImageData(2, 2);
     for (let i = 0; i < 8; i++) {

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -291,10 +291,6 @@ export class MathBackendCPU implements KernelBackend {
       let minIndex = 0;
       for (let j = 0; j < reduceSize; ++j) {
         const value = aVals[offset + j];
-        if (isNaN(value)) {
-          minIndex = util.NAN_INT32;
-          break;
-        }
         if (value < min) {
           min = value;
           minIndex = j;
@@ -320,10 +316,6 @@ export class MathBackendCPU implements KernelBackend {
       let maxIndex = 0;
       for (let j = 0; j < reduceSize; ++j) {
         const value = aVals[offset + j];
-        if (isNaN(value)) {
-          maxIndex = util.NAN_INT32;
-          break;
-        }
         if (value > max) {
           max = value;
           maxIndex = j;
@@ -336,61 +328,37 @@ export class MathBackendCPU implements KernelBackend {
 
   equal(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal === bVal) ? 1 : 0;
-      }
+      return (aVal === bVal) ? 1 : 0;
     });
   }
 
   notEqual(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal !== bVal) ? 1 : 0;
-      }
+      return (aVal !== bVal) ? 1 : 0;
     });
   }
 
   less(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal < bVal) ? 1 : 0;
-      }
+      return (aVal < bVal) ? 1 : 0;
     });
   }
 
   lessEqual(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal <= bVal) ? 1 : 0;
-      }
+      return (aVal <= bVal) ? 1 : 0;
     });
   }
 
   greater(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal > bVal) ? 1 : 0;
-      }
+      return (aVal > bVal) ? 1 : 0;
     });
   }
 
   greaterEqual(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return (aVal >= bVal) ? 1 : 0;
-      }
+      return (aVal >= bVal) ? 1 : 0;
     });
   }
 
@@ -398,42 +366,26 @@ export class MathBackendCPU implements KernelBackend {
     const values = x.dataSync();
     const newValues = new Int32Array(values.length);
     for (let i = 0; i < values.length; ++i) {
-      if (util.isValNaN(values[i], x.dtype)) {
-        newValues[i] = util.getNaN('bool');
-      } else {
-        newValues[i] = values[i] ? 0 : 1;
-      }
+      newValues[i] = values[i] ? 0 : 1;
     }
     return Tensor.make(x.shape, {values: newValues}, 'bool') as T;
   }
 
   logicalAnd(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return aVal && bVal;
-      }
+      return aVal && bVal;
     });
   }
 
   logicalOr(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return aVal || bVal;
-      }
+      return aVal || bVal;
     });
   }
 
   logicalXor(a: Tensor, b: Tensor): Tensor {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
-      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
-        return util.getNaN('bool');
-      } else {
-        return aVal ^ bVal;
-      }
+      return aVal ^ bVal;
     });
   }
 
@@ -505,10 +457,6 @@ export class MathBackendCPU implements KernelBackend {
       let min = aVals[0];
       for (let j = 0; j < reduceSize; ++j) {
         const value = aVals[offset + j];
-        if (isNaN(value)) {
-          min = Number.NaN;
-          break;
-        }
         if (value < min) {
           min = value;
         }
@@ -548,10 +496,6 @@ export class MathBackendCPU implements KernelBackend {
       let max = aVals[offset];
       for (let j = 0; j < reduceSize; ++j) {
         const value = aVals[offset + j];
-        if (isNaN(value)) {
-          max = Number.NaN;
-          break;
-        }
         if (value > max) {
           max = value;
         }
@@ -625,7 +569,7 @@ export class MathBackendCPU implements KernelBackend {
       }
     }
     return Tensor.make(x.shape, {values: newValues}) as T;
-  }  
+  }
 
   exp<T extends Tensor>(x: T): T {
     const values = x.dataSync();
@@ -699,12 +643,7 @@ export class MathBackendCPU implements KernelBackend {
     const values = x.dataSync();
     const newValues = new Float32Array(values.length);
     for (let i = 0; i < values.length; ++i) {
-      const value = values[i];
-      if (util.isValNaN(value, x.dtype)) {
-        newValues[i] = util.getNaN(x.dtype);
-      } else {
-        newValues[i] = 1 / value;
-      }
+      newValues[i] = 1 / values[i];
     }
     return Tensor.make(x.shape, {values: newValues}) as T;
   }
@@ -714,12 +653,7 @@ export class MathBackendCPU implements KernelBackend {
     const resVals = res.dataSync();
     const inVals = x.dataSync();
     for (let i = 0; i < inVals.length; ++i) {
-      const val = inVals[i];
-      if (util.isValNaN(val, x.dtype)) {
-        resVals[i] = util.getNaN(res.dtype);
-      } else {
-        resVals[i] = Math.max(0, inVals[i]);
-      }
+      resVals[i] = Math.max(0, inVals[i]);
     }
     return res as T;
   }
@@ -972,8 +906,8 @@ export class MathBackendCPU implements KernelBackend {
     const values = x.dataSync();
     for (let i = 0; i < values.length; ++i) {
       const value = values[i];
-      if (util.isValNaN(value, x.dtype)) {
-        resultValues[i] = util.getNaN(x.dtype);
+      if (isNaN(value)) {
+        resultValues[i] = NaN;
       } else {
         resultValues[i] = value > 0 ? 1 : alpha;
       }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -632,7 +632,7 @@ export class MathBackendWebGL implements KernelBackend {
   sign<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
     return this.compileAndRun(program, [x]) as T;
-  }    
+  }
 
   round<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
@@ -1042,9 +1042,7 @@ function float32ToTypedArray<D extends DataType>(
     const result = (dtype === 'int32') ? new Int32Array(a.length) :
                                          new Uint8Array(a.length);
     for (let i = 0; i < result.length; ++i) {
-      let val = a[i];
-      val = isNaN(val) ? util.getNaN(dtype) : Math.round(val);
-      result[i] = val;
+      result[i] = Math.round(a[i]);
     }
     return result;
   } else {
@@ -1054,14 +1052,5 @@ function float32ToTypedArray<D extends DataType>(
 
 function typedArrayToFloat32<D extends DataType>(
     a: DataTypeMap[D], dtype: D): Float32Array {
-  if (a instanceof Float32Array) {
-    return a;
-  } else {
-    const res = new Float32Array(a.length);
-    for (let i = 0; i < res.length; i++) {
-      const val = a[i];
-      res[i] = util.isValNaN(val, dtype) ? NaN : val;
-    }
-    return res;
-  }
+  return (a instanceof Float32Array) ? a : new Float32Array(a);
 }

--- a/src/kernels/webgl/argminmax_gpu.ts
+++ b/src/kernels/webgl/argminmax_gpu.ts
@@ -50,10 +50,6 @@ export class ArgMinMaxProgram implements GPGPUProgram {
         for (int i = 0; i < ${windowSize}; i++) {
           int inIdx = ${indexSnippet};
           float candidate = getA(batch, inIdx);
-          if (isNaN(candidate)) {
-            setOutput(candidate);
-            return;
-          }
           if (candidate ${compOp} bestValue) {
             bestValue = candidate;
             bestIndex = inIdx;

--- a/src/kernels/webgl/binaryop_gpu.ts
+++ b/src/kernels/webgl/binaryop_gpu.ts
@@ -35,9 +35,7 @@ export const SQUARED_DIFFERENCE = 'return (a - b) * (a - b);';
 export const EQUAL = CHECK_NAN_SNIPPET + `
   return float(a == b);
 `;
-export const NOT_EQUAL = CHECK_NAN_SNIPPET + `
-  return float(a != b);
-`;
+export const NOT_EQUAL = `return float(a != b);`;
 export const LESS = CHECK_NAN_SNIPPET + `
   return float(a < b);
 `;

--- a/src/kernels/webgl/reduce_gpu.ts
+++ b/src/kernels/webgl/reduce_gpu.ts
@@ -56,10 +56,6 @@ export class ReduceProgram implements GPGPUProgram {
       if (${isReduceSum}) {
         sumValue += dot(values, ones);
       } else {
-        if (hasNaN(values)) {
-          setOutput(getNaN(values));
-          return;
-        }
         minMaxValue = ${compareOp}(values, minMaxValue);
       }
     `;

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -951,7 +951,7 @@ describeWithFlags('randomUniform', ALL_ENVS, () => {
   });
 });
 
-describeWithFlags('fromPixels', ALL_ENVS, () => {
+describeWithFlags('fromPixels', WEBGL_ENVS, () => {
   it('ImageData 1x1x3', () => {
     const pixels = new ImageData(1, 1);
     pixels.data[0] = 0;

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -1592,16 +1592,6 @@ describeWithFlags('tile', ALL_ENVS, () => {
     expectArraysEqual(t2, [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]);
   });
 
-  it('bool propagates NaNs', () => {
-    const t = tf.tensor1d([true, false, NaN] as boolean[], 'bool');
-    const t2 = tf.tile(t, [2]);
-
-    expect(t2.shape).toEqual([6]);
-    expect(t2.dtype).toBe('bool');
-    expectArraysEqual(
-        t2, [1, 0, util.getNaN('bool'), 1, 0, util.getNaN('bool')]);
-  });
-
   it('1D int32 (tile)', () => {
     const t = tf.tensor1d([1, 2, 5], 'int32');
     const t2 = tf.tile(t, [2]);
@@ -1637,16 +1627,6 @@ describeWithFlags('tile', ALL_ENVS, () => {
     expect(t2.shape).toEqual([2, 4, 2]);
     expect(t2.dtype).toBe('int32');
     expectArraysEqual(t2, [1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 5, 6, 7, 8]);
-  });
-
-  it('int32 propagates NaNs', () => {
-    const t = tf.tensor1d([1, 3, NaN], 'int32');
-    const t2 = tf.tile(t, [2]);
-
-    expect(t2.shape).toEqual([6]);
-    expect(t2.dtype).toBe('int32');
-    expectArraysEqual(
-        t2, [1, 3, util.getNaN('int32'), 1, 3, util.getNaN('int32')]);
   });
 
   it('1D (tile) gradient', () => {

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -454,6 +454,12 @@ export class BinaryOps {
   @operation
   static minimum<T extends Tensor>(a: Tensor, b: Tensor): T {
     util.assertTypesMatch(a, b);
+    if (a.dtype === 'bool') {
+      a = a.toInt();
+    }
+    if (b.dtype === 'bool') {
+      b = b.toInt();
+    }
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     const der = (dy: Tensor) => {
       const derA = () => dy.mul(a.lessEqual(b).toFloat());
@@ -506,6 +512,12 @@ export class BinaryOps {
   @operation
   static maximum<T extends Tensor>(a: Tensor, b: Tensor): T {
     util.assertTypesMatch(a, b);
+    if (a.dtype === 'bool') {
+      a = a.toInt();
+    }
+    if (b.dtype === 'bool') {
+      b = b.toInt();
+    }
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     const der = (dy: Tensor) => {
       const derA = () => dy.mul(a.greaterEqual(b).toFloat());

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -89,8 +89,8 @@ describeWithFlags('maximum', ALL_ENVS, () => {
     const result = tf.maximum(a, b);
 
     expect(result.shape).toEqual(a.shape);
-    expect(result.dtype).toBe('bool');
-    expectArraysEqual(result, [true, false, true, true]);
+    expect(result.dtype).toBe('int32');
+    expectArraysEqual(result, [1, 0, 1, 1]);
   });
 
   it('different dtypes throws error', () => {
@@ -378,8 +378,8 @@ describeWithFlags('minimum', ALL_ENVS, () => {
     const result = tf.minimum(a, b);
 
     expect(result.shape).toEqual(a.shape);
-    expect(result.dtype).toBe('bool');
-    expectArraysEqual(result, [false, false, false, true]);
+    expect(result.dtype).toBe('int32');
+    expectArraysEqual(result, [0, 0, 0, 1]);
   });
 
   it('different dtypes throws error', () => {

--- a/src/ops/compareop_test.ts
+++ b/src/ops/compareop_test.ts
@@ -18,9 +18,6 @@
 import * as tf from '../index';
 // tslint:disable-next-line:max-line-length
 import {describeWithFlags, ALL_ENVS, expectArraysClose, expectArraysEqual} from '../test_util';
-import * as util from '../util';
-
-const boolNaN = util.getNaN('bool');
 
 describeWithFlags('equal', ALL_ENVS, () => {
   it('Tensor1D - int32', () => {
@@ -67,16 +64,10 @@ describeWithFlags('equal', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-
-    expectArraysClose(tf.equal(a, b), [0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
-    expectArraysClose(tf.equal(a, b), [0, boolNaN, boolNaN]);
+    expectArraysClose(tf.equal(a, b), [0, 0, 0]);
   });
   it('scalar and 1D broadcast', () => {
     const a = tf.scalar(2);
@@ -119,16 +110,10 @@ describeWithFlags('equal', ALL_ENVS, () => {
         tf.tensor2d([[0.1, 1.1, 2.1], [7.1, 8.1, 9.1]], [2, 3], 'float32');
     expectArraysClose(tf.equal(a, b), [0, 1, 0, 1, 0, 0]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [1, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    expectArraysClose(
-        tf.equal(a, b), [0, boolNaN, boolNaN, 1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
-    expectArraysClose(tf.equal(a, b), [0, boolNaN, 1, boolNaN]);
+    expectArraysClose(tf.equal(a, b), [0, 0, 1, 0]);
   });
   it('2D and 2D broadcast each with 1 dim', () => {
     const a = tf.tensor2d([1, 2, 5], [1, 3]);
@@ -199,21 +184,13 @@ describeWithFlags('equal', ALL_ENVS, () => {
     expectArraysClose(
         tf.equal(a, b), [1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    expectArraysClose(
-        tf.equal(a, b), [0, boolNaN, 1, 0, 1, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
     const b = tf.tensor3d(
       [[[0.1], [0.1], [1.1]], [[1.1], [0.1], [NaN]]], [2, 3, 1], 'float32');
     expectArraysClose(
-        tf.equal(a, b), [0, boolNaN, 1, 0, 1, boolNaN]);
+        tf.equal(a, b), [0, 0, 1, 0, 1, 0]);
   });
   it('3D and scalar', () => {
     const a = tf.tensor3d([1, 2, 3, 4, 5, -1], [2, 3, 1]);
@@ -265,15 +242,10 @@ describeWithFlags('equal', ALL_ENVS, () => {
         'float32');
     expectArraysClose(tf.equal(a, b), [1, 0, 0, 0, 1, 0, 0, 0]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    expectArraysClose(tf.equal(a, b), [0, boolNaN, 1, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
       const a = tf.tensor4d([1.1, NaN, 1.1, 0.1], [2, 2, 1, 1], 'float32');
       const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
-      expectArraysClose(tf.equal(a, b), [0, boolNaN, 1, boolNaN]);
+      expectArraysClose(tf.equal(a, b), [0, 0, 1, 0]);
   });
 });
 
@@ -320,17 +292,11 @@ describeWithFlags('equalStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, boolNaN]);
+        tf.equalStrict(a, b), [0, 0, 0]);
   });
 
   // Tensor2D:
@@ -372,17 +338,11 @@ describeWithFlags('equalStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [1, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, boolNaN, 1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, 1, boolNaN]);
+        tf.equalStrict(a, b), [0, 0, 1, 0]);
   });
 
   // Tensor3D:
@@ -445,23 +405,13 @@ describeWithFlags('equalStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d(
-          [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, 1, 0, 1, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
        [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
     const b = tf.tensor3d(
         [[[0.1], [0.1], [1.1]], [[1.1], [0.1], [NaN]]], [2, 3, 1], 'float32');
     expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, 1, 0, 1, boolNaN]);
+        tf.equalStrict(a, b), [0, 0, 1, 0, 1, 0]);
   });
 
   // Tensor4D:
@@ -512,17 +462,11 @@ describeWithFlags('equalStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, 1, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 1.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     expectArraysClose(
-        tf.equalStrict(a, b), [0, boolNaN, 1, boolNaN]);
+        tf.equalStrict(a, b), [0, 0, 1, 0]);
   });
 });
 
@@ -571,24 +515,18 @@ describeWithFlags('notEqual', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-
-    expectArraysClose(tf.notEqual(a, b), [1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
-    expectArraysClose(tf.notEqual(a, b), [1, boolNaN, boolNaN]);
+    expectArraysClose(tf.notEqual(a, b), [1, 1, 1]);
   });
-  it('propagates NaNs', () => {
+  it('works with NaNs', () => {
     const a = tf.tensor1d([2, 5, NaN]);
     const b = tf.tensor1d([4, 5, -1]);
 
     const res = tf.notEqual(a, b);
     expect(res.dtype).toBe('bool');
-    expectArraysEqual(res, [1, 0, util.NAN_BOOL]);
+    expectArraysEqual(res, [1, 0, 1]);
   });
   it('scalar and 1D broadcast', () => {
     const a = tf.scalar(2);
@@ -631,17 +569,10 @@ describeWithFlags('notEqual', ALL_ENVS, () => {
         tf.tensor2d([[0.1, 1.1, 2.1], [7.1, 8.1, 9.1]], [2, 3], 'float32');
     expectArraysClose(tf.notEqual(a, b), [1, 0, 1, 0, 1, 1]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [1, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, boolNaN, 0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
-    expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, 0, boolNaN]);
+    expectArraysClose(tf.notEqual(a, b), [1, 1, 0, 1]);
   });
   it('2D and scalar broadcast', () => {
     const a = tf.tensor2d([1, 2, 3, 2, 5, 6], [2, 3]);
@@ -719,23 +650,13 @@ describeWithFlags('notEqual', ALL_ENVS, () => {
     expectArraysClose(
         tf.notEqual(a, b), [0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d(
-          [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
     const b = tf.tensor3d(
         [[[0.1], [0.1], [1.1]], [[1.1], [0.1], [NaN]]], [2, 3, 1] ,'float32');
     expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
+        tf.notEqual(a, b), [1, 1, 0, 1, 0, 1]);
   });
   it('3D and scalar', () => {
     const a = tf.tensor3d([1, 2, 3, 4, 5, -1], [2, 3, 1]);
@@ -789,17 +710,11 @@ describeWithFlags('notEqual', ALL_ENVS, () => {
     expectArraysClose(
         tf.notEqual(a, b), [0, 1, 1, 1, 0, 1, 1, 1]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, 0, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 1.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     expectArraysClose(
-        tf.notEqual(a, b), [1, boolNaN, 0, boolNaN]);
+        tf.notEqual(a, b), [1, 1, 0, 1]);
   });
 });
 
@@ -846,17 +761,11 @@ describeWithFlags('notEqualStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, boolNaN]);
+        tf.notEqualStrict(a, b), [1, 1, 1]);
   });
   it('strict version throws when x and y are different shape', () => {
     const a = tf.tensor1d([2]);
@@ -907,18 +816,11 @@ describeWithFlags('notEqualStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [1, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    expectArraysClose(
-        tf.notEqualStrict(a, b),
-        [1, boolNaN, boolNaN, 0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, 0, boolNaN]);
+        tf.notEqualStrict(a, b), [1, 1, 0, 1]);
   });
 
   // Tensor3D:
@@ -984,23 +886,13 @@ describeWithFlags('notEqualStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d(
-          [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
     const b = tf.tensor3d(
         [[[0.1], [0.1], [1.1]], [[1.1], [0.1], [NaN]]], [2, 3, 1], 'float32');
     expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
+        tf.notEqualStrict(a, b), [1, 1, 0, 1, 0, 1]);
   });
 
   // Tensor4D:
@@ -1052,17 +944,11 @@ describeWithFlags('notEqualStrict', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, 0, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 1.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     expectArraysClose(
-        tf.notEqualStrict(a, b), [1, boolNaN, 0, boolNaN]);
+        tf.notEqualStrict(a, b), [1, 1, 0, 1]);
   });
 });
 
@@ -1127,21 +1013,13 @@ describeWithFlags('less', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    const res = tf.less(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     const res = tf.less(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, boolNaN]);
+    expectArraysClose(res, [1, 0, 0]);
   });
 
   // Tensor2D:
@@ -1194,22 +1072,13 @@ describeWithFlags('less', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 0, 1, 0, 1, 1]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [0, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    const res = tf.less(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(
-        res, [0, boolNaN, boolNaN, 1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [0.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const res = tf.less(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    expectArraysClose(res, [0, 0, 1, 0]);
   });
 
   // Tensor3D:
@@ -1283,19 +1152,6 @@ describeWithFlags('less', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]],
-          [2, 3, 1],
-          'int32');
-    const res = tf.less(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 0, 1, 0, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
@@ -1304,7 +1160,7 @@ describeWithFlags('less', ALL_ENVS, () => {
     const res = tf.less(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 0, 1, 0, boolNaN]);
+    expectArraysClose(res, [0, 0, 0, 1, 0, 0]);
   });
 
   // Tensor4D:
@@ -1372,21 +1228,13 @@ describeWithFlags('less', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 1, 1, 1, 0, 1, 0, 0]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 0, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    const res = tf.less(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 0.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     const res = tf.less(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    expectArraysClose(res, [0, 0, 1, 0]);
   });
 });
 
@@ -1506,21 +1354,13 @@ describeWithFlags('lessEqual', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    const res = tf.lessEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     const res = tf.lessEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, boolNaN]);
+    expectArraysClose(res, [1, 0, 0]);
   });
 
   // Tensor2D:
@@ -1573,22 +1413,13 @@ describeWithFlags('lessEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 1, 1, 1, 1, 1]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [0, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    const res = tf.lessEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(
-        res, [0, boolNaN, boolNaN, 1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [0.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const res = tf.lessEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    expectArraysClose(res, [0, 0, 1, 0]);
   });
 
   // Tensor3D:
@@ -1661,18 +1492,6 @@ describeWithFlags('lessEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d(
-          [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    const res = tf.lessEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, 1, 1, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
@@ -1681,7 +1500,7 @@ describeWithFlags('lessEqual', ALL_ENVS, () => {
     const res = tf.lessEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, 1, 1, boolNaN]);
+    expectArraysClose(res, [0, 0, 1, 1, 1, 0]);
   });
 
   // Tensor4D:
@@ -1749,21 +1568,13 @@ describeWithFlags('lessEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 1, 1, 1, 1, 1, 0, 0]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 0, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    const res = tf.lessEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 0.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     const res = tf.lessEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    expectArraysClose(res, [0, 0, 1, 0]);
   });
 });
 
@@ -1882,21 +1693,13 @@ describeWithFlags('greater', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    const res = tf.greater(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     const res = tf.greater(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, boolNaN]);
+    expectArraysClose(res, [0, 0, 0]);
   });
 
   // Tensor2D:
@@ -1949,22 +1752,13 @@ describeWithFlags('greater', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 0, 0, 0, 0, 0]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [0, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    const res = tf.greater(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(
-        res, [1, boolNaN, boolNaN, 0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [0.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const res = tf.greater(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
+    expectArraysClose(res, [1, 0, 0, 0]);
   });
 
   // Tensor3D:
@@ -2037,16 +1831,6 @@ describeWithFlags('greater', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a = tf.tensor3d(
-        [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b = tf.tensor3d(
-        [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    const res = tf.greater(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, 0, 0, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
@@ -2055,7 +1839,7 @@ describeWithFlags('greater', ALL_ENVS, () => {
     const res = tf.greater(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, 0, 0, boolNaN]);
+    expectArraysClose(res, [1, 0, 0, 0, 0, 0]);
   });
 
   // Tensor4D:
@@ -2123,21 +1907,13 @@ describeWithFlags('greater', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [0, 0, 0, 0, 0, 0, 1, 1]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 0, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    const res = tf.greater(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 0.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     const res = tf.greater(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
+    expectArraysClose(res, [1, 0, 0, 0]);
   });
 });
 
@@ -2257,21 +2033,13 @@ describeWithFlags('greaterEqual', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D - int32', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'int32');
-    const b = tf.tensor1d([0, 0, NaN], 'int32');
-    const res = tf.greaterEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor1D - float32', () => {
     const a = tf.tensor1d([1.1, NaN, 2.1], 'float32');
     const b = tf.tensor1d([2.1, 3.1, NaN], 'float32');
     const res = tf.greaterEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [0, boolNaN, boolNaN]);
+    expectArraysClose(res, [0, 0, 0]);
   });
 
   // Tensor2D:
@@ -2324,22 +2092,13 @@ describeWithFlags('greaterEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 1, 0, 1, 0, 0]);
   });
-  it('NaNs in Tensor2D - int32', () => {
-    const a = tf.tensor2d([[1, NaN, 2], [0, NaN, NaN]], [2, 3], 'int32');
-    const b = tf.tensor2d([[0, NaN, NaN], [1, NaN, 3]], [2, 3], 'int32');
-    const res = tf.greaterEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(
-        res, [1, boolNaN, boolNaN, 0, boolNaN, boolNaN]);
-  });
   it('NaNs in Tensor2D - float32', () => {
     const a = tf.tensor2d([[1.1, NaN], [0.1, NaN]], [2, 2], 'float32');
     const b = tf.tensor2d([[0.1, NaN], [1.1, NaN]], [2, 2], 'float32');
     const res = tf.greaterEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
+    expectArraysClose(res, [1, 0, 0, 0]);
   });
 
   // Tensor3D:
@@ -2412,18 +2171,6 @@ describeWithFlags('greaterEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1]);
   });
-  it('NaNs in Tensor3D - int32', () => {
-    const a =
-        tf.tensor3d(
-          [[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'int32');
-    const b =
-        tf.tensor3d(
-          [[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'int32');
-    const res = tf.greaterEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 1, 0, 1, boolNaN]);
-  });
   it('NaNs in Tensor3D - float32', () => {
     const a = tf.tensor3d(
         [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], [2, 3, 1], 'float32');
@@ -2432,7 +2179,7 @@ describeWithFlags('greaterEqual', ALL_ENVS, () => {
     const res = tf.greaterEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 1, 0, 1, boolNaN]);
+    expectArraysClose(res, [1, 0, 1, 0, 1, 0]);
   });
 
   // Tensor4D:
@@ -2500,21 +2247,13 @@ describeWithFlags('greaterEqual', ALL_ENVS, () => {
     expect(res.dtype).toBe('bool');
     expectArraysClose(res, [1, 0, 0, 0, 1, 0, 1, 1]);
   });
-  it('NaNs in Tensor4D - int32', () => {
-    const a = tf.tensor4d([1, NaN, 0, 0], [2, 2, 1, 1], 'int32');
-    const b = tf.tensor4d([0, 1, 1, NaN], [2, 2, 1, 1], 'int32');
-    const res = tf.greaterEqual(a, b);
-
-    expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
-  });
   it('NaNs in Tensor4D - float32', () => {
     const a = tf.tensor4d([1.1, NaN, 0.1, 0.1], [2, 2, 1, 1], 'float32');
     const b = tf.tensor4d([0.1, 1.1, 1.1, NaN], [2, 2, 1, 1], 'float32');
     const res = tf.greaterEqual(a, b);
 
     expect(res.dtype).toBe('bool');
-    expectArraysClose(res, [1, boolNaN, 0, boolNaN]);
+    expectArraysClose(res, [1, 0, 0, 0]);
   });
 });
 

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -17,9 +17,6 @@
 
 import * as tf from '../index';
 import {ALL_ENVS, describeWithFlags, expectArraysClose} from '../test_util';
-import * as util from '../util';
-
-const boolNaN = util.getNaN('bool');
 
 describeWithFlags('logicalNot', ALL_ENVS, () => {
   it('Tensor1D.', () => {
@@ -31,10 +28,6 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
 
     a = tf.tensor1d([1, 1], 'bool');
     expectArraysClose(tf.logicalNot(a), [0, 0]);
-  });
-  it('NaNs in Tensor1D', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'bool');
-    expectArraysClose(tf.logicalNot(a), [0, boolNaN, 1]);
   });
   it('Tests chaining in Tensor1D', () => {
     let a = tf.tensor1d([1, 0, 0], 'bool');
@@ -54,10 +47,6 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
     a = tf.tensor2d([[0, 0, 0], [1, 1, 1]], [2, 3], 'bool');
     expectArraysClose(tf.logicalNot(a), [1, 1, 1, 0, 0, 0]);
   });
-  it('NaNs in Tensor2D', () => {
-    const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
-    expectArraysClose(tf.logicalNot(a), [0, boolNaN, 1, boolNaN]);
-  });
 
   it('Tensor3D', () => {
     let a = tf.tensor3d([[[1], [0], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
@@ -65,11 +54,6 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
 
     a = tf.tensor3d([[[0], [0], [0]], [[1], [1], [1]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalNot(a), [1, 1, 1, 0, 0, 0]);
-  });
-  it('NaNs in Tensor3D', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    expectArraysClose(tf.logicalNot(a), [0, boolNaN, 0, 1, 1, 1]);
   });
 
   it('Tensor4D', () => {
@@ -81,10 +65,6 @@ describeWithFlags('logicalNot', ALL_ENVS, () => {
 
     a = tf.tensor4d([1, 1, 1, 1], [2, 2, 1, 1], 'bool');
     expectArraysClose(tf.logicalNot(a), [0, 0, 0, 0]);
-  });
-  it('NaNs in Tensor4D', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
-    expectArraysClose(tf.logicalNot(a), [0, boolNaN, 0, 1]);
   });
 });
 
@@ -110,11 +90,6 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'bool');
-    const b = tf.tensor1d([0, 0, NaN], 'bool');
-    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, boolNaN]);
-  });
 
   it('Tensor2D', () => {
     let a = tf.tensor2d([[1, 0, 1], [0, 0, 0]], [2, 3], 'bool');
@@ -129,11 +104,6 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     const a = tf.tensor2d([[1], [0]], [2, 1], 'bool');
     const b = tf.tensor2d([[0, 1, 0], [0, 1, 0]], [2, 3], 'bool');
     expectArraysClose(tf.logicalAnd(a, b), [0, 1, 0, 0, 0, 0]);
-  });
-  it('NaNs in Tensor2D', () => {
-    const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
-    const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 
   it('Tensor3D', () => {
@@ -154,13 +124,6 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     expectArraysClose(
         tf.logicalAnd(a, b), [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
   });
-  it('NaNs in Tensor3D', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    const b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
-  });
 
   it('Tensor4D', () => {
     let a = tf.tensor4d([1, 0, 1, 0], [2, 2, 1, 1], 'bool');
@@ -180,11 +143,6 @@ describeWithFlags('logicalAnd', ALL_ENVS, () => {
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
     expectArraysClose(tf.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
-  });
-  it('NaNs in Tensor4D', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
-    const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(tf.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
   });
 });
 
@@ -210,11 +168,6 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'bool');
-    const b = tf.tensor1d([0, 0, NaN], 'bool');
-    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, boolNaN]);
-  });
 
   it('Tensor2D', () => {
     let a = tf.tensor2d([[1, 0, 1], [0, 0, 0]], [2, 3], 'bool');
@@ -229,11 +182,6 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     const a = tf.tensor2d([[1], [0]], [2, 1], 'bool');
     const b = tf.tensor2d([[0, 0, 0], [0, 1, 0]], [2, 3], 'bool');
     expectArraysClose(tf.logicalOr(a, b), [1, 1, 1, 0, 1, 0]);
-  });
-  it('NaNs in Tensor2D', () => {
-    const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
-    const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   it('Tensor3D', () => {
@@ -252,13 +200,6 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     const b =
         tf.tensor3d([[[0], [0], [1]], [[1], [0], [0]]], [2, 3, 1], 'bool');
     expectArraysClose(tf.logicalOr(a, b), [1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0]);
-  });
-  it('NaNs in Tensor3D', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    const b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, 1, 0, boolNaN]);
   });
 
   it('Tensor4D', () => {
@@ -279,11 +220,6 @@ describeWithFlags('logicalOr', ALL_ENVS, () => {
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
     expectArraysClose(tf.logicalOr(a, b), [1, 1, 0, 0, 1, 1, 1, 1]);
-  });
-  it('NaNs in Tensor4D', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
-    const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(tf.logicalOr(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 
@@ -309,11 +245,6 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     };
     expect(f).toThrowError();
   });
-  it('NaNs in Tensor1D', () => {
-    const a = tf.tensor1d([1, NaN, 0], 'bool');
-    const b = tf.tensor1d([0, 0, NaN], 'bool');
-    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, boolNaN]);
-  });
 
   // Tensor2D:
   it('Tensor2D', () => {
@@ -329,11 +260,6 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     const a = tf.tensor2d([[1], [0]], [2, 1], 'bool');
     const b = tf.tensor2d([[0, 0, 0], [0, 1, 0]], [2, 3], 'bool');
     expectArraysClose(tf.logicalXor(a, b), [1, 1, 1, 0, 1, 0]);
-  });
-  it('NaNs in Tensor2D', () => {
-    const a = tf.tensor2d([[1, NaN], [0, NaN]], [2, 2], 'bool');
-    const b = tf.tensor2d([[0, NaN], [1, NaN]], [2, 2], 'bool');
-    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 
   // Tensor3D:
@@ -355,13 +281,6 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     expectArraysClose(
         tf.logicalXor(a, b), [1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]);
   });
-  it('NaNs in Tensor3D', () => {
-    const a =
-        tf.tensor3d([[[1], [NaN], [1]], [[0], [0], [0]]], [2, 3, 1], 'bool');
-    const b =
-        tf.tensor3d([[[0], [0], [1]], [[1], [0], [NaN]]], [2, 3, 1], 'bool');
-    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 0, 1, 0, boolNaN]);
-  });
 
   // Tensor4D:
   it('Tensor4D', () => {
@@ -382,11 +301,6 @@ describeWithFlags('logicalXor', ALL_ENVS, () => {
     const b = tf.tensor4d(
         [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], [2, 2, 1, 2], 'bool');
     expectArraysClose(tf.logicalXor(a, b), [0, 1, 0, 0, 1, 1, 1, 1]);
-  });
-  it('NaNs in Tensor4D', () => {
-    const a = tf.tensor4d([1, NaN, 1, 0], [2, 2, 1, 1], 'bool');
-    const b = tf.tensor4d([0, 1, 0, NaN], [2, 2, 1, 1], 'bool');
-    expectArraysClose(tf.logicalXor(a, b), [1, boolNaN, 1, boolNaN]);
   });
 });
 

--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -102,6 +102,9 @@ export class ReductionOps {
   @operation
   static sum<T extends Tensor>(
       x: Tensor, axis: number|number[] = null, keepDims = false): T {
+    if (x.dtype === 'bool') {
+      x = x.toInt();
+    }
     const axes = axis_util.parseAxisParam(axis, x.shape);
 
     // Use a custom gradient to bypass 2 gradient backprops since sum is used

--- a/src/ops/reduction_ops_test.ts
+++ b/src/ops/reduction_ops_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '../index';
 // tslint:disable-next-line:max-line-length
-import {ALL_ENVS, assertIsNan, describeWithFlags, expectArraysClose, expectArraysEqual, expectNumbersClose} from '../test_util';
+import {ALL_ENVS, describeWithFlags, expectArraysClose, expectArraysEqual, expectNumbersClose} from '../test_util';
 import * as reduce_util from './reduce_util';
 
 describeWithFlags('min', ALL_ENVS, () => {
@@ -26,9 +26,9 @@ describeWithFlags('min', ALL_ENVS, () => {
     expectNumbersClose(tf.min(a).get(), -7);
   });
 
-  it('propagates NaNs', () => {
+  it('ignores NaNs', () => {
     const a = tf.tensor1d([3, NaN, 2]);
-    expect(tf.min(a).get()).toEqual(NaN);
+    expect(tf.min(a).get()).toEqual(2);
   });
 
   it('2D', () => {
@@ -89,8 +89,8 @@ describeWithFlags('max', ALL_ENVS, () => {
     expectNumbersClose(r.get(), 3);
   });
 
-  it('propagates NaNs', () => {
-    expect(tf.max(tf.tensor1d([3, NaN, 2])).get()).toEqual(NaN);
+  it('ignores NaNs', () => {
+    expect(tf.max(tf.tensor1d([3, NaN, 2])).get()).toEqual(3);
   });
 
   it('2D', () => {
@@ -165,11 +165,11 @@ describeWithFlags('argmax', ALL_ENVS, () => {
     expect(result.get()).toBe(n - 1);
   });
 
-  it('propagates NaNs', () => {
-    const a = tf.tensor1d([5, 0, 3, NaN, 3]);
+  it('ignores NaNs', () => {
+    const a = tf.tensor1d([0, 3, 5, NaN, 3]);
     const res = tf.argMax(a);
     expect(res.dtype).toBe('int32');
-    assertIsNan(res.get(), res.dtype);
+    expect(res.get()).toBe(2);
   });
 
   it('2D, no axis specified', () => {
@@ -226,10 +226,10 @@ describeWithFlags('argmin', ALL_ENVS, () => {
     expect(result.get()).toBe(n - 1);
   });
 
-  it('Arg min propagates NaNs', () => {
-    const a = tf.tensor1d([5, 0, NaN, 7, 3]);
+  it('ignores NaNs', () => {
+    const a = tf.tensor1d([5, 0, NaN, -1, 3]);
     const res = tf.argMin(a);
-    assertIsNan(res.get(), res.dtype);
+    expect(res.get()).toBe(3);
   });
 
   it('2D, no axis specified', () => {
@@ -810,7 +810,7 @@ describeWithFlags('norm', ALL_ENVS, () => {
 
   it('propagates NaNs for norm', () => {
     const a = tf.tensor2d([1, 2, 3, NaN, 0, 1], [3, 2]);
-    const norm = tf.norm(a, Infinity, [0, 1]);
+    const norm = tf.norm(a);
 
     expect(norm.dtype).toBe('float32');
     expect(norm.get()).toEqual(NaN);

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -352,6 +352,9 @@ export class UnaryOps {
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
   static relu<T extends Tensor>(x: T): T {
+    if (x.dtype === 'bool') {
+      return x.toInt();
+    }
     const grad = (dy: T) => {
       const stepRes = x.step();
       return {x: () => dy.mulStrict(stepRes.toFloat())};

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -54,20 +54,6 @@ describeWithFlags('relu', ALL_ENVS, () => {
     expectArraysClose(result, [1, 0, 0, 3, 0, NaN]);
   });
 
-  it('propagates NaNs, int32', () => {
-    const a = tf.tensor1d([1, -2, 0, 3, -1, util.NAN_INT32], 'int32');
-    const result = tf.relu(a);
-    expect(result.dtype).toBe('int32');
-    expectArraysClose(result, [1, 0, 0, 3, 0, util.NAN_INT32]);
-  });
-
-  it('propagates NaNs, bool', () => {
-    const a = tf.tensor1d([1, 0, 0, 1, 0, util.NAN_BOOL], 'bool');
-    const result = tf.relu(a);
-    expect(result.dtype).toBe('bool');
-    expectArraysClose(result, [1, 0, 0, 1, 0, util.NAN_BOOL]);
-  });
-
   it('gradients: positive scalar', () => {
     const a = tf.scalar(3);
     const dy = tf.scalar(5);

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -19,7 +19,7 @@ import {ENV, Environment, Features} from './environment';
 import {MathBackendCPU} from './kernels/backend_cpu';
 import {MathBackendWebGL} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
-import {DataType, TypedArray} from './types';
+import {TypedArray} from './types';
 import * as util from './util';
 
 // Constraints for testing.
@@ -224,10 +224,4 @@ function executeTests(testName: string, tests: () => void, features: Features) {
 
     tests();
   });
-}
-
-export function assertIsNan(val: number, dtype: DataType) {
-  if (!util.isValNaN(val, dtype)) {
-    throw new Error(`Value ${val} does not represent NaN for dtype ${dtype}`);
-  }
 }

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -170,64 +170,6 @@ describe('util.inferFromImplicitShape', () => {
   });
 });
 
-describe('util.getNaN', () => {
-  it('float32', () => {
-    expect(isNaN(util.getNaN('float32'))).toBe(true);
-  });
-
-  it('int32', () => {
-    expect(util.getNaN('int32')).toBe(util.NAN_INT32);
-  });
-
-  it('bool', () => {
-    expect(util.getNaN('bool')).toBe(util.NAN_BOOL);
-  });
-
-  it('unknown type throws error', () => {
-    // tslint:disable-next-line:no-any
-    expect(() => util.getNaN('hello' as any)).toThrowError();
-  });
-});
-
-describe('util.isValNaN', () => {
-  it('NaN for float32', () => {
-    expect(util.isValNaN(NaN, 'float32')).toBe(true);
-  });
-
-  it('2 for float32', () => {
-    expect(util.isValNaN(3, 'float32')).toBe(false);
-  });
-
-  it('255 for float32', () => {
-    expect(util.isValNaN(255, 'float32')).toBe(false);
-  });
-
-  it('255 for int32', () => {
-    expect(util.isValNaN(255, 'int32')).toBe(false);
-  });
-
-  it('NAN_INT32 for int32', () => {
-    expect(util.isValNaN(util.NAN_INT32, 'int32')).toBe(true);
-  });
-
-  it('NAN_INT32 for bool', () => {
-    expect(util.isValNaN(util.NAN_INT32, 'bool')).toBe(false);
-  });
-
-  it('NAN_BOOL for bool', () => {
-    expect(util.isValNaN(util.NAN_BOOL, 'bool')).toBe(true);
-  });
-
-  it('2 for bool', () => {
-    expect(util.isValNaN(2, 'bool')).toBe(false);
-  });
-
-  it('throws error for unknown dtype', () => {
-    // tslint:disable-next-line:no-any
-    expect(() => util.isValNaN(0, 'hello' as any)).toThrowError();
-  });
-});
-
 describe('util.squeezeShape', () => {
   it('scalar', () => {
     const {newShape, keptDims} = util.squeezeShape([]);
@@ -299,37 +241,7 @@ describe('util.checkForNaN', () => {
     // Int32 and Bool NaNs should not trigger an error.
     expect(
         () => util.checkForNaN(
-            new Float32Array(
-                [1, 2, 3, 4, -1, 255, util.NAN_INT32, util.NAN_BOOL]),
-            'float32', ''))
-        .not.toThrowError();
-  });
-
-  it('Int32Array has NaN', () => {
-    expect(
-        () => util.checkForNaN(
-            new Int32Array([1, 2, 3, util.NAN_INT32, 4, 255]), 'int32', ''))
-        .toThrowError();
-  });
-
-  it('Int32Array no NaN', () => {
-    expect(
-        () => util.checkForNaN(
-            new Int32Array([1, 2, 3, 4, -1, 255, util.NAN_BOOL]), 'int32', ''))
-        .not.toThrowError();
-  });
-
-  it('Bool has NaN', () => {
-    expect(
-        () => util.checkForNaN(
-            new Uint8Array([1, 2, 3, util.NAN_BOOL, 4, 10]), 'bool', ''))
-        .toThrowError();
-  });
-
-  it('Bool no NaN', () => {
-    expect(
-        () => util.checkForNaN(
-            new Uint8Array([1, 2, 3, 4, 1, util.NAN_INT32]), 'bool', ''))
+            new Float32Array([1, 2, 3, 4, -1, 255]), 'float32', ''))
         .not.toThrowError();
   });
 });


### PR DESCRIPTION
- Remove NaN support for tensors of dtype 'bool' and 'int32'