### PR TITLE
Optimize CPU conv2dDerInput

### DIFF
--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -38,9 +38,8 @@ export interface TensorData {
 export class TensorBuffer<R extends Rank> {
   size: number;
   shape: ShapeMap[R];
+  strides: number[];
   values: TypedArray;
-
-  private strides: number[];
 
   constructor(shape: ShapeMap[R], public dtype: DataType, values: TypedArray) {
     if (values != null) {


### PR DESCRIPTION
This makes conv2dTranspose about 100x times faster on v8 (node v8.9.0).
There are more convolutional ops to optimize - doing it one at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/995)
<!-- Reviewable:end -->
