### PR TITLE
Ensure that gather indices are int32 to match TF.

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -857,7 +857,9 @@ export class ArrayOps {
   static gather<T extends Tensor>(x: T, indices: Tensor1D, axis = 0): T {
     const axes = parseAxisParam(axis, x.shape);
     return ENV.engine.runKernel(
-        backend => backend.gather(x, indices, axes[0]), {x, indices});
+        backend => backend.gather(
+            x, indices.dtype === 'int32' ? indices : indices.toInt(), axes[0]),
+        {x, indices});
   }
 
   /**


### PR DESCRIPTION
TF wants this value as an int32. Let me know if you think that enforcing this at method signature level is better (I couldn't figure it out).

Layers calls into gather without specifying type: https://github.com/tensorflow/tfjs-layers/blob/master/src/engine/training.ts#L328

This currently provides problems running TF backend + tfjs-layers API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/950)
<!-- Reviewable:end -->
