### PR TITLE
Fix some issues in batchNormalization gradient

### DIFF
--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -210,22 +210,19 @@ export class BatchNormOps {
 
     const der = (dy: Tensor) => {
       const scaleValue = scale == null ? ArrayOps.scalar(1) : scale;
-
-      let nonDepthMultiplier = 1;
-      let xMinusMean: Tensor;
+      const reductionAxes: number[] = [];
       const tileShape: number[] = [];
-
       if (mean.rank === 1) {
         for (let i = 0; i < x4D.shape.length - 1; ++i) {
-          nonDepthMultiplier *= x4D.shape[i];
+          reductionAxes.push(i);
           tileShape.push(x4D.shape[i]);
         }
         tileShape.push(1);
-        xMinusMean = x.sub(mean).sum(0).reshape(mean.shape);
       } else {
-        xMinusMean = x.sub(mean);
       }
 
+      const xMinusMean = x.sub(mean);
+      const dyTimesScaleValue = dy.mul(scaleValue);
       const oneOverSqrtVariance =
           rsqrt(variance.add(ArrayOps.scalar(varianceEpsilon)));
       const minusHalfRCube = oneOverSqrtVariance.mul(oneOverSqrtVariance)
@@ -233,35 +230,44 @@ export class BatchNormOps {
                                  .mul(ArrayOps.scalar(-0.5));
       const derX = () => {
         if (mean.rank === 1) {
-          return ArrayOps
-              .tile(oneOverSqrtVariance.as4D(1, 1, 1, mean.shape[0]), tileShape)
+          return dy
+              .mul(ArrayOps.tile(
+                  oneOverSqrtVariance.as4D(1, 1, 1, mean.shape[0]), tileShape))
               .mul(scaleValue)
               .reshape(x.shape);
         } else {
-          return oneOverSqrtVariance.mul(scaleValue).reshape(x.shape);
+          return dy.mul(oneOverSqrtVariance).mul(scaleValue).reshape(x.shape);
         }
       };
       const derMean = () => {
-        return oneOverSqrtVariance.mul(ArrayOps.scalar(-1 * nonDepthMultiplier))
-            .mul(scaleValue)
-            .reshape(mean.shape);
+        let meanDer =
+            oneOverSqrtVariance.mul(ArrayOps.scalar(-1)).mul(dyTimesScaleValue);
+        if (mean.rank === 1) {
+          meanDer = meanDer.sum(reductionAxes);
+        }
+        return meanDer.reshape(mean.shape);
       };
       const derVariance = () => {
-        return minusHalfRCube.mul(xMinusMean)
-            .mul(scaleValue)
-            .reshape(variance.shape);
+        let varianceDer = minusHalfRCube.mul(xMinusMean).mul(dyTimesScaleValue);
+        if (mean.rank === 1) {
+          varianceDer = varianceDer.sum(reductionAxes);
+        }
+        return varianceDer.reshape(mean.shape);
       };
       const derScale = () => {
-        return xMinusMean.mul(oneOverSqrtVariance).reshape(mean.shape);
+        const xMinusMean2TimesRsqrt = xMinusMean.mul(oneOverSqrtVariance);
+        let scaleDer = dy.mul(xMinusMean2TimesRsqrt);
+        if (mean.rank === 1) {
+          scaleDer = scaleDer.sum(reductionAxes);
+        }
+        return scaleDer.reshape(mean.shape);
       };
       const derOffset = () => {
+        let offsetDer = dy;
         if (mean.rank === 1) {
-          return ArrayOps.onesLike(mean)
-              .mul(ArrayOps.scalar(nonDepthMultiplier))
-              .reshape(mean.shape);
-        } else {
-          return ArrayOps.onesLike(mean);
+          offsetDer = offsetDer.sum(reductionAxes);
         }
+        return offsetDer.reshape(mean.shape);
       };
       return {
         x: derX,

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -127,28 +127,28 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const dy = tf.tensor4d([1, 1, 1, 1], [2, 1, 1, 2]);
+    const dy = tf.tensor4d([-1, -1, -1, -1], [2, 1, 1, 2]);
     const gradX = tf.grad(
         (x: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
     expectArraysClose(
-        gradX, tf.tensor4d([1.414, 2.887, 1.414, 2.887], [2, 1, 1, 2]));
+        gradX, tf.tensor4d([-1.414, -2.887, -1.414, -2.887], [2, 1, 1, 2]));
     const gradMean = tf.grad(
         (mean: tf.Tensor1D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
-    expectArraysClose(gradMean, tf.tensor1d([-2.828, -5.773]));
+    expectArraysClose(gradMean, tf.tensor1d([2.828, 5.773]));
     const gradVariance = tf.grad(
         (variance: tf.Tensor1D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
-    expectArraysClose(gradVariance, tf.tensor1d([-1.413, -238.519]));
+    expectArraysClose(gradVariance, tf.tensor1d([1.413, 238.519]));
     const gradOffset = tf.grad(
         (offset: tf.Tensor1D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
-    expectArraysClose(gradOffset, tf.onesLike(offset).mul(tf.scalar(2)));
+    expectArraysClose(gradOffset, dy.sum([0, 1, 2]));
     const gradScale = tf.grad(
         (scale: tf.Tensor1D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
-    expectArraysClose(gradScale, tf.tensor1d([2.828, 286.318]));
+    expectArraysClose(gradScale, tf.tensor1d([-2.828, -286.318]));
   });
 
   it('batchnorm4D gradients, same shapes in x, mean and variance', () => {
@@ -160,32 +160,31 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const dy = tf.tensor4d([1, 1, 1, 1], [2, 1, 1, 2]);
+    const dy = tf.tensor4d([-1, -1, -1, -1], [2, 1, 1, 2]);
     const gradX = tf.grad(
         (x: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
     expectArraysClose(
-        gradX, tf.tensor4d([1.414, 2.500, 0.816, 1.768], [2, 1, 1, 2]));
+        gradX, tf.tensor4d([-1.414, -2.500, -0.816, -1.768], [2, 1, 1, 2]));
     const gradMean = tf.grad(
         (mean: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
     expectArraysClose(
-        gradMean, tf.tensor4d([-1.414, -2.500, -0.816, -1.768], [2, 1, 1, 2]));
+        gradMean, tf.tensor4d([1.414, 2.500, 0.816, 1.768], [2, 1, 1, 2]));
     const gradVariance = tf.grad(
         (variance: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
     expectArraysClose(
-        gradVariance,
-        tf.tensor4d([-3.533, -4.686, -1.360, -2.762], [2, 1, 1, 2]));
+        gradVariance, tf.tensor4d([3.533, 4.686, 1.360, 2.762], [2, 1, 1, 2]));
     const gradOffset = tf.grad(
         (offset: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
-    expectArraysClose(gradOffset, tf.onesLike(offset));
+    expectArraysClose(gradOffset, dy);
     const gradScale = tf.grad(
         (scale: tf.Tensor4D) => tf.batchNormalization4d(
             x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
     expectArraysClose(
-        gradScale, tf.tensor4d([7.069, 7.499, 8.164, 8.838], [2, 1, 1, 2]));
+        gradScale, tf.tensor4d([-7.069, -7.499, -8.164, -8.838], [2, 1, 1, 2]));
   });
 });
 


### PR DESCRIPTION
Two issues fixed:
1. The outgoing gradient (`dy`) was previously not used.
2. The ordering of reduce sum and multiplication was wrong in
   some of the gradients previously.

Also tested with BatchNormalization training in tfjs-layers:
https://github.com/tensorflow/tfjs-layers/pull/139/files