### PR TITLE
Unary Ops: Add chaining to round op

### DIFF
--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2081,7 +2081,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
 describeWithFlags('round', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor1d([0.9, 2.5, 2.3, 1.5, -4.5]);
-    const r = tf.round(a);
+    const r = a.round();
 
     expectNumbersClose(r.get(0), 1.0);
     expectNumbersClose(r.get(1), 2.0);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -827,6 +827,10 @@ export class Tensor<R extends Rank = Rank> {
     this.throwIfDisposed();
     return ops.erf(this);
   }
+  round<T extends Tensor>(this: T): T {
+    this.throwIfDisposed();
+    return ops.round(this);
+  }
   step<T extends Tensor>(this: T, alpha = 0.0): T {
     this.throwIfDisposed();
     return ops.step(this, alpha);


### PR DESCRIPTION
Chaining on round operation was missing. This PR fixes the same.