### PR TITLE
Add rank, size ops

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -1232,6 +1232,25 @@ export class ArrayOps {
   static print<T extends Tensor>(x: T, verbose = false): void {
     console.log(tensor_util.tensorToString(x, verbose));
   }
+
+  /**
+   * Returns a 0-D int32 Tensor representing the rank of input.
+   * @param x The tensor whose rank is returned.
+   */
+  @doc({heading: 'Tensors', subheading: 'Transformations'})
+  static rank<T extends Tensor>(x: T): Scalar {
+    return ArrayOps.tensor(x.rank, [], 'int32');
+  }
+
+  /**
+   * Returns a 0-D Tensor representing the number of elements
+   * in input of type out_type. Defaults to tf.int32.
+   * @param x The tensor whose sie is returned.
+   */
+  @doc({heading: 'Tensors', subheading: 'Transformations'})
+  static size<T extends Tensor>(x: T): Scalar {
+    return ArrayOps.tensor(x.size, [], 'int32');
+  }
 }
 
 function makeZerosTypedArray<D extends DataType>(

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2198,3 +2198,47 @@ describeWithFlags('expandDims', ALL_ENVS, () => {
         .toThrowError(/Argument 'x' passed to 'expandDims' must be a Tensor/);
   });
 });
+
+describeWithFlags('rank ops', ALL_ENVS, () => {
+  it('rank of scalar', () => {
+    const res = tf.rank(tf.scalar(1));
+    expect(res.get()).toEqual(0);
+  });
+
+  it('rank of tensor1d', () => {
+    const res = tf.rank(tf.tensor1d([1]));
+    expect(res.get()).toEqual(1);
+  });
+
+  it('rank of tensor2d', () => {
+    const res = tf.rank(tf.tensor2d([[1,2,3], [4,5,6]], [2, 3]));
+    expect(res.get()).toEqual(2);
+  });
+
+  it('rank of tensor3d', () => {
+    const res = tf.rank(tf.tensor3d([1,2,3,4,5,6], [1, 2, 3]));
+    expect(res.get()).toEqual(3);
+  });
+});
+
+describeWithFlags('size ops', ALL_ENVS, () => {
+  it('size of scalar', () => {
+    const res = tf.size(tf.scalar(1));
+    expect(res.get()).toEqual(1);
+  });
+
+  it('size of tensor1d', () => {
+    const res = tf.size(tf.tensor1d([1]));
+    expect(res.get()).toEqual(1);
+  });
+
+  it('size of tensor2d', () => {
+    const res = tf.size(tf.tensor2d([[1,2,3], [4,5,6]], [2, 3]));
+    expect(res.get()).toEqual(6);
+  });
+
+  it('size of tensor3d', () => {
+    const res = tf.size(tf.tensor3d([1,2,3,4,5,6], [1, 2, 3]));
+    expect(res.get()).toEqual(6);
+  });
+});

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -204,6 +204,9 @@ export const pad2d = ArrayOps.pad2d;
 export const pad3d = ArrayOps.pad3d;
 export const pad4d = ArrayOps.pad4d;
 
+export const rank = ArrayOps.rank;
+export const size = ArrayOps.size;
+
 export const movingAverage = MovingAverageOps.movingAverage;
 
 export const basicLSTMCell = LSTMOps.basicLSTMCell;


### PR DESCRIPTION
# Purpose

As described [here](https://github.com/tensorflow/tfjs/issues/188#issuecomment-381845538), MobileNet V2 depends on the rank and size as an ops implementation. Like TensorFlow, they can be returned as rank0 tensor (scalar). 

# Note
We may need to consider consistency with `rank` in eager mode because it returns a rank as just a number not a tensor.

see: https://github.com/tensorflow/tfjs/issues/188#issuecomment-381845538

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/976)
<!-- Reviewable:end -->
