### PR TITLE
Add IS_BROWSER to ENV; add scheme-based URL router to tf.io.* modules

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,7 +31,7 @@ export interface Features {
   // Whether to enable debug mode.
   'DEBUG'?: boolean;
   // Whether we are in a node.js (i.e., non-browser) environment.
-  'IS_NODE'?: boolean;
+  'IS_BROWSER'?: boolean;
   // The disjoint_query_timer extension version.
   // 0: disabled, 1: EXT_disjoint_timer_query, 2:
   // EXT_disjoint_timer_query_webgl2.
@@ -53,7 +53,7 @@ export interface Features {
 }
 
 export const URL_PROPERTIES: URLProperty[] = [
-  {name: 'DEBUG', type: Type.BOOLEAN}, {name: 'IS_NODE', type: Type.BOOLEAN},
+  {name: 'DEBUG', type: Type.BOOLEAN}, {name: 'IS_BROWSER', type: Type.BOOLEAN},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN},
   {name: 'WEBGL_VERSION', type: Type.NUMBER},
@@ -304,8 +304,8 @@ export class Environment {
   private evaluateFeature<K extends keyof Features>(feature: K): Features[K] {
     if (feature === 'DEBUG') {
       return false;
-    } else if (feature === 'IS_NODE') {
-      return typeof window === 'undefined';
+    } else if (feature === 'IS_BROWSER') {
+      return typeof window !== 'undefined';
     } else if (feature === 'BACKEND') {
       return this.getBestBackendType();
     } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -30,7 +30,7 @@ export enum Type {
 export interface Features {
   // Whether to enable debug mode.
   'DEBUG'?: boolean;
-  // Whether we are in a node.js (i.e., non-browser) environment.
+  // Whether we are in a browser (as versus, say, node.js) environment.
   'IS_BROWSER'?: boolean;
   // The disjoint_query_timer extension version.
   // 0: disabled, 1: EXT_disjoint_timer_query, 2:

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -30,6 +30,8 @@ export enum Type {
 export interface Features {
   // Whether to enable debug mode.
   'DEBUG'?: boolean;
+  // Whether we are in a node.js (i.e., non-browser) environment.
+  'IS_NODE'?: boolean;
   // The disjoint_query_timer extension version.
   // 0: disabled, 1: EXT_disjoint_timer_query, 2:
   // EXT_disjoint_timer_query_webgl2.
@@ -51,7 +53,7 @@ export interface Features {
 }
 
 export const URL_PROPERTIES: URLProperty[] = [
-  {name: 'DEBUG', type: Type.BOOLEAN},
+  {name: 'DEBUG', type: Type.BOOLEAN}, {name: 'IS_NODE', type: Type.BOOLEAN},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN},
   {name: 'WEBGL_VERSION', type: Type.NUMBER},
@@ -302,6 +304,8 @@ export class Environment {
   private evaluateFeature<K extends keyof Features>(feature: K): Features[K] {
     if (feature === 'DEBUG') {
       return false;
+    } else if (feature === 'IS_NODE') {
+      return typeof window === 'undefined';
     } else if (feature === 'BACKEND') {
       return this.getBestBackendType();
     } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {

--- a/src/io/browser_files.ts
+++ b/src/io/browser_files.ts
@@ -39,9 +39,10 @@ export class BrowserDownloads implements IOHandler {
   private readonly jsonAnchor: HTMLAnchorElement;
   private readonly weightDataAnchor: HTMLAnchorElement;
 
+  static readonly URL_SCHEME = 'downloads://';
+
   constructor(fileNamePrefix?: string) {
-    // TODO(cais): Use central environment flag when it's available.
-    if (ENV.get('IS_NODE')) {
+    if (!ENV.get('IS_BROWSER')) {
       // TODO(cais): Provide info on what IOHandlers are available under the
       //   current environment.
       throw new Error(
@@ -49,8 +50,8 @@ export class BrowserDownloads implements IOHandler {
           'is not a browser.');
     }
 
-    if (fileNamePrefix.startsWith(URL_SCHEME)) {
-      fileNamePrefix = fileNamePrefix.slice(URL_SCHEME.length);
+    if (fileNamePrefix.startsWith(BrowserDownloads.URL_SCHEME)) {
+      fileNamePrefix = fileNamePrefix.slice(BrowserDownloads.URL_SCHEME.length);
     }
     if (fileNamePrefix == null || fileNamePrefix.length === 0) {
       fileNamePrefix = DEFAULT_FILE_NAME_PREFIX;
@@ -240,13 +241,12 @@ class BrowserFiles implements IOHandler {
   }
 }
 
-const URL_SCHEME = 'downloads://';
 export const browserDownloadsRouter: IORouter = (url: string) => {
-  if (ENV.get('IS_NODE')) {
+  if (!ENV.get('IS_BROWSER')) {
     return null;
   } else {
-    if (url.startsWith(URL_SCHEME)) {
-      return browserDownloads(url.slice(URL_SCHEME.length));
+    if (url.startsWith(BrowserDownloads.URL_SCHEME)) {
+      return browserDownloads(url.slice(BrowserDownloads.URL_SCHEME.length));
     } else {
       return null;
     }

--- a/src/io/browser_files.ts
+++ b/src/io/browser_files.ts
@@ -21,15 +21,19 @@
  */
 
 // tslint:disable:max-line-length
+import {ENV} from '../environment';
+
 import {basename, concatenateArrayBuffers, getModelArtifactsInfoForKerasJSON} from './io_utils';
+import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
+
 // tslint:enable:max-line-length
 
 const DEFAULT_FILE_NAME_PREFIX = 'model';
 const DEFAULT_JSON_EXTENSION_NAME = '.json';
 const DEFAULT_WEIGHT_DATA_EXTENSION_NAME = '.weights.bin';
 
-class BrowserDownloads implements IOHandler {
+export class BrowserDownloads implements IOHandler {
   private readonly modelTopologyFileName: string;
   private readonly weightDataFileName: string;
   private readonly jsonAnchor: HTMLAnchorElement;
@@ -37,7 +41,7 @@ class BrowserDownloads implements IOHandler {
 
   constructor(fileNamePrefix?: string) {
     // TODO(cais): Use central environment flag when it's available.
-    if (typeof window === 'undefined') {
+    if (ENV.get('IS_NODE')) {
       // TODO(cais): Provide info on what IOHandlers are available under the
       //   current environment.
       throw new Error(
@@ -45,7 +49,10 @@ class BrowserDownloads implements IOHandler {
           'is not a browser.');
     }
 
-    if (fileNamePrefix == null) {
+    if (fileNamePrefix.startsWith(URL_SCHEME)) {
+      fileNamePrefix = fileNamePrefix.slice(URL_SCHEME.length);
+    }
+    if (fileNamePrefix == null || fileNamePrefix.length === 0) {
       fileNamePrefix = DEFAULT_FILE_NAME_PREFIX;
     }
 
@@ -233,6 +240,20 @@ class BrowserFiles implements IOHandler {
   }
 }
 
+const URL_SCHEME = 'downloads://';
+export const browserDownloadsRouter: IORouter = (url: string) => {
+  if (ENV.get('IS_NODE')) {
+    return null;
+  } else {
+    if (url.startsWith(URL_SCHEME)) {
+      return browserDownloads(url.slice(URL_SCHEME.length));
+    } else {
+      return null;
+    }
+  }
+};
+IORouterRegistry.registerSaveRouter(browserDownloadsRouter);
+
 /**
  * Creates an IOHandler that triggers file downloads from the browser.
  *
@@ -243,10 +264,17 @@ class BrowserFiles implements IOHandler {
  * const model = tf.sequential();
  * model.add(tf.layers.dense(
  *     {units: 1, inputShape: [10], activation: 'sigmoid'}));
- * const artifactsInfo = await model.save(tf.io.browserDownloads('mymodel'));
+ * const saveResult = await model.save(tf.io.browserDownloads('mymodel'));
  * // This will trigger downloading of two files:
  * //   'mymodel.json' and 'mymodel.weights.bin'.
- * console.log(artifactsInfo);
+ * console.log(saveResult);
+ * ```
+ *
+ * You can also simply pass a string with a 'downloads://' scheme followed by
+ * the file-name prefix to `model.save`:
+ *
+ * ```js
+ * const saveResult = await model.save('downloads://mymodel');
  * ```
  *
  * @param fileNamePrefix Prefix name of the files to be downloaded. For use with

--- a/src/io/browser_files_test.ts
+++ b/src/io/browser_files_test.ts
@@ -104,9 +104,9 @@ describeWithFlags('browserDownloads', CPU_ENVS, () => {
     });
   });
 
-  it('Explicit file name prefix, with existing anchors', async done => {
+  it('Explicit file name prefix, with existing anchors', done => {
     const testStartDate = new Date();
-    const downloadTrigger = browserDownloads('test-model');
+    const downloadTrigger = tf.io.getSaveHandlers('downloads://test-model')[0];
     downloadTrigger.save(artifacts1)
         .then(async saveResult => {
           expect(saveResult.errors).toEqual(undefined);
@@ -159,7 +159,7 @@ describeWithFlags('browserDownloads', CPU_ENVS, () => {
         });
   });
 
-  it('URL scheme in explicit name gets stripped', async done => {
+  it('URL scheme in explicit name gets stripped', done => {
     const testStartDate = new Date();
     const downloadTrigger = browserDownloads('downloads://test-model');
     downloadTrigger.save(artifacts1)
@@ -214,7 +214,7 @@ describeWithFlags('browserDownloads', CPU_ENVS, () => {
         });
   });
 
-  it('No file name provided, with existing anchors', async done => {
+  it('No file name provided, with existing anchors', done => {
     const testStartDate = new Date();
     const downloadTrigger = browserDownloads();
     downloadTrigger.save(artifacts1)
@@ -265,7 +265,7 @@ describeWithFlags('browserDownloads', CPU_ENVS, () => {
         });
   });
 
-  it('Download only model topology', async done => {
+  it('Download only model topology', done => {
     const testStartDate = new Date();
     const downloadTrigger = browserDownloads();
     const modelTopologyOnlyArtifacts: tf.io.ModelArtifacts = {
@@ -320,7 +320,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
   const weightsFile = new File(
       [weightsBlob], 'model.weights.bin', {type: 'application/octet-stream'});
 
-  it('One group, one path', async done => {
+  it('One group, one path', done => {
     const weightsManifest: WeightsManifestConfig = [{
       paths: ['./model.weights.bin'],
       weights: weightSpecs1,
@@ -349,7 +349,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it(`One group, two paths`, async done => {
+  it(`One group, two paths`, done => {
     const weightSpecs: WeightsManifestEntry[] = [
       {
         name: 'foo',
@@ -404,7 +404,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it(`Two groups, four paths, reverseOrder=false`, async done => {
+  it(`Two groups, four paths, reverseOrder=false`, done => {
     const weightSpecs1: WeightsManifestEntry[] = [
       {
         name: 'foo',
@@ -491,7 +491,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it(`Two groups, four paths, reverseOrder=true`, async done => {
+  it(`Two groups, four paths, reverseOrder=true`, done => {
     const weightSpecs1: WeightsManifestEntry[] = [
       {
         name: 'foo',
@@ -578,7 +578,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it('Upload model topology only', async done => {
+  it('Upload model topology only', done => {
     const weightsManifest: WeightsManifestConfig = [{
       paths: ['./model.weights.bin'],
       weights: weightSpecs1,
@@ -606,7 +606,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it('Mismatch in number of paths and number of files', async done => {
+  it('Mismatch in number of paths and number of files', done => {
     const weightsManifest: WeightsManifestConfig = [{
       paths: ['./model.weights.1.bin'],
       weights: weightSpecs1,
@@ -653,7 +653,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it('Mismatch in manifest paths and file names', async done => {
+  it('Mismatch in manifest paths and file names', done => {
     const weightSpecs: WeightsManifestEntry[] = [
       {
         name: 'foo',
@@ -711,7 +711,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it('Duplicate basenames in paths fails', async done => {
+  it('Duplicate basenames in paths fails', done => {
     const weightSpecs: WeightsManifestEntry[] = [
       {
         name: 'foo',
@@ -771,7 +771,7 @@ describeWithFlags('browserFiles', CPU_ENVS, () => {
         });
   });
 
-  it('Missing modelTopology from JSON leads to Error', async done => {
+  it('Missing modelTopology from JSON leads to Error', done => {
     const weightsManifest: WeightsManifestConfig = [{
       paths: ['./model.weights.bin'],
       weights: weightSpecs1,

--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -21,19 +21,26 @@
  * Uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
  */
 
+import {ENV} from '../environment';
 import {assert} from '../util';
 
 import {getModelArtifactsInfoForKerasJSON} from './io_utils';
+import {IORouter, IORouterRegistry} from './router_registry';
 // tslint:disable-next-line:max-line-length
 import {IOHandler, ModelArtifacts, SaveResult, WeightsManifestConfig} from './types';
 
-class BrowserHTTPRequest implements IOHandler {
+export class BrowserHTTPRequest implements IOHandler {
   protected readonly path: string;
   protected readonly requestInit: RequestInit;
 
   readonly DEFAULT_METHOD = 'POST';
 
   constructor(path: string, requestInit?: RequestInit) {
+    if (ENV.get('IS_NODE')) {
+      throw new Error(
+          'browserHTTPRequest is not supported outside the web browser.');
+    }
+
     assert(
         path != null && path.length > 0,
         'URL path for browserHTTPRequest must not be null, undefined or ' +
@@ -100,6 +107,25 @@ class BrowserHTTPRequest implements IOHandler {
   //   See: https://github.com/tensorflow/tfjs/issues/290
 }
 
+const URL_SCHEMES = ['http://', 'https://'];
+export const httpRequestRouter: IORouter = (url: string) => {
+  if (ENV.get('IS_NODE')) {
+    // browserHTTPRequest uses `fetch`, which differs from HTTP requests in
+    // node.js, which use `node-fetch`.
+    return null;
+  } else {
+    for (const scheme of URL_SCHEMES) {
+      if (url.startsWith(scheme)) {
+        return browserHTTPRequest(url);
+      }
+    }
+    return null;
+  }
+};
+IORouterRegistry.registerSaveRouter(httpRequestRouter);
+// TODO(cais): Once `tf.loadModel` use `IOHandler`s, register a load router
+//   here as well.
+
 // tslint:disable:max-line-length
 /**
  * Creates an IOHandler subtype that sends model artifacts to HTTP server.
@@ -126,6 +152,13 @@ class BrowserHTTPRequest implements IOHandler {
  * console.log(saveResult);
  * ```
  *
+ * If the default `POST` method is to be used, without any custom parameters
+ * such as headers, you can simply pass an HTTP or HTTPS URL to `model.save`:
+ *
+ * ```js
+ * const saveResult = await model.save('http://model-server:5000/upload');
+ * ```
+ *
  * The following Python code snippet based on the
  * [flask](https://github.com/pallets/flask) server framework implements a
  * server that can receive the request. Upon receiving the model artifacts
@@ -133,7 +166,7 @@ class BrowserHTTPRequest implements IOHandler {
  * [Keras Models](https://keras.io/models/model/) in memory.
  *
  * ```python
- * # pip install -U flask flask-cors keras tensorflow tensorflowjs
+ * # pip install -U flask flask-cors tensorflow tensorflowjs
  *
  * from __future__ import absolute_import
  * from __future__ import division

--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -35,8 +35,10 @@ export class BrowserHTTPRequest implements IOHandler {
 
   readonly DEFAULT_METHOD = 'POST';
 
+  static readonly URL_SCHEMES = ['http://', 'https://'];
+
   constructor(path: string, requestInit?: RequestInit) {
-    if (ENV.get('IS_NODE')) {
+    if (!ENV.get('IS_BROWSER')) {
       throw new Error(
           'browserHTTPRequest is not supported outside the web browser.');
     }
@@ -107,14 +109,13 @@ export class BrowserHTTPRequest implements IOHandler {
   //   See: https://github.com/tensorflow/tfjs/issues/290
 }
 
-const URL_SCHEMES = ['http://', 'https://'];
 export const httpRequestRouter: IORouter = (url: string) => {
-  if (ENV.get('IS_NODE')) {
+  if (!ENV.get('IS_BROWSER')) {
     // browserHTTPRequest uses `fetch`, which differs from HTTP requests in
     // node.js, which use `node-fetch`.
     return null;
   } else {
-    for (const scheme of URL_SCHEMES) {
+    for (const scheme of BrowserHTTPRequest.URL_SCHEMES) {
       if (url.startsWith(scheme)) {
         return browserHTTPRequest(url);
       }

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -22,6 +22,7 @@
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {CPU_ENVS} from '../test_util';
+import {BrowserHTTPRequest, httpRequestRouter} from './browser_http';
 
 describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
   // Test data.
@@ -279,5 +280,16 @@ describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
         .toThrowError(/must not be null, undefined or empty/);
     expect(() => tf.io.browserHTTPRequest(''))
         .toThrowError(/must not be null, undefined or empty/);
+  });
+
+  it('router', () => {
+    expect(httpRequestRouter('http://bar/foo') instanceof BrowserHTTPRequest)
+        .toEqual(true);
+    expect(
+        httpRequestRouter('https://localhost:5000/upload') instanceof
+        BrowserHTTPRequest)
+        .toEqual(true);
+    expect(httpRequestRouter('localhost://foo')).toBeNull();
+    expect(httpRequestRouter('foo:5000/bar')).toBeNull();
   });
 });

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -82,7 +82,7 @@ describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
   beforeEach(() => {
     requestInits = [];
     spyOn(window, 'fetch').and.callFake((path: string, init: RequestInit) => {
-      if (path === 'model-upload-test') {
+      if (path === 'model-upload-test' || path === 'http://model-upload-test') {
         requestInits.push(init);
         return new Response(null, {status: 200});
       } else {
@@ -93,7 +93,7 @@ describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
 
   it('Save topology and weights, default POST method', done => {
     const testStartDate = new Date();
-    const handler = tf.io.browserHTTPRequest('model-upload-test');
+    const handler = tf.io.getSaveHandlers('http://model-upload-test')[0];
     handler.save(artifacts1)
         .then(saveResult => {
           expect(saveResult.modelArtifactsInfo.dateSaved.getTime())
@@ -146,7 +146,7 @@ describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
 
   it('Save topology only, default POST method', done => {
     const testStartDate = new Date();
-    const handler = tf.io.browserHTTPRequest('model-upload-test');
+    const handler = tf.io.getSaveHandlers('http://model-upload-test')[0];
     const topologyOnlyArtifacts = {modelTopology: modelTopology1};
     handler.save(topologyOnlyArtifacts)
         .then(saveResult => {
@@ -250,7 +250,7 @@ describeWithFlags('browserHTTPRequest', CPU_ENVS, () => {
   });
 
   it('404 response causes Error', done => {
-    const handler = tf.io.browserHTTPRequest('invalid/path');
+    const handler = tf.io.getSaveHandlers('http://invalid/path')[0];
     handler.save(artifacts1)
         .then(saveResult => {
           done.fail(

--- a/src/io/indexed_db.ts
+++ b/src/io/indexed_db.ts
@@ -16,8 +16,12 @@
  */
 
 // tslint:disable:max-line-length
+import {ENV} from '../environment';
+
 import {getModelArtifactsInfoForKerasJSON} from './io_utils';
+import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, ModelArtifactsInfo, SaveResult} from './types';
+
 // tslint:enable:max-line-length
 
 const DATABASE_NAME = 'tensorflowjs';
@@ -40,7 +44,7 @@ export async function deleteDatabase(): Promise<void> {
 function getIndexedDBFactory(): IDBFactory {
   // TODO(cais): Use central environment flag when it's available.
   //   See: https://github.com/tensorflow/tfjs/issues/282.
-  if (typeof window === 'undefined') {
+  if (ENV.get('IS_NODE')) {
     // TODO(cais): Add more info about what IOHandler subtypes are available.
     //   Maybe point to a doc page on the web and/or automatically determine
     //   the available IOHandlers and print them in the error message.
@@ -65,7 +69,7 @@ function getIndexedDBFactory(): IDBFactory {
  *
  * See the doc string of `browserIndexedDB` for more details.
  */
-class BrowserIndexedDB implements IOHandler {
+export class BrowserIndexedDB implements IOHandler {
   protected readonly indexedDB: IDBFactory;
   protected readonly modelPath: string;
 
@@ -157,6 +161,21 @@ class BrowserIndexedDB implements IOHandler {
     db.createObjectStore(OBJECT_STORE_NAME, {keyPath: 'modelPath'});
   }
 }
+
+const URL_SCHEME = 'indexeddb://';
+export const indexedDBRouter: IORouter = (url: string) => {
+  if (ENV.get('IS_NODE')) {
+    return null;
+  } else {
+    if (url.startsWith(URL_SCHEME)) {
+      return browserIndexedDB(url.slice(URL_SCHEME.length));
+    } else {
+      return null;
+    }
+  }
+};
+IORouterRegistry.registerSaveRouter(indexedDBRouter);
+IORouterRegistry.registerLoadRouter(indexedDBRouter);
 
 /**
  * Creates a browser IndexedDB IOHandler for saving and loading models.

--- a/src/io/indexed_db.ts
+++ b/src/io/indexed_db.ts
@@ -185,7 +185,7 @@ IORouterRegistry.registerLoadRouter(indexedDBRouter);
  * model.add(
  *     tf.layers.dense({units: 1, inputShape: [100], activation: 'sigmoid'}));
  *
- * const saveResult = await model.save(tf.io.browserIndexedDB('MyModel'));
+ * const saveResult = await model.save('indexeddb://MyModel'));
  * console.log(saveResult);
  * ```
  *

--- a/src/io/indexed_db.ts
+++ b/src/io/indexed_db.ts
@@ -42,9 +42,7 @@ export async function deleteDatabase(): Promise<void> {
 }
 
 function getIndexedDBFactory(): IDBFactory {
-  // TODO(cais): Use central environment flag when it's available.
-  //   See: https://github.com/tensorflow/tfjs/issues/282.
-  if (ENV.get('IS_NODE')) {
+  if (!ENV.get('IS_BROWSER')) {
     // TODO(cais): Add more info about what IOHandler subtypes are available.
     //   Maybe point to a doc page on the web and/or automatically determine
     //   the available IOHandlers and print them in the error message.
@@ -72,6 +70,8 @@ function getIndexedDBFactory(): IDBFactory {
 export class BrowserIndexedDB implements IOHandler {
   protected readonly indexedDB: IDBFactory;
   protected readonly modelPath: string;
+
+  static readonly URL_SCHEME = 'indexeddb://';
 
   constructor(modelPath: string) {
     this.indexedDB = getIndexedDBFactory();
@@ -162,13 +162,12 @@ export class BrowserIndexedDB implements IOHandler {
   }
 }
 
-const URL_SCHEME = 'indexeddb://';
 export const indexedDBRouter: IORouter = (url: string) => {
-  if (ENV.get('IS_NODE')) {
+  if (!ENV.get('IS_BROWSER')) {
     return null;
   } else {
-    if (url.startsWith(URL_SCHEME)) {
-      return browserIndexedDB(url.slice(URL_SCHEME.length));
+    if (url.startsWith(BrowserIndexedDB.URL_SCHEME)) {
+      return browserIndexedDB(url.slice(BrowserIndexedDB.URL_SCHEME.length));
     } else {
       return null;
     }

--- a/src/io/indexed_db_test.ts
+++ b/src/io/indexed_db_test.ts
@@ -23,7 +23,8 @@ import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {CPU_ENVS} from '../test_util';
 
-import {deleteDatabase} from './indexed_db';
+// tslint:disable-next-line:max-line-length
+import {browserIndexedDB, BrowserIndexedDB, deleteDatabase, indexedDBRouter} from './indexed_db';
 
 describeWithFlags('IndexedDB', CPU_ENVS, () => {
   // Test data.
@@ -105,7 +106,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
 
   it('Save-load round trip', done => {
     const testStartDate = new Date();
-    const handler = tf.io.browserIndexedDB('FooModel');
+    const handler = browserIndexedDB('FooModel');
     handler.save(artifacts1)
         .then(saveResult => {
           expect(saveResult.modelArtifactsInfo.dateSaved.getTime())
@@ -142,7 +143,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
       weightSpecs: weightSpecs2,
       weightData: weightData2,
     };
-    const handler1 = tf.io.browserIndexedDB('Model/1');
+    const handler1 = browserIndexedDB('Model/1');
     handler1.save(artifacts1)
         .then(saveResult1 => {
           // Note: The following two assertions work only because there is no
@@ -154,7 +155,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
           expect(saveResult1.modelArtifactsInfo.weightDataBytes)
               .toEqual(weightData1.byteLength);
 
-          const handler2 = tf.io.browserIndexedDB('Model/2');
+          const handler2 = browserIndexedDB('Model/2');
           handler2.save(artifacts2)
               .then(saveResult2 => {
                 expect(saveResult2.modelArtifactsInfo.dateSaved.getTime())
@@ -192,7 +193,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
   });
 
   it('Loading nonexistent model fails', done => {
-    const handler = tf.io.browserIndexedDB('NonexistentModel');
+    const handler = browserIndexedDB('NonexistentModel');
     handler.load()
         .then(modelArtifacts => {
           done.fail(
@@ -208,14 +209,21 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
   });
 
   it('Null, undefined or empty modelPath throws Error', () => {
-    expect(() => tf.io.browserIndexedDB(null))
+    expect(() => browserIndexedDB(null))
         .toThrowError(
             /IndexedDB, modelPath must not be null, undefined or empty/);
-    expect(() => tf.io.browserIndexedDB(undefined))
+    expect(() => browserIndexedDB(undefined))
         .toThrowError(
             /IndexedDB, modelPath must not be null, undefined or empty/);
-    expect(() => tf.io.browserIndexedDB(''))
+    expect(() => browserIndexedDB(''))
         .toThrowError(
             /IndexedDB, modelPath must not be null, undefined or empty./);
+  });
+
+  it('router', () => {
+    expect(indexedDBRouter('indexeddb://bar') instanceof BrowserIndexedDB)
+        .toEqual(true);
+    expect(indexedDBRouter('localstorage://bar')).toBeNull();
+    expect(indexedDBRouter('qux')).toBeNull();
   });
 });

--- a/src/io/indexed_db_test.ts
+++ b/src/io/indexed_db_test.ts
@@ -106,7 +106,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
 
   it('Save-load round trip', done => {
     const testStartDate = new Date();
-    const handler = browserIndexedDB('FooModel');
+    const handler = tf.io.getSaveHandlers('indexeddb://FooModel')[0];
     handler.save(artifacts1)
         .then(saveResult => {
           expect(saveResult.modelArtifactsInfo.dateSaved.getTime())
@@ -143,7 +143,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
       weightSpecs: weightSpecs2,
       weightData: weightData2,
     };
-    const handler1 = browserIndexedDB('Model/1');
+    const handler1 = tf.io.getSaveHandlers('indexeddb://Model/1')[0];
     handler1.save(artifacts1)
         .then(saveResult1 => {
           // Note: The following two assertions work only because there is no
@@ -155,7 +155,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
           expect(saveResult1.modelArtifactsInfo.weightDataBytes)
               .toEqual(weightData1.byteLength);
 
-          const handler2 = browserIndexedDB('Model/2');
+          const handler2 = tf.io.getSaveHandlers('indexeddb://Model/2')[0];
           handler2.save(artifacts2)
               .then(saveResult2 => {
                 expect(saveResult2.modelArtifactsInfo.dateSaved.getTime())
@@ -193,7 +193,7 @@ describeWithFlags('IndexedDB', CPU_ENVS, () => {
   });
 
   it('Loading nonexistent model fails', done => {
-    const handler = browserIndexedDB('NonexistentModel');
+    const handler = tf.io.getSaveHandlers('indexeddb://NonexistentModel')[0];
     handler.load()
         .then(modelArtifacts => {
           done.fail(

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -15,27 +15,37 @@
  * =============================================================================
  */
 
-import {browserDownloads, browserFiles} from './browser_files';
+// Importing loca_storage and indexed_db is necessary for the routers to be
+// registered.
+import './indexed_db';
+import './local_storage';
+
+import {browserFiles} from './browser_files';
 import {browserHTTPRequest} from './browser_http';
-import {browserIndexedDB} from './indexed_db';
 import {decodeWeights, encodeWeights} from './io_utils';
-import {browserLocalStorage} from './local_storage';
+import {IORouterRegistry} from './router_registry';
 // tslint:disable-next-line:max-line-length
 import {IOHandler, LoadHandler, ModelArtifacts, SaveConfig, SaveHandler, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
 import {loadWeights} from './weights_loader';
 
+const registerSaveRouter = IORouterRegistry.registerSaveRouter;
+const registerLoadRouter = IORouterRegistry.registerLoadRouter;
+const getSaveHandler = IORouterRegistry.getSaveHandler;
+const getLoadHandler = IORouterRegistry.getLoadHandler;
+
 export {
-  browserDownloads,
   browserFiles,
   browserHTTPRequest,
-  browserIndexedDB,
-  browserLocalStorage,
   decodeWeights,
   encodeWeights,
+  getLoadHandler,
+  getSaveHandler,
   IOHandler,
   LoadHandler,
   loadWeights,
   ModelArtifacts,
+  registerLoadRouter,
+  registerSaveRouter,
   SaveConfig,
   SaveHandler,
   SaveResult,

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -30,16 +30,16 @@ import {loadWeights} from './weights_loader';
 
 const registerSaveRouter = IORouterRegistry.registerSaveRouter;
 const registerLoadRouter = IORouterRegistry.registerLoadRouter;
-const getSaveHandler = IORouterRegistry.getSaveHandler;
-const getLoadHandler = IORouterRegistry.getLoadHandler;
+const getSaveHandlers = IORouterRegistry.getSaveHandlers;
+const getLoadHandlers = IORouterRegistry.getLoadHandlers;
 
 export {
   browserFiles,
   browserHTTPRequest,
   decodeWeights,
   encodeWeights,
-  getLoadHandler,
-  getSaveHandler,
+  getLoadHandlers,
+  getSaveHandlers,
   IOHandler,
   LoadHandler,
   loadWeights,

--- a/src/io/local_storage.ts
+++ b/src/io/local_storage.ts
@@ -37,8 +37,7 @@ const WEIGHT_DATA_SUFFIX = 'weight_data';
  * @returns Paths of the models purged.
  */
 export function purgeLocalStorageArtifacts(): string[] {
-  // TODO(cais): Use central environment flag when it's available.
-  if (ENV.get('IS_NODE') || typeof window.localStorage === 'undefined') {
+  if (!ENV.get('IS_BROWSER') || typeof window.localStorage === 'undefined') {
     throw new Error(
         'purgeLocalStorageModels() cannot proceed because local storage is ' +
         'unavailable in the current environment.');
@@ -68,8 +67,10 @@ export class BrowserLocalStorage implements IOHandler {
   protected readonly modelPath: string;
   protected readonly paths: {[key: string]: string};
 
+  static readonly URL_SCHEME = 'localstorage://';
+
   constructor(modelPath: string) {
-    if (ENV.get('IS_NODE') || typeof window.localStorage === 'undefined') {
+    if (!ENV.get('IS_BROWSER') || typeof window.localStorage === 'undefined') {
       // TODO(cais): Add more info about what IOHandler subtypes are available.
       //   Maybe point to a doc page on the web and/or automatically determine
       //   the available IOHandlers and print them in the error message.
@@ -193,13 +194,13 @@ export class BrowserLocalStorage implements IOHandler {
   }
 }
 
-const URL_SCHEME = 'localstorage://';
 export const localStorageRouter: IORouter = (url: string) => {
-  if (ENV.get('IS_NODE')) {
+  if (!ENV.get('IS_BROWSER')) {
     return null;
   } else {
-    if (url.startsWith(URL_SCHEME)) {
-      return browserLocalStorage(url.slice(URL_SCHEME.length));
+    if (url.startsWith(BrowserLocalStorage.URL_SCHEME)) {
+      return browserLocalStorage(
+          url.slice(BrowserLocalStorage.URL_SCHEME.length));
     } else {
       return null;
     }

--- a/src/io/local_storage.ts
+++ b/src/io/local_storage.ts
@@ -16,7 +16,10 @@
  */
 
 // tslint:disable:max-line-length
+import {ENV} from '../environment';
+
 import {arrayBufferToBase64String, base64StringToArrayBuffer, getModelArtifactsInfoForKerasJSON} from './io_utils';
+import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, ModelArtifactsInfo, SaveResult} from './types';
 
 // tslint:enable:max-line-length
@@ -35,8 +38,7 @@ const WEIGHT_DATA_SUFFIX = 'weight_data';
  */
 export function purgeLocalStorageArtifacts(): string[] {
   // TODO(cais): Use central environment flag when it's available.
-  if (typeof window === 'undefined' ||
-      typeof window.localStorage === 'undefined') {
+  if (ENV.get('IS_NODE') || typeof window.localStorage === 'undefined') {
     throw new Error(
         'purgeLocalStorageModels() cannot proceed because local storage is ' +
         'unavailable in the current environment.');
@@ -61,13 +63,13 @@ export function purgeLocalStorageArtifacts(): string[] {
  *
  * See the doc string to `browserLocalStorage` for more details.
  */
-class BrowserLocalStorage implements IOHandler {
+export class BrowserLocalStorage implements IOHandler {
   protected readonly LS: Storage;
   protected readonly modelPath: string;
   protected readonly paths: {[key: string]: string};
 
   constructor(modelPath: string) {
-    if (!(window && window.localStorage)) {
+    if (ENV.get('IS_NODE') || typeof window.localStorage === 'undefined') {
       // TODO(cais): Add more info about what IOHandler subtypes are available.
       //   Maybe point to a doc page on the web and/or automatically determine
       //   the available IOHandlers and print them in the error message.
@@ -100,11 +102,6 @@ class BrowserLocalStorage implements IOHandler {
    * @returns An instance of SaveResult.
    */
   async save(modelArtifacts: ModelArtifacts): Promise<SaveResult> {
-    if (!(window && window.localStorage)) {
-      throw new Error(
-          'The current environment does not support local storage.');
-    }
-
     if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
       throw new Error(
           'BrowserLocalStorage.save() does not support saving model topology ' +
@@ -195,6 +192,21 @@ class BrowserLocalStorage implements IOHandler {
     return out;
   }
 }
+
+const URL_SCHEME = 'localstorage://';
+export const localStorageRouter: IORouter = (url: string) => {
+  if (ENV.get('IS_NODE')) {
+    return null;
+  } else {
+    if (url.startsWith(URL_SCHEME)) {
+      return browserLocalStorage(url.slice(URL_SCHEME.length));
+    } else {
+      return null;
+    }
+  }
+};
+IORouterRegistry.registerSaveRouter(localStorageRouter);
+IORouterRegistry.registerLoadRouter(localStorageRouter);
 
 /**
  * Factory function for local storage IOHandler.

--- a/src/io/local_storage_test.ts
+++ b/src/io/local_storage_test.ts
@@ -107,9 +107,9 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
     purgeLocalStorageArtifacts();
   });
 
-  it('Save artifacts succeeds', async done => {
+  it('Save artifacts succeeds', done => {
     const testStartDate = new Date();
-    const handler = browserLocalStorage('FooModel');
+    const handler = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler.save(artifacts1)
         .then(saveResult => {
           expect(saveResult.modelArtifactsInfo.dateSaved.getTime())
@@ -155,11 +155,11 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Save-load round trip succeeds', async done => {
-    const handler1 = browserLocalStorage('FooModel');
+  it('Save-load round trip succeeds', done => {
+    const handler1 = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler1.save(artifacts1)
         .then(saveResult => {
-          const handler2 = browserLocalStorage('FooModel');
+          const handler2 = tf.io.getLoadHandlers('localstorage://FooModel')[0];
           handler2.load()
               .then(loaded => {
                 expect(loaded.modelTopology).toEqual(modelTopology1);
@@ -176,8 +176,8 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Loading nonexistent model fails.', async done => {
-    const handler = browserLocalStorage('NonexistentModel');
+  it('Loading nonexistent model fails.', done => {
+    const handler = tf.io.getSaveHandlers('localstorage://NonexistentModel')[0];
     handler.load()
         .then(aritfacts => {
           fail('Loading nonexistent model succeeded unexpectedly.');
@@ -191,15 +191,15 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Loading model with missing topology fails.', async done => {
-    const handler1 = browserLocalStorage('FooModel');
+  it('Loading model with missing topology fails.', done => {
+    const handler1 = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the topology item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/model_topology');
 
-          const handler2 = browserLocalStorage('FooModel');
+          const handler2 = tf.io.getLoadHandlers('localstorage://FooModel')[0];
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -219,15 +219,15 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Loading model with missing weight specs fails.', async done => {
-    const handler1 = browserLocalStorage('FooModel');
+  it('Loading model with missing weight specs fails.', done => {
+    const handler1 = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the weight specs item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/weight_specs');
 
-          const handler2 = browserLocalStorage('FooModel');
+          const handler2 = tf.io.getLoadHandlers('localstorage://FooModel')[0];
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -247,15 +247,15 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Loading model with missing weight data fails.', async done => {
-    const handler1 = browserLocalStorage('FooModel');
+  it('Loading model with missing weight data fails.', done => {
+    const handler1 = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the weight data item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/weight_data');
 
-          const handler2 = browserLocalStorage('FooModel');
+          const handler2 = tf.io.getLoadHandlers('localstorage://FooModel')[0];
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -275,14 +275,14 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
         });
   });
 
-  it('Data size too large leads to error thrown', async done => {
+  it('Data size too large leads to error thrown', done => {
     const overflowByteSize = findOverflowingByteSize();
     const overflowArtifacts: tf.io.ModelArtifacts = {
       modelTopology: modelTopology1,
       weightSpecs: weightSpecs1,
       weightData: new ArrayBuffer(overflowByteSize),
     };
-    const handler1 = browserLocalStorage('FooModel');
+    const handler1 = tf.io.getSaveHandlers('localstorage://FooModel')[0];
     handler1.save(overflowArtifacts)
         .then(saveResult => {
           fail(

--- a/src/io/local_storage_test.ts
+++ b/src/io/local_storage_test.ts
@@ -20,7 +20,8 @@ import {describeWithFlags} from '../jasmine_util';
 import {CPU_ENVS} from '../test_util';
 
 import {arrayBufferToBase64String, base64StringToArrayBuffer} from './io_utils';
-import {purgeLocalStorageArtifacts} from './local_storage';
+// tslint:disable-next-line:max-line-length
+import {browserLocalStorage, BrowserLocalStorage, localStorageRouter, purgeLocalStorageArtifacts} from './local_storage';
 
 describeWithFlags('LocalStorage', CPU_ENVS, () => {
   // Test data.
@@ -108,7 +109,7 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
 
   it('Save artifacts succeeds', async done => {
     const testStartDate = new Date();
-    const handler = tf.io.browserLocalStorage('FooModel');
+    const handler = browserLocalStorage('FooModel');
     handler.save(artifacts1)
         .then(saveResult => {
           expect(saveResult.modelArtifactsInfo.dateSaved.getTime())
@@ -155,10 +156,10 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Save-load round trip succeeds', async done => {
-    const handler1 = tf.io.browserLocalStorage('FooModel');
+    const handler1 = browserLocalStorage('FooModel');
     handler1.save(artifacts1)
         .then(saveResult => {
-          const handler2 = tf.io.browserLocalStorage('FooModel');
+          const handler2 = browserLocalStorage('FooModel');
           handler2.load()
               .then(loaded => {
                 expect(loaded.modelTopology).toEqual(modelTopology1);
@@ -176,7 +177,7 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Loading nonexistent model fails.', async done => {
-    const handler = tf.io.browserLocalStorage('NonexistentModel');
+    const handler = browserLocalStorage('NonexistentModel');
     handler.load()
         .then(aritfacts => {
           fail('Loading nonexistent model succeeded unexpectedly.');
@@ -191,14 +192,14 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Loading model with missing topology fails.', async done => {
-    const handler1 = tf.io.browserLocalStorage('FooModel');
+    const handler1 = browserLocalStorage('FooModel');
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the topology item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/model_topology');
 
-          const handler2 = tf.io.browserLocalStorage('FooModel');
+          const handler2 = browserLocalStorage('FooModel');
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -219,14 +220,14 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Loading model with missing weight specs fails.', async done => {
-    const handler1 = tf.io.browserLocalStorage('FooModel');
+    const handler1 = browserLocalStorage('FooModel');
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the weight specs item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/weight_specs');
 
-          const handler2 = tf.io.browserLocalStorage('FooModel');
+          const handler2 = browserLocalStorage('FooModel');
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -247,14 +248,14 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Loading model with missing weight data fails.', async done => {
-    const handler1 = tf.io.browserLocalStorage('FooModel');
+    const handler1 = browserLocalStorage('FooModel');
     handler1.save(artifacts1)
         .then(saveResult => {
           // Manually remove the weight data item from local storage.
           window.localStorage.removeItem(
               'tensorflowjs_models/FooModel/weight_data');
 
-          const handler2 = tf.io.browserLocalStorage('FooModel');
+          const handler2 = browserLocalStorage('FooModel');
           handler2.load()
               .then(aritfacts => {
                 fail(
@@ -281,7 +282,7 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
       weightSpecs: weightSpecs1,
       weightData: new ArrayBuffer(overflowByteSize),
     };
-    const handler1 = tf.io.browserLocalStorage('FooModel');
+    const handler1 = browserLocalStorage('FooModel');
     handler1.save(overflowArtifacts)
         .then(saveResult => {
           fail(
@@ -298,14 +299,22 @@ describeWithFlags('LocalStorage', CPU_ENVS, () => {
   });
 
   it('Null, undefined or empty modelPath throws Error', () => {
-    expect(() => tf.io.browserLocalStorage(null))
+    expect(() => browserLocalStorage(null))
         .toThrowError(
             /local storage, modelPath must not be null, undefined or empty/);
-    expect(() => tf.io.browserLocalStorage(undefined))
+    expect(() => browserLocalStorage(undefined))
         .toThrowError(
             /local storage, modelPath must not be null, undefined or empty/);
-    expect(() => tf.io.browserLocalStorage(''))
+    expect(() => browserLocalStorage(''))
         .toThrowError(
             /local storage, modelPath must not be null, undefined or empty./);
+  });
+
+  it('router', () => {
+    expect(
+        localStorageRouter('localstorage://bar') instanceof BrowserLocalStorage)
+        .toEqual(true);
+    expect(localStorageRouter('indexeddb://bar')).toBeNull();
+    expect(localStorageRouter('qux')).toBeNull();
   });
 });

--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {IOHandler} from './io';
+
+export type IORouter = (url: string) => IOHandler;
+
+export class IORouterRegistry {
+  private static instance: IORouterRegistry = null;
+
+  private saveRouters: IORouter[];
+  private loadRouters: IORouter[];
+
+  private constructor() {
+    this.saveRouters = [];
+    this.loadRouters = [];
+  }
+
+  private static getInstance(): IORouterRegistry {
+    if (IORouterRegistry.instance == null) {
+      IORouterRegistry.instance = new IORouterRegistry();
+    }
+    return IORouterRegistry.instance;
+  }
+
+  static registerSaveRouter(saveRouter: IORouter) {
+    IORouterRegistry.getInstance().saveRouters.push(saveRouter);
+  }
+
+  static registerLoadRouter(loadRouter: IORouter) {
+    IORouterRegistry.getInstance().loadRouters.push(loadRouter);
+  }
+
+  static getSaveHandler(url: string): IOHandler {
+    return IORouterRegistry.getHandler(url, 'save');
+  }
+
+  static getLoadHandler(url: string): IOHandler {
+    return IORouterRegistry.getHandler(url, 'load');
+  }
+
+  private static getHandler(url: string, handlerType: 'save'|'load'):
+      IOHandler {
+    const validHandlers: IOHandler[] = [];
+    for (const router of handlerType === 'load' ?
+             this.getInstance().loadRouters :
+             this.getInstance().saveRouters) {
+      const handler = router(url);
+      if (handler !== null) {
+        validHandlers.push(handler);
+      }
+    }
+    if (validHandlers.length === 0) {
+      return null;
+    } else if (validHandlers.length > 1) {
+      throw new Error(
+          `More than one (${validHandlers.length}) ${handlerType} handlers ` +
+          ` are found for URL '${url}'.`);
+    } else {
+      return validHandlers[0];
+    }
+  }
+}

--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -20,6 +20,7 @@ import {IOHandler} from './io';
 export type IORouter = (url: string) => IOHandler;
 
 export class IORouterRegistry {
+  // Singletone instance.
   private static instance: IORouterRegistry = null;
 
   private saveRouters: IORouter[];
@@ -37,18 +38,46 @@ export class IORouterRegistry {
     return IORouterRegistry.instance;
   }
 
+  /**
+   * Register a save-handler router.
+   *
+   * @param saveRouter A function that maps a URL-like string onto an instance
+   * of `IOHandler` with the `save` method defined or `null`.
+   */
   static registerSaveRouter(saveRouter: IORouter) {
     IORouterRegistry.getInstance().saveRouters.push(saveRouter);
   }
 
+  /**
+   * Register a load-handler router.
+   *
+   * @param loadRouter A function that maps a URL-like string onto an instance
+   * of `IOHandler` with the `load` method defined or `null`.
+   */
   static registerLoadRouter(loadRouter: IORouter) {
     IORouterRegistry.getInstance().loadRouters.push(loadRouter);
   }
 
+  /**
+   * Look up IOHandler for saving, given a URL-like string.
+   *
+   * @param url
+   * @returns If only one match is found, an instance of IOHandler with the
+   * `save` method defined. If no match is found, `null`.
+   * @throws Error, if more than one match is found.
+   */
   static getSaveHandler(url: string): IOHandler {
     return IORouterRegistry.getHandler(url, 'save');
   }
 
+  /**
+   * Look up IOHandler for loading, given a URL-like string.
+   *
+   * @param url
+   * @returns If only one match is found, an instance of IOHandler with the
+   * `save` method defined. If no match is found, `null`.
+   * @throws Error, if more than one match is found.
+   */
   static getLoadHandler(url: string): IOHandler {
     return IORouterRegistry.getHandler(url, 'load');
   }

--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -85,7 +85,7 @@ export class IORouterRegistry {
       IOHandler[] {
     const validHandlers: IOHandler[] = [];
     const routers = handlerType === 'load' ? this.getInstance().loadRouters :
-                                             this.getInstance().saveRouters
+                                             this.getInstance().saveRouters;
     routers.forEach(router => {
       const handler = router(url);
       if (handler !== null) {

--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -20,8 +20,8 @@ import {IOHandler} from './io';
 export type IORouter = (url: string) => IOHandler;
 
 export class IORouterRegistry {
-  // Singletone instance.
-  private static instance: IORouterRegistry = null;
+  // Singleton instance.
+  private static instance: IORouterRegistry;
 
   private saveRouters: IORouter[];
   private loadRouters: IORouter[];
@@ -66,41 +66,32 @@ export class IORouterRegistry {
    * `save` method defined. If no match is found, `null`.
    * @throws Error, if more than one match is found.
    */
-  static getSaveHandler(url: string): IOHandler {
-    return IORouterRegistry.getHandler(url, 'save');
+  static getSaveHandlers(url: string): IOHandler[] {
+    return IORouterRegistry.getHandlers(url, 'save');
   }
 
   /**
    * Look up IOHandler for loading, given a URL-like string.
    *
    * @param url
-   * @returns If only one match is found, an instance of IOHandler with the
-   * `save` method defined. If no match is found, `null`.
-   * @throws Error, if more than one match is found.
+   * @returns All valid handlers for `url`, given the currently registered
+   *   handler routers.
    */
-  static getLoadHandler(url: string): IOHandler {
-    return IORouterRegistry.getHandler(url, 'load');
+  static getLoadHandlers(url: string): IOHandler[] {
+    return IORouterRegistry.getHandlers(url, 'load');
   }
 
-  private static getHandler(url: string, handlerType: 'save'|'load'):
-      IOHandler {
+  private static getHandlers(url: string, handlerType: 'save'|'load'):
+      IOHandler[] {
     const validHandlers: IOHandler[] = [];
-    for (const router of handlerType === 'load' ?
-             this.getInstance().loadRouters :
-             this.getInstance().saveRouters) {
+    const routers = handlerType === 'load' ? this.getInstance().loadRouters :
+                                             this.getInstance().saveRouters
+    routers.forEach(router => {
       const handler = router(url);
       if (handler !== null) {
         validHandlers.push(handler);
       }
-    }
-    if (validHandlers.length === 0) {
-      return null;
-    } else if (validHandlers.length > 1) {
-      throw new Error(
-          `More than one (${validHandlers.length}) ${handlerType} handlers ` +
-          ` are found for URL '${url}'.`);
-    } else {
-      return validHandlers[0];
-    }
+    });
+    return validHandlers;
   }
 }

--- a/src/io/router_registry_test.ts
+++ b/src/io/router_registry_test.ts
@@ -58,27 +58,31 @@ describe('IORouterRegistry', () => {
     IORouterRegistry.registerSaveRouter(localStorageRouter);
     IORouterRegistry.registerSaveRouter(indexedDBRouter);
 
-    const out1 = tf.io.getSaveHandler('localstorage://foo-model');
-    expect(out1 instanceof BrowserLocalStorage).toEqual(true);
-    const out2 = tf.io.getSaveHandler('indexeddb://foo-model');
-    expect(out2 instanceof BrowserIndexedDB).toEqual(true);
+    const out1 = tf.io.getSaveHandlers('localstorage://foo-model');
+    expect(out1.length).toEqual(1);
+    expect(out1[0] instanceof BrowserLocalStorage).toEqual(true);
+    const out2 = tf.io.getSaveHandlers('indexeddb://foo-model');
+    expect(out2.length).toEqual(1);
+    expect(out2[0] instanceof BrowserIndexedDB).toEqual(true);
   });
 
   it('getLoadHandler succeeds', () => {
     IORouterRegistry.registerLoadRouter(localStorageRouter);
     IORouterRegistry.registerLoadRouter(indexedDBRouter);
 
-    const out1 = tf.io.getLoadHandler('localstorage://foo-model');
-    expect(out1 instanceof BrowserLocalStorage).toEqual(true);
-    const out2 = tf.io.getLoadHandler('indexeddb://foo-model');
-    expect(out2 instanceof BrowserIndexedDB).toEqual(true);
+    const out1 = tf.io.getLoadHandlers('localstorage://foo-model');
+    expect(out1.length).toEqual(1);
+    expect(out1[0] instanceof BrowserLocalStorage).toEqual(true);
+    const out2 = tf.io.getLoadHandlers('indexeddb://foo-model');
+    expect(out2.length).toEqual(1);
+    expect(out2[0] instanceof BrowserIndexedDB).toEqual(true);
   });
 
   it('getSaveHandler fails', () => {
     IORouterRegistry.registerSaveRouter(localStorageRouter);
 
-    expect(tf.io.getSaveHandler('invalidscheme://foo-model')).toBeNull();
+    expect(tf.io.getSaveHandlers('invalidscheme://foo-model')).toEqual([]);
     // Check there is no crosstalk between save and load handlers.
-    expect(tf.io.getLoadHandler('localstorage://foo-model')).toBeNull();
+    expect(tf.io.getLoadHandlers('localstorage://foo-model')).toEqual([]);
   });
 });

--- a/src/io/router_registry_test.ts
+++ b/src/io/router_registry_test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+
+import {BrowserIndexedDB, browserIndexedDB} from './indexed_db';
+import {BrowserLocalStorage, browserLocalStorage} from './local_storage';
+import {IORouterRegistry} from './router_registry';
+
+describe('IORouterRegistry', () => {
+  const localStorageRouter = (url: string) => {
+    const scheme = 'localstorage://';
+    if (url.startsWith(scheme)) {
+      return browserLocalStorage(url.slice(scheme.length));
+    } else {
+      return null;
+    }
+  };
+
+  const indexedDBRouter = (url: string) => {
+    const scheme = 'indexeddb://';
+    if (url.startsWith(scheme)) {
+      return browserIndexedDB(url.slice(scheme.length));
+    } else {
+      return null;
+    }
+  };
+
+  let tempRegistryInstance: IORouterRegistry = null;
+  beforeEach(() => {
+    // Force reset registry for testing.
+    // tslint:disable:no-any
+    tempRegistryInstance = (IORouterRegistry as any).instance;
+    (IORouterRegistry as any).instance = null;
+    // tslint:enable:no-any
+  });
+
+  afterEach(() => {
+    // tslint:disable-next-line:no-any
+    (IORouterRegistry as any).instance = tempRegistryInstance;
+  });
+
+  it('getSaveHandler succeeds', () => {
+    IORouterRegistry.registerSaveRouter(localStorageRouter);
+    IORouterRegistry.registerSaveRouter(indexedDBRouter);
+
+    const out1 = tf.io.getSaveHandler('localstorage://foo-model');
+    expect(out1 instanceof BrowserLocalStorage).toEqual(true);
+    const out2 = tf.io.getSaveHandler('indexeddb://foo-model');
+    expect(out2 instanceof BrowserIndexedDB).toEqual(true);
+  });
+
+  it('getLoadHandler succeeds', () => {
+    IORouterRegistry.registerLoadRouter(localStorageRouter);
+    IORouterRegistry.registerLoadRouter(indexedDBRouter);
+
+    const out1 = tf.io.getLoadHandler('localstorage://foo-model');
+    expect(out1 instanceof BrowserLocalStorage).toEqual(true);
+    const out2 = tf.io.getLoadHandler('indexeddb://foo-model');
+    expect(out2 instanceof BrowserIndexedDB).toEqual(true);
+  });
+
+  it('getSaveHandler fails', () => {
+    IORouterRegistry.registerSaveRouter(localStorageRouter);
+
+    expect(tf.io.getSaveHandler('invalidscheme://foo-model')).toBeNull();
+    // Check there is no crosstalk between save and load handlers.
+    expect(tf.io.getLoadHandler('localstorage://foo-model')).toBeNull();
+  });
+});


### PR DESCRIPTION
The currently supported schemes are:
- localstorage:// for browser local storage
- indexeddb:// for browser IndexedDB
- downloads:// for browser file downloads
- http:// and https:// fro browser HTTP requests

Since browserLocalStorage, browserIndexedDB and browserDownloads
are methods without any optional arguments and can be copmletely
replaced by the URL-like strings, they are removed from the tf.io.*
exports.

Also:
- Export tf.io.getSaveHandler, tf.io.getLoadHandler
- Export tf.io.registerSaveRouter and tf.io.registerLoadRouter

Fixes: https://github.com/tensorflow/tfjs/issues/282
Towards: https://github.com/tensorflow/tfjs/issues/13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1034)
<!-- Reviewable:end -->
