### PR TITLE
test_util still depends on jasmine typings because of `DoneFn`. This fixes it

### DIFF
--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -90,6 +90,11 @@ export function expectArraysClose(
   }
 }
 
+export interface DoneFn {
+  (): void;
+  fail: (message?: Error|string) => void;
+}
+
 export function expectPromiseToFail(fn: () => Promise<{}>, done: DoneFn): void {
   fn().then(() => done.fail(), () => done());
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/985)
<!-- Reviewable:end -->
