### PR TITLE
Move @types/jasmine to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jasmine": "~2.5.53",
     "@types/node": "~9.6.0",
     "@types/seedrandom": "~2.4.27",
     "browserify": "~14.4.0",
@@ -41,6 +40,7 @@
     "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun"
   },
   "dependencies": {
+    "@types/jasmine": "^2.8.6",
     "seedrandom": "~2.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/jasmine@~2.5.53":
-  version "2.5.54"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.54.tgz#a6b5f2ae2afb6e0307774e8c7c608e037d491c63"
+"@types/jasmine@^2.8.6":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.6.tgz#14445b6a1613cf4e05dd61c3c3256d0e95c0421e"
 
 "@types/node@~9.6.0":
   version "9.6.0"


### PR DESCRIPTION
@types/jasmine is required if an @tensorflow/tfjs-core is used directly since test_util is in the index.

https://github.com/tensorflow/magenta-js/pull/38
@iansimon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/972)
<!-- Reviewable:end -->
