### PR TITLE
Check condition type strictly in where op

### DIFF
--- a/src/ops/logical_ops.ts
+++ b/src/ops/logical_ops.ts
@@ -145,8 +145,8 @@ export class LogicalOps {
   static where<T extends Tensor>(condition: Tensor, a: T, b: T): T {
     util.assertArgumentsAreTensors({condition, a, b}, 'where');
     util.assert(
-        condition.dtype === 'bool' || a.dtype === 'bool' || b.dtype === 'bool',
-        'Error Array must be of type bool.');
+        condition.dtype === 'bool',
+        'Error Condition must be of type bool.');
     util.assertShapesMatch(a.shape, b.shape, 'Error in where: ');
 
     if (condition.rank === 1) {

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -345,6 +345,17 @@ describeWithFlags('where', ALL_ENVS, () => {
 
     expectArraysClose(tf.where(c, a, b), [10]);
   });
+
+  it('Invalid condition type', () => {
+    const c = tf.tensor1d([1, 0, 1, 0], 'int32');
+    const a = tf.tensor1d([10, 10, 10, 10], 'bool');
+    const b = tf.tensor1d([20, 20, 20, 20], 'bool');
+    let f = () => {
+      tf.where(c, a, b);
+    }
+    expect(f).toThrowError();
+  });
+
   it('Tensor1D', () => {
     const c = tf.tensor1d([1, 0, 1, 0], 'bool');
     const a = tf.tensor1d([10, 10, 10, 10]);

--- a/src/ops/logicalop_test.ts
+++ b/src/ops/logicalop_test.ts
@@ -350,9 +350,9 @@ describeWithFlags('where', ALL_ENVS, () => {
     const c = tf.tensor1d([1, 0, 1, 0], 'int32');
     const a = tf.tensor1d([10, 10, 10, 10], 'bool');
     const b = tf.tensor1d([20, 20, 20, 20], 'bool');
-    let f = () => {
+    const f = () => {
       tf.where(c, a, b);
-    }
+    };
     expect(f).toThrowError();
   });
 


### PR DESCRIPTION
BUG check condition type strictly in where op

# Purpose

TensorFlow [`where`](https://www.tensorflow.org/api_docs/python/tf/where) op only receives `bool` type tensor as a condition. In order to align with TensorFlow, TensorFlow.js implementation also should check condition type strictly regardless of the types of other tensors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1062)
<!-- Reviewable:end -->
