### PR TITLE
Require shape in tensor2d/3d/4d(flatValues, shape)

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -117,8 +117,7 @@ export class ArrayOps {
   static tensor1d(values: TensorLike1D, dtype: DataType = 'float32'): Tensor1D {
     const inferredShape = util.inferShape(values);
     if (inferredShape.length !== 1) {
-      throw new Error(
-          'Error creating a new Tensor1D: values must be a flat/TypedArray');
+      throw new Error('tensor1d() requires values to be a flat/TypedArray');
     }
     return ArrayOps.tensor(values, inferredShape as [number], dtype);
   }
@@ -151,8 +150,12 @@ export class ArrayOps {
     const inferredShape = util.inferShape(values);
     if (inferredShape.length !== 2 && inferredShape.length !== 1) {
       throw new Error(
-          'Error creating a new Tensor2D: values must be number[][] ' +
-          'or flat/TypedArray');
+          'tensor2d() requires values to be number[][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor2d() requires shape to be provided when `values` ' +
+          'are a flat/TypedArray');
     }
     shape = shape || inferredShape as [number, number];
     return ArrayOps.tensor(values, shape, dtype);
@@ -186,8 +189,12 @@ export class ArrayOps {
     const inferredShape = util.inferShape(values);
     if (inferredShape.length !== 3 && inferredShape.length !== 1) {
       throw new Error(
-          'Error creating a new Tensor3D: values must be number[][][]' +
-          'or flat/TypedArray');
+          'tensor3d() requires values to be number[][][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor3d() requires shape to be provided when `values` ' +
+          'are a flat array');
     }
     shape = shape || inferredShape as [number, number, number];
     return ArrayOps.tensor(values, shape, dtype);
@@ -221,8 +228,12 @@ export class ArrayOps {
     const inferredShape = util.inferShape(values);
     if (inferredShape.length !== 4 && inferredShape.length !== 1) {
       throw new Error(
-          'Error creating a new Tensor4D: values must be number[][][][]' +
-          'or flat/TypedArray');
+          'tensor4d() requires values to be number[][][][] or flat/TypedArray');
+    }
+    if (inferredShape.length === 1 && shape == null) {
+      throw new Error(
+          'tensor4d() requires shape to be provided when `values` ' +
+          'are a flat array');
     }
     shape = shape || inferredShape as [number, number, number, number];
     return ArrayOps.tensor(values, shape, dtype);

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -285,6 +285,10 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(() => tf.tensor2d([[1, 2, 3], [4, 5, 6]], [3, 2])).toThrowError();
   });
 
+  it('tf.tensor2d() from number[], but no shape throws error', () => {
+    expect(() => tf.tensor2d([1, 2, 3, 4])).toThrowError();
+  });
+
   it('tensor3d() from number[][][]', () => {
     const a = tf.tensor3d([[[1], [2], [3]], [[4], [5], [6]]], [2, 3, 1]);
     expectArraysClose(a, [1, 2, 3, 4, 5, 6]);
@@ -294,6 +298,10 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const values = [[[1], [2], [3]], [[4], [5], [6]]];
     // Actual shape is [2, 3, 1].
     expect(() => tf.tensor3d(values, [3, 2, 1])).toThrowError();
+  });
+
+  it('tf.tensor3d() from number[], but no shape throws error', () => {
+    expect(() => tf.tensor3d([1, 2, 3, 4])).toThrowError();
   });
 
   it('tensor4d() from number[][][][]', () => {
@@ -307,6 +315,10 @@ describeWithFlags('tensor', ALL_ENVS, () => {
       tf.tensor4d([[[[1]], [[2]]], [[[4]], [[5]]]], [2, 1, 2, 1]);
     };
     expect(f).toThrowError();
+  });
+
+  it('tf.tensor4d() from number[], but no shape throws error', () => {
+    expect(() => tf.tensor4d([1, 2, 3, 4])).toThrowError();
   });
 
   it('default dtype', () => {


### PR DESCRIPTION
**Bug**
`tensor2d([1, 2, 3, 4])` returns Tensor of rank 1 with shape `[4]`. Likewise for `tensor3d` and `tensor4d`

**Solution**
`tensor2d(flatValues)` throws an error requiring shape to be provided explicitly by the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/969)
<!-- Reviewable:end -->
