### PR TITLE
Fix build issue where module-import code gets dropped from the bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@
  * =============================================================================
  */
 
+import './kernels/backend_webgl';
+import './kernels/backend_cpu';
+
 import {BrowserUtil} from './browser_util';
 import * as environment from './environment';
 import {Environment} from './environment';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@
  * =============================================================================
  */
 
+// backend_cpu.ts and backend_webgl.ts are standalone files and should be
+// explicily included here. Below, there is an export from backend_webgl, but
+// that doesn't count since it's exporting a Typescript interface.
 import './kernels/backend_webgl';
 import './kernels/backend_cpu';
 


### PR DESCRIPTION
`backend_cpu.ts` and `backend_webgl.ts` are never included from `index.ts` even though there is
`export {WebGLTimingInfo} from './kernels/backend_webgl';`. That export is just a Typescript interface, and gets compiled away in the es5 code.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/987)
<!-- Reviewable:end -->
