### PR TITLE
Fix nan propagation in tf.relu

### DIFF
--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -46,7 +46,9 @@ const CHECK_NAN_SNIPPET = `if (isNaN(x)) return x;`;
 
 export const ABS = `return abs(x);`;
 
-export const RELU = `return (x < 0.0) ? 0.0 : x;`;
+export const RELU = CHECK_NAN_SNIPPET + `
+  return (x < 0.0) ? 0.0 : x;
+`;
 
 export const ELU = `return (x >= 0.0) ? x : (exp(x) - 1.0);`;
 


### PR DESCRIPTION
BUG Default behavior changed with newest NVidia Drivers in Mac OS `>=10.13.4` so we have to check for NaN explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1001)
<!-- Reviewable:end -->
