### PR TITLE
Add unstack op

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -1097,23 +1097,14 @@ export class ArrayOps {
    * ```
    *
    * @param value A tensor object.
-   * @param num The number of unstacked tensors.
    * @param axis The axis to unstack along. Defaults to 0 (the first dim).
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
   @operation
   static unstack<T extends Tensor>(
-      value: T, num: number = null, axis = 0): Tensor[] {
-    if (num === null) {
-      // Default num is the length of dimension axis.
-      num = value.shape[axis];
-    }
-    util.assert(
-        value.shape[axis] === num,
-        'Number of splits must be equal to the axis.');
-
-    const outputShape: number[]
-        = Array(value.rank - 1).fill(0);
+      value: T, axis = 0): Tensor[] {
+    const num = value.shape[axis];
+    const outputShape: number[] = Array(value.rank - 1).fill(0);
     let outIndex = 0;
     for (let i = 0; i < value.rank; i++) {
       if (i !== axis) {

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -1088,6 +1088,20 @@ export class ArrayOps {
     return ConcatOps.concat(expandedTensors, axis);
   }
 
+  /**
+   * Unstacks a `Tensor` of rank-`R` into a list of rank-`(R-1)` `Tensor`s.
+   *
+   * ```js
+   * const a = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+   * tf.unstack(a).print();
+   * ```
+   *
+   * @param value A tensor object.
+   * @param num The number of unstacked tensors.
+   * @param axis The axis to unstack along. Defaults to 0 (the first dim).
+   */
+  @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
+  @operation
   static unstack<T extends Tensor>(
       value: T, num: number = null, axis = 0): Tensor[] {
     if (num === null) {

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -1088,6 +1088,38 @@ export class ArrayOps {
     return ConcatOps.concat(expandedTensors, axis);
   }
 
+  static unstack<T extends Tensor>(
+      value: T, num: number = null, axis = 0): Tensor[] {
+    if (num === null) {
+      // Default num is the length of dimension axis.
+      num = value.shape[axis];
+    }
+    util.assert(
+        value.shape[axis] === num,
+        'Number of splits must be equal to the axis.');
+
+    const outputShape: number[]
+        = Array(value.rank - 1).fill(0);
+    let outIndex = 0;
+    for (let i = 0; i < value.rank; i++) {
+      if (i !== axis) {
+        outputShape[outIndex] = value.shape[i];
+        outIndex++;
+      }
+    }
+
+    let splitSizes: number[];
+    splitSizes = Array(num).fill(1);
+    const begin = Array(value.rank).fill(0);
+    const size = value.shape.slice();
+    return splitSizes.map(s => {
+      size[axis] = s;
+      const slice = value.slice(begin, size);
+      begin[axis] += s;
+      return slice.reshape(outputShape);
+    });
+  }
+
   /**
    * Splits a `Tensor` into sub tensors.
    *

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2264,7 +2264,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack into 3 tensors', () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6], [3, 2]);
-    const res = tf.unstack(x, 3, 0);
+    const res = tf.unstack(x, 0);
     expect(res.length).toEqual(3);
     expect(res[0].rank).toEqual(1);
     expect(res[0].shape).toEqual([2]);
@@ -2279,7 +2279,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack by axis=1', () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
-    const res = tf.unstack(x, 4, 1);
+    const res = tf.unstack(x, 1);
     expect(res.length).toEqual(4);
     expect(res[0].rank).toEqual(1);
     expect(res[0].shape).toEqual([2]);
@@ -2309,7 +2309,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack rank 3 tensor with axis=1', () => {
     const x = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
-    const res = tf.unstack(x, 2, 1);
+    const res = tf.unstack(x, 1);
     expect(res.length).toEqual(2);
     expect(res[0].rank).toEqual(2);
     expect(res[0].shape).toEqual([2, 2]);
@@ -2321,7 +2321,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack rank 3 tensor with axis=2', () => {
     const x = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
-    const res = tf.unstack(x, 2, 2);
+    const res = tf.unstack(x, 2);
     expect(res.length).toEqual(2);
     expect(res[0].rank).toEqual(2);
     expect(res[0].shape).toEqual([2, 2]);
@@ -2345,7 +2345,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack rank 4 tensor with axis=1', () => {
     const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
-    const res = tf.unstack(x, 2, 1);
+    const res = tf.unstack(x, 1);
     expect(res.length).toEqual(2);
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 1]);
@@ -2357,7 +2357,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack rank 4 tensor with axis=2', () => {
     const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
-    const res = tf.unstack(x, 2, 2);
+    const res = tf.unstack(x, 2);
     expect(res.length).toEqual(2);
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 1]);
@@ -2369,7 +2369,7 @@ describeWithFlags('unstack', ALL_ENVS, () => {
 
   it('unstack rank 4 tensor with axis=3', () => {
     const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
-    const res = tf.unstack(x, 1, 3);
+    const res = tf.unstack(x, 3);
     expect(res.length).toEqual(1);
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 2]);

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2262,6 +2262,21 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expectArraysClose(res[1], [5, 6, 7, 8]);
   });
 
+  it('unstack into 3 tensors', () => {
+    const x = tf.tensor2d([1, 2, 3, 4, 5, 6], [3, 2]);
+    const res = tf.unstack(x, 3, 0);
+    expect(res.length).toEqual(3);
+    expect(res[0].rank).toEqual(1);
+    expect(res[0].shape).toEqual([2]);
+    expectArraysClose(res[0], [1, 2]);
+    expect(res[1].rank).toEqual(1);
+    expect(res[1].shape).toEqual([2]);
+    expectArraysClose(res[1], [3, 4]);
+    expect(res[2].rank).toEqual(1);
+    expect(res[2].shape).toEqual([2]);
+    expectArraysClose(res[2], [5, 6]);
+  });
+
   it('unstack by axis=1', () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
     const res = tf.unstack(x, 4, 1);
@@ -2269,8 +2284,14 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(1);
     expect(res[0].shape).toEqual([2]);
     expectArraysClose(res[0], [1, 5]);
+    expect(res[1].rank).toEqual(1);
+    expect(res[1].shape).toEqual([2]);
     expectArraysClose(res[1], [2, 6]);
+    expect(res[2].rank).toEqual(1);
+    expect(res[2].shape).toEqual([2]);
     expectArraysClose(res[2], [3, 7]);
+    expect(res[3].rank).toEqual(1);
+    expect(res[3].shape).toEqual([2]);
     expectArraysClose(res[3], [4, 8]);
   });
 
@@ -2281,6 +2302,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(2);
     expect(res[0].shape).toEqual([2, 2]);
     expectArraysClose(res[0], [1, 2, 3, 4]);
+    expect(res[1].rank).toEqual(2);
+    expect(res[1].shape).toEqual([2, 2]);
     expectArraysClose(res[1], [5, 6, 7, 8]);
   });
 
@@ -2291,6 +2314,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(2);
     expect(res[0].shape).toEqual([2, 2]);
     expectArraysClose(res[0], [1, 2, 5, 6]);
+    expect(res[1].rank).toEqual(2);
+    expect(res[1].shape).toEqual([2, 2]);
     expectArraysClose(res[1], [3, 4, 7, 8]);
   });
 
@@ -2301,6 +2326,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(2);
     expect(res[0].shape).toEqual([2, 2]);
     expectArraysClose(res[0], [1, 3, 5, 7]);
+    expect(res[1].rank).toEqual(2);
+    expect(res[1].shape).toEqual([2, 2]);
     expectArraysClose(res[1], [2, 4, 6, 8]);
   });
 
@@ -2311,6 +2338,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[0], [1, 2, 3, 4]);
+    expect(res[1].rank).toEqual(3);
+    expect(res[1].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[1], [5, 6, 7, 8]);
   });
 
@@ -2321,6 +2350,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[0], [1, 2, 5, 6]);
+    expect(res[1].rank).toEqual(3);
+    expect(res[1].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[1], [3, 4, 7, 8]);
   });
 
@@ -2331,6 +2362,8 @@ describeWithFlags('unstack', ALL_ENVS, () => {
     expect(res[0].rank).toEqual(3);
     expect(res[0].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[0], [1, 3, 5, 7]);
+    expect(res[1].rank).toEqual(3);
+    expect(res[1].shape).toEqual([2, 2, 1]);
     expectArraysClose(res[1], [2, 4, 6, 8]);
   });
 

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2249,6 +2249,101 @@ describeWithFlags('stack', ALL_ENVS, () => {
   });
 });
 
+describeWithFlags('unstack', ALL_ENVS, () => {
+  it('unstack by default', () => {
+    const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
+    const res = tf.unstack(x);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(1);
+    expect(res[0].shape).toEqual([4]);
+    expectArraysClose(res[0], [1, 2, 3, 4]);
+    expect(res[1].rank).toEqual(1);
+    expect(res[1].shape).toEqual([4]);
+    expectArraysClose(res[1], [5, 6, 7, 8]);
+  });
+
+  it('unstack by axis=1', () => {
+    const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
+    const res = tf.unstack(x, 4, 1);
+    expect(res.length).toEqual(4);
+    expect(res[0].rank).toEqual(1);
+    expect(res[0].shape).toEqual([2]);
+    expectArraysClose(res[0], [1, 5]);
+    expectArraysClose(res[1], [2, 6]);
+    expectArraysClose(res[2], [3, 7]);
+    expectArraysClose(res[3], [4, 8]);
+  });
+
+  it('unstack rank 3 tensor', () => {
+    const x = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
+    const res = tf.unstack(x);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(2);
+    expect(res[0].shape).toEqual([2, 2]);
+    expectArraysClose(res[0], [1, 2, 3, 4]);
+    expectArraysClose(res[1], [5, 6, 7, 8]);
+  });
+
+  it('unstack rank 3 tensor with axis=1', () => {
+    const x = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
+    const res = tf.unstack(x, 2, 1);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(2);
+    expect(res[0].shape).toEqual([2, 2]);
+    expectArraysClose(res[0], [1, 2, 5, 6]);
+    expectArraysClose(res[1], [3, 4, 7, 8]);
+  });
+
+  it('unstack rank 3 tensor with axis=2', () => {
+    const x = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
+    const res = tf.unstack(x, 2, 2);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(2);
+    expect(res[0].shape).toEqual([2, 2]);
+    expectArraysClose(res[0], [1, 3, 5, 7]);
+    expectArraysClose(res[1], [2, 4, 6, 8]);
+  });
+
+  it('unstack rank 4 tensor', () => {
+    const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
+    const res = tf.unstack(x);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(3);
+    expect(res[0].shape).toEqual([2, 2, 1]);
+    expectArraysClose(res[0], [1, 2, 3, 4]);
+    expectArraysClose(res[1], [5, 6, 7, 8]);
+  });
+
+  it('unstack rank 4 tensor with axis=1', () => {
+    const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
+    const res = tf.unstack(x, 2, 1);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(3);
+    expect(res[0].shape).toEqual([2, 2, 1]);
+    expectArraysClose(res[0], [1, 2, 5, 6]);
+    expectArraysClose(res[1], [3, 4, 7, 8]);
+  });
+
+  it('unstack rank 4 tensor with axis=2', () => {
+    const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
+    const res = tf.unstack(x, 2, 2);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(3);
+    expect(res[0].shape).toEqual([2, 2, 1]);
+    expectArraysClose(res[0], [1, 3, 5, 7]);
+    expectArraysClose(res[1], [2, 4, 6, 8]);
+  });
+
+  it('unstack rank 4 tensor with axis=3', () => {
+    const x = tf.tensor4d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2, 1]);
+    const res = tf.unstack(x, 1, 3);
+    expect(res.length).toEqual(1);
+    expect(res[0].rank).toEqual(3);
+    expect(res[0].shape).toEqual([2, 2, 2]);
+    expectArraysClose(res[0], [1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+});
+
 describeWithFlags('split', ALL_ENVS, () => {
   it('split by number', () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -199,6 +199,7 @@ export const tensor4d = ArrayOps.tensor4d;
 export const print = ArrayOps.print;
 export const expandDims = ArrayOps.expandDims;
 export const stack = ArrayOps.stack;
+export const unstack = ArrayOps.unstack;
 export const split = ArrayOps.split;
 
 export const pad = ArrayOps.pad;

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -482,6 +482,9 @@ export class Tensor<R extends Rank = Rank> {
   stack(x: Tensor, axis = 0): Tensor {
     return ops.stack([this, x], axis);
   }
+  unstack(x: Tensor, num: number = null, axis = 0): Tensor[] {
+    return ops.unstack(this, num, axis);
+  }
   pad<T extends Tensor>(
       this: T, paddings: Array<[number, number]>, constantValue = 0): T {
     return ops.pad(this, paddings, constantValue);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -482,8 +482,8 @@ export class Tensor<R extends Rank = Rank> {
   stack(x: Tensor, axis = 0): Tensor {
     return ops.stack([this, x], axis);
   }
-  unstack(x: Tensor, num: number = null, axis = 0): Tensor[] {
-    return ops.unstack(this, num, axis);
+  unstack(x: Tensor, axis = 0): Tensor[] {
+    return ops.unstack(this, axis);
   }
   pad<T extends Tensor>(
       this: T, paddings: Array<[number, number]>, constantValue = 0): T {


### PR DESCRIPTION
# Purpose

Some model including MobileNet requires `unstack` op (https://github.com/tensorflow/tfjs/issues/188). Since `unpack` is depracated and renamed to `unstack`, TensorFlow.js should also use the same name convention.

see: [tf.unstack](https://www.tensorflow.org/api_docs/python/tf/unstack)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1018)
<!-- Reviewable:end -->
