### PR TITLE
Add backend.floorDiv to align tf.div op

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -72,7 +72,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
   add(a: Tensor, b: Tensor): Tensor;
   subtract(a: Tensor, b: Tensor): Tensor;
   multiply(a: Tensor, b: Tensor): Tensor;
-  divide(a: Tensor, b: Tensor): Tensor;
+  realDivide(a: Tensor, b: Tensor): Tensor;
   floorDiv(a: Tensor, b: Tensor): Tensor;
 
   sum(x: Tensor, axes: number[]): Tensor;

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -73,6 +73,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
   subtract(a: Tensor, b: Tensor): Tensor;
   multiply(a: Tensor, b: Tensor): Tensor;
   divide(a: Tensor, b: Tensor): Tensor;
+  floorDiv(a: Tensor, b: Tensor): Tensor;
 
   sum(x: Tensor, axes: number[]): Tensor;
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -285,15 +285,14 @@ export class MathBackendCPU implements KernelBackend {
   }
 
   divide(a: Tensor, b: Tensor): Tensor {
-    let op: (a: number, b: number) => number;
-    let outputDtype: 'float32'|'int32';
-    if (a.dtype === 'int32' && b.dtype === 'int32') {
-      outputDtype = 'int32';
-      op = (a: number, b: number) => Math.floor(a / b);
-    } else {
-      outputDtype = 'float32';
-      op = (a: number, b: number) => a / b;
-    }
+    const op = (a: number, b: number) => a / b;
+    const outputDtype = 'float32';
+    return this.broadcastedBinaryOp(a, b, outputDtype, op) as Tensor;
+  }
+
+  floorDiv(a: Tensor, b: Tensor): Tensor {
+    const op = (a: number, b: number) => Math.floor(a / b);
+    const outputDtype = 'int32';
     return this.broadcastedBinaryOp(a, b, outputDtype, op) as Tensor;
   }
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -284,7 +284,7 @@ export class MathBackendCPU implements KernelBackend {
                (aValue, bValue) => aValue * bValue) as Tensor;
   }
 
-  divide(a: Tensor, b: Tensor): Tensor {
+  realDivide(a: Tensor, b: Tensor): Tensor {
     const op = (a: number, b: number) => a / b;
     const outputDtype = 'float32';
     return this.broadcastedBinaryOp(a, b, outputDtype, op) as Tensor;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -621,7 +621,7 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [a, b]);
   }
 
-  divide(a: Tensor, b: Tensor): Tensor {
+  realDivide(a: Tensor, b: Tensor): Tensor {
     const op = binaryop_gpu.DIV;
     const outputDtype = 'float32';
     const program = new BinaryOpProgram(op, a.shape, b.shape);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -622,16 +622,16 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   divide(a: Tensor, b: Tensor): Tensor {
-    let op: string;
-    let outputDtype: 'float32'|'int32';
-    if (a.dtype === 'int32' && b.dtype === 'int32') {
-      op = binaryop_gpu.INT_DIV;
-      outputDtype = 'int32';
-    } else {
-      op = binaryop_gpu.DIV;
-      outputDtype = 'float32';
-    }
+    const op = binaryop_gpu.DIV;
+    const outputDtype = 'float32';
+    const program = new BinaryOpProgram(op, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, outputDtype);
+    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+  }
 
+  floorDiv(a: Tensor, b: Tensor): Tensor {
+    const op = binaryop_gpu.INT_DIV;
+    const outputDtype = 'int32';
     const program = new BinaryOpProgram(op, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, outputDtype);
     return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -24,7 +24,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './operation';
 import {neg, scalar, square} from './ops';
-import {KernelBackend} from '..';
+import {KernelBackend} from '../kernels/backend';
 
 export class BinaryOps {
   /**
@@ -345,9 +345,9 @@ export class BinaryOps {
 
     let forwardFunc: (backend: KernelBackend) => Tensor;
     if (a.dtype === 'int32' && b.dtype === 'int32') {
-      forwardFunc = (backend: KernelBackend) => backend.floorDiv(a, b);
+      return BinaryOps.floorDiv(a, b);
     } else {
-      forwardFunc = (backend: KernelBackend) => backend.divide(a, b);
+      forwardFunc = (backend: KernelBackend) => backend.realDivide(a, b);
     }
 
     const outShape =

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -24,6 +24,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './operation';
 import {neg, scalar, square} from './ops';
+import {KernelBackend} from '..';
 
 export class BinaryOps {
   /**
@@ -342,6 +343,13 @@ export class BinaryOps {
     util.assertArgumentsAreTensors({a, b}, 'div');
     util.assertTypesMatch(a, b);
 
+    let forwardFunc: (backend: KernelBackend) => Tensor;
+    if (a.dtype === 'int32' && b.dtype === 'int32') {
+      forwardFunc = (backend: KernelBackend) => backend.floorDiv(a, b);
+    } else {
+      forwardFunc = (backend: KernelBackend) => backend.divide(a, b);
+    }
+
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     const der = (dy: Tensor) => {
@@ -364,7 +372,64 @@ export class BinaryOps {
       };
       return {a: derA, b: derB};
     };
-    return ENV.engine.runKernel(backend => backend.divide(a, b), {a, b}, der) as
+    return ENV.engine.runKernel(forwardFunc, {a, b}, der) as
+        T;
+  }
+
+  /**
+   * Divides two `Tensor`s element-wise, A / B. Supports broadcasting.
+   * The result is rounded with floor function.
+   *
+   *
+   * ```js
+   * const a = tf.tensor1d([1, 4, 9, 16]);
+   * const b = tf.tensor1d([1, 2, 3, 4]);
+   *
+   * a.floorDiv(b).print();  // or tf.div(a, b)
+   * ```
+   *
+   * ```js
+   * // Broadcast div a with b.
+   * const a = tf.tensor1d([2, 4, 6, 8]);
+   * const b = tf.scalar(2);
+   *
+   * a.floorDiv(b).print();  // or tf.floorDiv(a, b)
+   * ```
+   *
+   * @param a The first tensor as the numerator.
+   * @param b The second tensor as the denominator. Must have the same dtype as
+   * `a`.
+   */
+  @doc({heading: 'Operations', subheading: 'Arithmetic'})
+  @operation
+  static floorDiv<T extends Tensor>(a: Tensor, b: Tensor): T {
+    util.assertArgumentsAreTensors({a, b}, 'floorDiv');
+    util.assertTypesMatch(a, b);
+
+    const forwardFunc = (backend: KernelBackend) => backend.floorDiv(a, b);
+    const outShape =
+        broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    const der = (dy: Tensor) => {
+      const derA = () => {
+        const res = dy.div(b.toFloat());
+        const reduceAxes = broadcast_util.getReductionAxes(a.shape, outShape);
+        if (reduceAxes.length > 0) {
+          return res.sum(reduceAxes).reshape(a.shape);
+        }
+        return res;
+      };
+      const derB = () => {
+        let res = dy.mul(a.toFloat());
+        const reduceAxes = broadcast_util.getReductionAxes(b.shape, outShape);
+        if (reduceAxes.length > 0) {
+          res = res.sum(reduceAxes).reshape(b.shape);
+        }
+        const tmp = b.square() as Tensor;
+        return res.div(tmp.toFloat()).neg() as Tensor;
+      };
+      return {a: derA, b: derB};
+    };
+    return ENV.engine.runKernel(forwardFunc, {a, b}, der) as
         T;
   }
 

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -888,7 +888,8 @@ describeWithFlags('div', ALL_ENVS, () => {
     const result = tf.div(a, b);
 
     expect(result.shape).toEqual(a.shape);
-    expectArraysClose(result, [0, 5.0, -8.0, -8.0, 5.714285850524902, -3.3333332538604736]);
+    expectArraysClose(result, [0, 5.0, -8.0, -8.0,
+      5.714285850524902, -3.3333332538604736]);
   });
 
   it('floored internally', () => {

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -880,3 +880,32 @@ describeWithFlags('atan2', ALL_ENVS, () => {
         .toThrowError(/Argument 'b' passed to 'atan2' must be a Tensor/);
   });
 });
+
+describeWithFlags('div', ALL_ENVS, () => {
+  it('basic', () => {
+    const a = tf.tensor1d([0, 1, -2, -4]);
+    const b = tf.tensor1d([0.15, 0.2, 0.25, 0.5]);
+    const result = tf.div(a, b);
+
+    expect(result.shape).toEqual(a.shape);
+    expectArraysClose(result, [0, 5.0, -8.0, -8.0]);
+  });
+
+  it('floored internally', () => {
+    const a = tf.tensor1d([10, 20, -20, -40], 'int32');
+    const b = tf.tensor1d([10, 12, 8, 5], 'int32');
+    const result = tf.div(a, b);
+
+    expect(result.shape).toEqual(a.shape);
+    expectArraysClose(result, [1, 1, -3, -8]);
+  });
+
+  it('floorDiv', () => {
+    const a = tf.tensor1d([10, 20, -20, -40], 'int32');
+    const b = tf.tensor1d([10, 12, 8, 5], 'int32');
+    const result = tf.floorDiv(a, b);
+
+    expect(result.shape).toEqual(a.shape);
+    expectArraysClose(result, [1, 1, -3, -8]);
+  });
+});

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -883,12 +883,12 @@ describeWithFlags('atan2', ALL_ENVS, () => {
 
 describeWithFlags('div', ALL_ENVS, () => {
   it('basic', () => {
-    const a = tf.tensor1d([0, 1, -2, -4]);
-    const b = tf.tensor1d([0.15, 0.2, 0.25, 0.5]);
+    const a = tf.tensor1d([0, 1, -2, -4, 4, -4]);
+    const b = tf.tensor1d([0.15, 0.2, 0.25, 0.5, 0.7, 1.2]);
     const result = tf.div(a, b);
 
     expect(result.shape).toEqual(a.shape);
-    expectArraysClose(result, [0, 5.0, -8.0, -8.0]);
+    expectArraysClose(result, [0, 5.0, -8.0, -8.0, 5.714285850524902, -3.3333332538604736]);
   });
 
   it('floored internally', () => {

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -151,6 +151,7 @@ export const add = BinaryOps.add;
 export const addStrict = BinaryOps.addStrict;
 export const atan2 = BinaryOps.atan2;
 export const div = BinaryOps.div;
+export const floorDiv = BinaryOps.floorDiv;
 export const divStrict = BinaryOps.divStrict;
 export const maximum = BinaryOps.maximum;
 export const maximumStrict = BinaryOps.maximumStrict;

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -591,6 +591,10 @@ export class Tensor<R extends Rank = Rank> {
     this.throwIfDisposed();
     return ops.div(this, x);
   }
+  floorDiv<T extends Tensor>(x: Tensor): T {
+    this.throwIfDisposed();
+    return ops.floorDiv(this, x);
+  }
   divStrict<T extends this>(this: T, x: T): T {
     this.throwIfDisposed();
     return ops.divStrict(this, x);


### PR DESCRIPTION
FEATURE Add backend.floorDiv

To align with `tf.div` op behavior, I added `backend.floorDiv` that can be used both internally and externally.
see: https://github.com/tensorflow/tfjs/issues/215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1061)
<!-- Reviewable:end -->
