### PR TITLE
Make sure tf-core.(min).js bundle has the @license header

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 .vscode/
+.rpt2_cache/
 demos/
+integration_tests/
 docs/
 scripts/
 src/

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,23 @@ import typescript from 'rollup-plugin-typescript2';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 
+const PREAMBLE = `/**
+ * @license
+ * Copyright ${(new Date).getFullYear()} Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */`;
+
 export default {
   input: 'src/index.ts',
   plugins: [
@@ -35,7 +52,7 @@ export default {
   ],
   output: {
     extend: true,
-    banner: `// @tensorflow/tfjs-core Copyright ${(new Date).getFullYear()} Google`,
+    banner: PREAMBLE,
     file: 'dist/tf-core.js',
     format: 'umd',
     name: 'tf',

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -21,7 +21,7 @@ yarn
 
 yarn build
 rollup -c
-uglifyjs dist/tf-core.js -c -m -o dist/tf-core.min.js
+uglifyjs dist/tf-core.js --comments -c -m -o dist/tf-core.min.js
 
 echo "Stored standalone library at dist/tf-core(.min).js"
 npm pack


### PR DESCRIPTION
Make sure both tf-core.js and tf-core.min.js have the `@license` header at the top.

Also:
 - add `.rpt2_cache` and `integration_tests` to npmignore

Other repos should do the same.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1063)
<!-- Reviewable:end -->
