### PR TITLE
Make sure tf.fromPixels() gets called after the DOM is ready

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -132,948 +132,958 @@ export class MathBackendWebGL implements KernelBackend {
         }
         this.canvas = document.createElement('canvas');
       }
+      this.canvas.width = pixels.width;
+      this.canvas.height = pixels.height;
+      this.canvas.getContext('2d').drawImage(
+          pixels, 0, 0, pixels.width, pixels.height);
+      pixels = this.canvas;
     }
-    this.canvas.width = pixels.width;
-    this.canvas.height = pixels.height;
-    this.canvas.getContext('2d').drawImage(
-        pixels, 0, 0, pixels.width, pixels.height);
-    pixels = this.canvas;
-  }
-  const tempPixelArray = Tensor.make(texShape, {}, 'int32');
+    const tempPixelArray = Tensor.make(texShape, {}, 'int32');
 
-  // This is a byte texture with pixels.
-  this.texData.get(tempPixelArray.dataId).texType = TextureType.UNSIGNED_BYTE;
-  this.gpgpu.uploadPixelDataToTexture(
-      this.getTexture(tempPixelArray.dataId), pixels);
-  const program = new FromPixelsProgram(outShape);
-  const res = this.compileAndRun(program, [tempPixelArray]);
+    // This is a byte texture with pixels.
+    this.texData.get(tempPixelArray.dataId).texType = TextureType.UNSIGNED_BYTE;
+    this.gpgpu.uploadPixelDataToTexture(
+        this.getTexture(tempPixelArray.dataId), pixels);
+    const program = new FromPixelsProgram(outShape);
+    const res = this.compileAndRun(program, [tempPixelArray]);
 
-  tempPixelArray.dispose();
+    tempPixelArray.dispose();
 
-  return res as Tensor3D;
-}
-write(dataId: DataId, values: TypedArray): void {
-  if (values == null) {
-    throw new Error('MathBackendWebGL.write(): values can not be null');
+    return res as Tensor3D;
   }
-  this.throwIfNoData(dataId);
+  write(dataId: DataId, values: TypedArray): void {
+    if (values == null) {
+      throw new Error('MathBackendWebGL.write(): values can not be null');
+    }
+    this.throwIfNoData(dataId);
 
-  const texData = this.texData.get(dataId);
-  const {texture, texShape, texType} = texData;
-  if (texture != null) {
-    // Release the old texture.
-    this.textureManager.releaseTexture(texture, texShape, texType);
-    texData.texture = null;
-    texData.texShape = null;
-  }
-  texData.values = values;
+    const texData = this.texData.get(dataId);
+    const {texture, texShape, texType} = texData;
+    if (texture != null) {
+      // Release the old texture.
+      this.textureManager.releaseTexture(texture, texShape, texType);
+      texData.texture = null;
+      texData.texShape = null;
+    }
+    texData.values = values;
 
-  if (!this.delayedStorage) {
-    this.uploadToGPU(dataId);
+    if (!this.delayedStorage) {
+      this.uploadToGPU(dataId);
+    }
   }
-}
-readSync(dataId: DataId): TypedArray {
-  this.throwIfNoData(dataId);
-  const texData = this.texData.get(dataId);
-  const {texture, values, texShape} = texData;
-  if (values != null) {
-    this.cacheOnCPU(dataId);
-    return values;
-  }
-  const shouldTimeProgram = this.activeTimers != null;
-  let start: number;
-  if (shouldTimeProgram) {
-    start = performance.now();
-  }
-  const float32Values =
-      this.gpgpu.downloadMatrixFromTexture(texture, texShape[0], texShape[1]);
-  if (shouldTimeProgram) {
-    this.downloadWaitMs += performance.now() - start;
-  }
-  this.cacheOnCPU(dataId, float32Values);
-  return texData.values;
-}
-async read(dataId: DataId): Promise<TypedArray> {
-  this.throwIfNoData(dataId);
-  const texData = this.texData.get(dataId);
-  const {texture, values, texShape} = texData;
-  if (values != null) {
-    this.cacheOnCPU(dataId);
-    return values;
-  }
-  if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
-    const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
-        texture, texShape[0], texShape[1]);
+  readSync(dataId: DataId): TypedArray {
+    this.throwIfNoData(dataId);
+    const texData = this.texData.get(dataId);
+    const {texture, values, texShape} = texData;
+    if (values != null) {
+      this.cacheOnCPU(dataId);
+      return values;
+    }
+    const shouldTimeProgram = this.activeTimers != null;
+    let start: number;
+    if (shouldTimeProgram) {
+      start = performance.now();
+    }
+    const float32Values =
+        this.gpgpu.downloadMatrixFromTexture(texture, texShape[0], texShape[1]);
+    if (shouldTimeProgram) {
+      this.downloadWaitMs += performance.now() - start;
+    }
     this.cacheOnCPU(dataId, float32Values);
     return texData.values;
   }
+  async read(dataId: DataId): Promise<TypedArray> {
+    this.throwIfNoData(dataId);
+    const texData = this.texData.get(dataId);
+    const {texture, values, texShape} = texData;
+    if (values != null) {
+      this.cacheOnCPU(dataId);
+      return values;
+    }
+    if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
+      const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
+          texture, texShape[0], texShape[1]);
+      this.cacheOnCPU(dataId, float32Values);
+      return texData.values;
+    }
 
-  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 0) {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 0) {
+      return this.readSync(dataId);
+    }
+
+    // Construct an empty query. We're just interested in getting a callback
+    // when the GPU command queue has executed until this point in time.
+    await this.gpgpu.runQuery(() => {});
     return this.readSync(dataId);
   }
 
-  // Construct an empty query. We're just interested in getting a callback
-  // when the GPU command queue has executed until this point in time.
-  await this.gpgpu.runQuery(() => {});
-  return this.readSync(dataId);
-}
+  async time(f: () => void): Promise<WebGLTimingInfo> {
+    const oldActiveTimers = this.activeTimers;
+    const newActiveTimers: TimerNode[] = [];
 
-async time(f: () => void): Promise<WebGLTimingInfo> {
-  const oldActiveTimers = this.activeTimers;
-  const newActiveTimers: TimerNode[] = [];
+    let outerMostTime = false;
+    if (this.programTimersStack == null) {
+      this.programTimersStack = newActiveTimers;
+      outerMostTime = true;
+    } else {
+      this.activeTimers.push(newActiveTimers);
+    }
+    this.activeTimers = newActiveTimers;
 
-  let outerMostTime = false;
-  if (this.programTimersStack == null) {
-    this.programTimersStack = newActiveTimers;
-    outerMostTime = true;
-  } else {
-    this.activeTimers.push(newActiveTimers);
+    f();
+
+    const flattenedActiveTimers = util.flatten(this.activeTimers);
+    this.activeTimers = oldActiveTimers;
+
+    if (outerMostTime) {
+      this.programTimersStack = null;
+    }
+
+    const kernelMs = await Promise.all(flattenedActiveTimers).then(results => {
+      let sum = 0;
+      results.forEach(result => sum += result);
+      return sum;
+    });
+    const res: WebGLTimingInfo = {
+      uploadWaitMs: this.uploadWaitMs,
+      downloadWaitMs: this.downloadWaitMs,
+      kernelMs,
+      wallMs: null  // will be filled by the engine
+    };
+    this.uploadWaitMs = 0;
+    this.downloadWaitMs = 0;
+    return res;
   }
-  this.activeTimers = newActiveTimers;
-
-  f();
-
-  const flattenedActiveTimers = util.flatten(this.activeTimers);
-  this.activeTimers = oldActiveTimers;
-
-  if (outerMostTime) {
-    this.programTimersStack = null;
+  memory() {
+    return {unreliable: false};
   }
 
-  const kernelMs = await Promise.all(flattenedActiveTimers).then(results => {
-    let sum = 0;
-    results.forEach(result => sum += result);
-    return sum;
-  });
-  const res: WebGLTimingInfo = {
-    uploadWaitMs: this.uploadWaitMs,
-    downloadWaitMs: this.downloadWaitMs,
-    kernelMs,
-    wallMs: null  // will be filled by the engine
-  };
-  this.uploadWaitMs = 0;
-  this.downloadWaitMs = 0;
-  return res;
-}
-memory() {
-  return {unreliable: false};
-}
-
-private startTimer(): WebGLQuery|CPUTimerQuery {
-  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-    return this.gpgpu.beginQuery();
+  private startTimer(): WebGLQuery|CPUTimerQuery {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+      return this.gpgpu.beginQuery();
+    }
+    return {startMs: performance.now(), endMs: null};
   }
-  return {startMs: performance.now(), endMs: null};
-}
 
-private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
-    {startMs: number, endMs: number} {
-  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-    this.gpgpu.endQuery();
+  private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
+      {startMs: number, endMs: number} {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+      this.gpgpu.endQuery();
+      return query;
+    }
+    (query as CPUTimerQuery).endMs = performance.now();
     return query;
   }
-  (query as CPUTimerQuery).endMs = performance.now();
-  return query;
-}
 
-private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
-  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-    return this.gpgpu.pollQueryTime(query);
-  }
-  const timerQuery = query as CPUTimerQuery;
-  return timerQuery.endMs - timerQuery.startMs;
-}
-
-disposeData(dataId: DataId): void {
-  if (this.texData.has(dataId)) {
-    const {texture, texShape, texType} = this.texData.get(dataId);
-    if (texture != null) {
-      this.textureManager.releaseTexture(texture, texShape, texType);
+  private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+      return this.gpgpu.pollQueryTime(query);
     }
-    this.texData.delete(dataId);
-  }
-}
-
-getTexture(dataId: DataId): WebGLTexture {
-  this.uploadToGPU(dataId);
-  return this.texData.get(dataId).texture;
-}
-
-getTextureData(dataId: DataId): TextureData {
-  this.uploadToGPU(dataId);
-  return this.texData.get(dataId);
-}
-
-private textureManager: TextureManager;
-private binaryCache: {[key: string]: GPGPUBinary} = {};
-private gpgpuCreatedLocally: boolean;
-
-constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
-  if (ENV.get('WEBGL_VERSION') < 1) {
-    throw new Error('WebGL is not supported on this device');
-  }
-  if (gpgpu == null) {
-    this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));
-    this.gpgpuCreatedLocally = true;
-  } else {
-    this.gpgpuCreatedLocally = false;
+    const timerQuery = query as CPUTimerQuery;
+    return timerQuery.endMs - timerQuery.startMs;
   }
 
-  this.textureManager = new TextureManager(this.gpgpu);
-}
-
-getGPGPUContext(): GPGPUContext {
-  return this.gpgpu;
-}
-getCanvas(): HTMLCanvasElement {
-  return this.canvas;
-}
-
-slice<T extends Tensor>(x: T, begin: number[], size: number[]): T {
-  const program = new SliceProgram(size);
-  const customSetup = program.getCustomSetupFunc(begin);
-  return this.compileAndRun(program, [x], null, customSetup);
-}
-
-stridedSlice<T extends Tensor>(
-    x: T, begin: number[], end: number[], strides: number[], beginMask: number,
-    endMask: number): T {
-  const [beginIndex, size] =
-      getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
-
-  if (size.some(axis => axis === 0)) {
-    return ops.tensor([], size) as T;
+  disposeData(dataId: DataId): void {
+    if (this.texData.has(dataId)) {
+      const {texture, texShape, texType} = this.texData.get(dataId);
+      if (texture != null) {
+        this.textureManager.releaseTexture(texture, texShape, texType);
+      }
+      this.texData.delete(dataId);
+    }
   }
 
-  const program = new StridedSliceProgram(beginIndex, strides, size);
-  return this.compileAndRun(program, [x]);
-}
-
-reverse<T extends Tensor>(x: T, axis: number[]): T {
-  const program = new ReverseProgram(x.shape, axis);
-  return this.compileAndRun(program, [x]);
-}
-
-// Concats 2d tensors along axis=1. See comments in MathBackend.concat().
-concat(a: Tensor2D, b: Tensor2D): Tensor2D {
-  const program = new ConcatProgram(a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]);
-}
-
-neg<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.NEG);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
-    Tensor2D {
-  const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-  return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
-}
-
-multiply(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
-  const output =
-      this.makeOutputArray(
-          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-  return this.compileAndRun(program, [a, b], output) as Tensor;
-}
-
-batchNormalization(
-    x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
-    varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
-    offset?: Tensor4D|Tensor1D): Tensor4D {
-  const inputs = [x, mean, variance];
-
-  let offsetShape = null;
-  if (offset != null) {
-    offsetShape = offset.shape;
-    inputs.push(offset);
+  getTexture(dataId: DataId): WebGLTexture {
+    this.uploadToGPU(dataId);
+    return this.texData.get(dataId).texture;
   }
 
-  let scaleShape = null;
-  if (scale != null) {
-    scaleShape = scale.shape;
-    inputs.push(scale);
+  getTextureData(dataId: DataId): TextureData {
+    this.uploadToGPU(dataId);
+    return this.texData.get(dataId);
   }
 
-  const program = new BatchNormProgram(
-      x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
-      varianceEpsilon);
-  return this.compileAndRun(program, inputs);
-}
+  private textureManager: TextureManager;
+  private binaryCache: {[key: string]: GPGPUBinary} = {};
+  private gpgpuCreatedLocally: boolean;
 
-localResponseNormalization4D(
-    x: Tensor4D, radius: number, bias: number, alpha: number,
-    beta: number): Tensor4D {
-  const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
-  return this.compileAndRun(program, [x]);
-}
+  constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
+    if (ENV.get('WEBGL_VERSION') < 1) {
+      throw new Error('WebGL is not supported on this device');
+    }
+    if (gpgpu == null) {
+      this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));
+      this.gpgpuCreatedLocally = true;
+    } else {
+      this.gpgpuCreatedLocally = false;
+    }
 
-tile<T extends Tensor>(x: T, reps: number[]): T {
-  const program = new TileProgram(x.shape, reps);
-  return this.compileAndRun(program, [x]);
-}
-
-pad<T extends Tensor>(
-    x: T, paddings: Array<[number, number]>, constantValue: number): T {
-  const program = new PadProgram(x.shape, paddings, constantValue);
-  return this.compileAndRun(program, [x]);
-}
-
-transpose<T extends Tensor>(x: T, perm: number[]): T {
-  const program = new TransposeProgram(x.shape, perm);
-  return this.compileAndRun(program, [x]);
-}
-
-gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T {
-  const program = new GatherProgram(x.shape, indices.size, axis);
-  return this.compileAndRun(program, [x, indices]);
-}
-
-private reduce(
-    x: Tensor2D, reduceType: 'max'|'min'|'sum', dtype: DataType): Tensor2D {
-  const batchSize = x.shape[0];
-  const inSize = x.shape[1];
-  const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-  const reduceInfo = {windowSize, inSize, batchSize};
-  const program = new ReduceProgram(reduceInfo, reduceType);
-  const [rows, cols] = program.outputShape;
-  const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
-  this.compileAndRun(program, [x], output);
-  // No need to run another GPGPU program.
-  if (output.shape[1] === 1) {
-    return output;
-  }
-  return this.reduce(output, reduceType, dtype);
-}
-
-private argReduce(
-    x: Tensor2D, reduceType: 'max'|'min',
-    bestIndicesA: Tensor2D = null): Tensor2D {
-  let batchSize = x.shape[0];
-  let inSize = x.shape[1];
-  if (bestIndicesA != null) {
-    batchSize = bestIndicesA.shape[0];
-    inSize = bestIndicesA.shape[1];
-  }
-  const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-  const reduceInfo = {windowSize, inSize, batchSize};
-  const program =
-      new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
-  const [rows, cols] = program.outputShape;
-  const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
-  const inputs = [x];
-  if (bestIndicesA != null) {
-    inputs.push(bestIndicesA);
-  }
-  this.compileAndRun(program, inputs, output);
-  // No need to run another GPGPU program.
-  if (output.shape[1] === 1) {
-    return output;
-  }
-  return this.argReduce(x, reduceType, output);
-}
-
-sum(x: Tensor, axes: number[]): Tensor {
-  axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
-  const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
-  const inSize = util.sizeFromShape(reduceShape);
-  const a2D = x.as2D(-1, inSize);
-  const outputDType = types.sumOutType(x.dtype);
-  return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
-}
-
-argMin(x: Tensor, axis: number): Tensor {
-  const axes = [axis];
-  axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
-  const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
-  const inSize = util.sizeFromShape(reduceShape);
-  const a2D = x.as2D(-1, inSize);
-  return this.argReduce(a2D, 'min').reshape(outShape);
-}
-
-argMax(x: Tensor, axis: number): Tensor {
-  const axes = [axis];
-  axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
-  const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
-  const inSize = util.sizeFromShape(reduceShape);
-  const a2D = x.as2D(-1, inSize);
-  return this.argReduce(a2D, 'max').reshape(outShape);
-}
-
-cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean): Tensor {
-  if (axis !== x.rank - 1) {
-    throw new Error(
-        `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
-        `but got axis=${axis}`);
-  }
-  const program = new CumSumProgram(x.shape, exclusive, reverse);
-  return this.compileAndRun(program, [x]);
-}
-
-equal(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.EQUAL, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-notEqual(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-less(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.LESS, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-lessEqual(a: Tensor, b: Tensor): Tensor {
-  const program =
-      new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-greater(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-greaterEqual(a: Tensor, b: Tensor): Tensor {
-  const program =
-      new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-logicalNot<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.LOGICAL_NOT);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-logicalAnd(a: Tensor, b: Tensor): Tensor {
-  const program =
-      new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-logicalOr(a: Tensor, b: Tensor): Tensor {
-  const program =
-      new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, 'bool');
-  return this.compileAndRun(program, [a, b], output);
-}
-
-where(condition: Tensor, a: Tensor, b: Tensor, dtype: DataType): Tensor {
-  const program = new WhereProgram(condition.rank, a.shape, a.rank);
-  const output = this.makeOutputArray(program.outputShape, dtype);
-  return this.compileAndRun(program, [condition, a, b], output);
-}
-
-topKValues<T extends Tensor>(x: T, k: number): Tensor1D {
-  throw new Error('topKValues GPU not yet implemented!');
-}
-
-topKIndices(x: Tensor, k: number): Tensor1D {
-  throw new Error('topKIndices GPU not yet implemented!');
-}
-
-min(x: Tensor, axes: number[]): Tensor {
-  axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
-  const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
-  const inSize = util.sizeFromShape(reduceShape);
-  const a2D = x.as2D(-1, inSize);
-  return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
-}
-
-minimum(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]);
-}
-
-mod(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]);
-}
-
-max(x: Tensor, axes: number[]): Tensor {
-  axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
-  const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
-  const inSize = util.sizeFromShape(reduceShape);
-  const a2D = x.as2D(-1, inSize);
-  return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
-}
-
-maximum(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]);
-}
-
-squaredDifference(a: Tensor, b: Tensor): Tensor {
-  const program =
-      new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]);
-}
-
-divide(a: Tensor, b: Tensor): Tensor {
-  let op: string;
-  let outputDtype: 'float32'|'int32';
-  if (a.dtype === 'int32' && b.dtype === 'int32') {
-    op = binaryop_gpu.INT_DIV;
-    outputDtype = 'int32';
-  } else {
-    op = binaryop_gpu.DIV;
-    outputDtype = 'float32';
+    this.textureManager = new TextureManager(this.gpgpu);
   }
 
-  const program = new BinaryOpProgram(op, a.shape, b.shape);
-  const output = this.makeOutputArray(program.outputShape, outputDtype);
-  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-}
-
-add(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
-  const output =
-      this.makeOutputArray(
-          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-}
-
-subtract(a: Tensor, b: Tensor): Tensor {
-  const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
-  const output =
-      this.makeOutputArray(
-          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-}
-
-pow<T extends Tensor>(a: T, b: Tensor): T {
-  const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
-  const output =
-      this.makeOutputArray(
-          program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
-  return this.compileAndRun<Tensor, T>(program, [a, b], output);
-}
-
-ceil<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.CEIL);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-floor<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.FLOOR);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-sign<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-round<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-exp<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.EXP);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-expm1<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.EXPM1);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-log<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.LOG);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-log1p<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.LOG1P);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-sqrt<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SQRT);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-rsqrt<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.RSQRT);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-square<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SQUARE);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-reciprocal<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.RECIPROCAL);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-relu<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.RELU);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-elu<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ELU);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-eluDer<T extends Tensor>(dy: T, y: T): T {
-  const program = new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
-  return this.compileAndRun(program, [dy, y]) as T;
-}
-
-selu<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SELU);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-int<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
-  const output = this.makeOutputArray(program.outputShape, 'int32');
-  return this.compileAndRun(program, [x], output) as T;
-}
-
-clip<T extends Tensor>(x: T, min: number, max: number): T {
-  const program = new ClipProgram(x.shape, min, max);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-abs<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ABS);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-sigmoid<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SIGMOID);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-softplus<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SOFTPLUS);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-sin<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SIN);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-cos<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.COS);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-tan<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.TAN);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-asin<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ASIN);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-acos<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ACOS);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-atan<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ATAN);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-atan2<T extends Tensor>(a: T, b: T): T {
-  const program = new BinaryOpProgram(binaryop_gpu.ATAN2, a.shape, b.shape);
-  return this.compileAndRun(program, [a, b]) as T;
-}
-
-sinh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.SINH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-cosh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.COSH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-tanh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.TANH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-asinh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ASINH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-acosh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-atanh<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-erf<T extends Tensor>(x: T): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.ERF);
-  return this.compileAndRun(program, [x]) as T;
-}
-
-step<T extends Tensor>(x: T, alpha: number): T {
-  const program = new UnaryOpProgram(x.shape, unary_op.STEP(alpha));
-  return this.compileAndRun(program, [x]) as T;
-}
-
-conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new Conv2DProgram(convInfo);
-  return this.compileAndRun(program, [x, filter]);
-}
-
-conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new Conv2DDerInputProgram(convInfo);
-  return this.compileAndRun(program, [dy, filter]);
-}
-
-conv2dDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new Conv2DDerFilterProgram(convInfo);
-  return this.compileAndRun(program, [x, dy]);
-}
-
-depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new DepthwiseConv2DProgram(convInfo);
-  return this.compileAndRun(program, [x, filter]);
-}
-
-maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new Pool2DProgram(convInfo, 'max', false);
-  const output = this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
-  return this.compileAndRun(program, [x], output);
-}
-
-avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const program = new Pool2DProgram(convInfo, 'avg', false);
-  const output = this.makeOutputArray(program.outputShape, 'float32');
-  return this.compileAndRun(program, [x], output) as Tensor4D;
-}
-
-maxPoolBackprop(
-    dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const getPositions = true;
-  const maxPoolPositionsProgram =
-      new Pool2DProgram(convInfo, 'max', getPositions);
-  const maxPoolPositions: Tensor4D =
-      this.compileAndRun(maxPoolPositionsProgram, [x]);
-
-  const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
-  const output =
-      this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
-  const result = this.compileAndRun(
-      maxPoolBackPropProgram, [dy, maxPoolPositions], output);
-  maxPoolPositions.dispose();
-  return result as Tensor4D;
-}
-
-avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-  const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
-  const output =
-      this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
-  return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
-}
-
-cast<T extends Tensor<types.Rank>>(x: T, dtype: DataType): T {
-  return backend_util.castTensor(x, dtype, this);
-}
-
-reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
-    x: T, shape: types.ShapeMap[R]): Tensor<R> {
-  return backend_util.reshapeTensor(x, shape);
-}
-
-resizeBilinear(
-    x: Tensor4D, newHeight: number, newWidth: number,
-    alignCorners: boolean): Tensor4D {
-  const program =
-      new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
-  return this.compileAndRun(program, [x]);
-}
-
-resizeBilinearBackprop(
-    dy: Tensor4D, x: Tensor4D, alignCorners: boolean): Tensor4D {
-  const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
-
-  return this.compileAndRun(program, [dy]);
-}
-
-resizeNearestNeighbor(
-    x: Tensor4D, newHeight: number, newWidth: number,
-    alignCorners: boolean): Tensor4D {
-  const program = new ResizeNearestNeighborProgram(
-      x.shape, newHeight, newWidth, alignCorners);
-  return this.compileAndRun(program, [x]);
-}
-
-multinomial(
-    logits: Tensor2D, normalized: boolean, numSamples: number,
-    seed: number): Tensor2D {
-  const probs = normalized ? logits : ops.softmax(logits);
-  const batchSize = probs.shape[0];
-  const numOutcomes = probs.shape[1];
-  const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
-  const output = this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
-  const customSetup = program.getCustomSetupFunc(seed);
-  return this.compileAndRun(program, [probs], output, customSetup);
-}
-
-oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
-    Tensor2D {
-  const program = new OneHotProgram(indices.size, depth, onValue, offValue);
-  return this.compileAndRun(program, [indices]);
-}
-
-private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType): T {
-  return Tensor.make(shape, {}, dtype) as T;
-}
-
-private compileAndRun<T extends Tensor, K extends Tensor>(
-    program: GPGPUProgram, inputs: T[], output?: K,
-    customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) =>
-        void): K {
-  if (output == null) {
-    output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+  getGPGPUContext(): GPGPUContext {
+    return this.gpgpu;
   }
-  const inputsData: Array<TensorData<T>> = inputs.map(input => {
-    this.uploadToGPU(input.dataId);
-    return {tensor: input, texData: this.texData.get(input.dataId)};
-  });
-  this.uploadToGPU(output.dataId);
-  const outputData = {tensor: output, texData: this.texData.get(output.dataId)};
-  const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
-  const binary = this.getAndSaveBinary(key, () => {
-    return gpgpu_math.compileProgram(
-        this.gpgpu, program, inputsData, outputData);
-  });
-  const shouldTimeProgram = this.activeTimers != null;
-  let query: WebGLQuery|CPUTimerQuery;
-  if (shouldTimeProgram) {
-    query = this.startTimer();
+  getCanvas(): HTMLCanvasElement {
+    return this.canvas;
   }
 
-  gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
+  slice<T extends Tensor>(x: T, begin: number[], size: number[]): T {
+    const program = new SliceProgram(size);
+    const customSetup = program.getCustomSetupFunc(begin);
+    return this.compileAndRun(program, [x], null, customSetup);
+  }
 
-  if (shouldTimeProgram) {
-    query = this.endTimer(query);
-    this.activeTimers.push(this.getQueryTime(query));
-  }
-  return output;
-}
+  stridedSlice<T extends Tensor>(
+      x: T, begin: number[], end: number[], strides: number[],
+      beginMask: number, endMask: number): T {
+    const [beginIndex, size] =
+        getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
 
-private getAndSaveBinary(
-    key: string, getBinary: () => GPGPUBinary): GPGPUBinary {
-  if (!(key in this.binaryCache)) {
-    this.binaryCache[key] = getBinary();
-  }
-  return this.binaryCache[key];
-}
+    if (size.some(axis => axis === 0)) {
+      return ops.tensor([], size) as T;
+    }
 
-getTextureManager(): TextureManager {
-  return this.textureManager;
-}
+    const program = new StridedSliceProgram(beginIndex, strides, size);
+    return this.compileAndRun(program, [x]);
+  }
 
-private disposed = false;
+  reverse<T extends Tensor>(x: T, axis: number[]): T {
+    const program = new ReverseProgram(x.shape, axis);
+    return this.compileAndRun(program, [x]);
+  }
 
-dispose() {
-  if (this.disposed) {
-    return;
+  // Concats 2d tensors along axis=1. See comments in MathBackend.concat().
+  concat(a: Tensor2D, b: Tensor2D): Tensor2D {
+    const program = new ConcatProgram(a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]);
   }
-  for (const key in this.binaryCache) {
-    this.gpgpu.deleteProgram(this.binaryCache[key].webGLProgram);
-  }
-  this.textureManager.dispose();
-  this.canvas.remove();
-  if (this.gpgpuCreatedLocally) {
-    this.gpgpu.dispose();
-  }
-  this.disposed = true;
-}
 
-private throwIfNoData(dataId: DataId) {
-  if (!this.texData.has(dataId)) {
-    throw new Error(
-        `WebGL backend: No data found for this tensor. ` +
-        `Did you change your backend in the middle of the program? ` +
-        `New backends can't use Tensors created with previous backends`);
+  neg<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.NEG);
+    return this.compileAndRun(program, [x]) as T;
   }
-}
 
-private uploadToGPU(dataId: DataId): void {
-  this.throwIfNoData(dataId);
-  const texData = this.texData.get(dataId);
-  const {shape, values, texture, dtype, texType} = texData;
-  if (texture != null) {
-    // Array is already on GPU. No-op.
-    return;
+  matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
+      Tensor2D {
+    const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
+    return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
   }
-  const shouldTimeProgram = this.activeTimers != null;
-  let start: number;
-  if (shouldTimeProgram) {
-    start = performance.now();
+
+  multiply(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+    return this.compileAndRun(program, [a, b], output) as Tensor;
   }
-  const texShape =
-      webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
-  texData.texShape = texShape;
-  const newTexture = this.textureManager.acquireTexture(texShape, texType);
-  texData.texture = newTexture;
-  if (values != null) {
-    this.gpgpu.uploadMatrixToTexture(
-        newTexture, texShape[0],
-        // TODO(smilkov): Propagate the original typed array to gpgpu.
-        texShape[1], typedArrayToFloat32(values, dtype));
-    // Once uploaded, don't store the values on cpu.
-    texData.values = null;
+
+  batchNormalization(
+      x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
+      varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
+      offset?: Tensor4D|Tensor1D): Tensor4D {
+    const inputs = [x, mean, variance];
+
+    let offsetShape = null;
+    if (offset != null) {
+      offsetShape = offset.shape;
+      inputs.push(offset);
+    }
+
+    let scaleShape = null;
+    if (scale != null) {
+      scaleShape = scale.shape;
+      inputs.push(scale);
+    }
+
+    const program = new BatchNormProgram(
+        x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
+        varianceEpsilon);
+    return this.compileAndRun(program, inputs);
+  }
+
+  localResponseNormalization4D(
+      x: Tensor4D, radius: number, bias: number, alpha: number,
+      beta: number): Tensor4D {
+    const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
+    return this.compileAndRun(program, [x]);
+  }
+
+  tile<T extends Tensor>(x: T, reps: number[]): T {
+    const program = new TileProgram(x.shape, reps);
+    return this.compileAndRun(program, [x]);
+  }
+
+  pad<T extends Tensor>(
+      x: T, paddings: Array<[number, number]>, constantValue: number): T {
+    const program = new PadProgram(x.shape, paddings, constantValue);
+    return this.compileAndRun(program, [x]);
+  }
+
+  transpose<T extends Tensor>(x: T, perm: number[]): T {
+    const program = new TransposeProgram(x.shape, perm);
+    return this.compileAndRun(program, [x]);
+  }
+
+  gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T {
+    const program = new GatherProgram(x.shape, indices.size, axis);
+    return this.compileAndRun(program, [x, indices]);
+  }
+
+  private reduce(x: Tensor2D, reduceType: 'max'|'min'|'sum', dtype: DataType):
+      Tensor2D {
+    const batchSize = x.shape[0];
+    const inSize = x.shape[1];
+    const windowSize = reduce_util.computeOptimalWindowSize(inSize);
+    const reduceInfo = {windowSize, inSize, batchSize};
+    const program = new ReduceProgram(reduceInfo, reduceType);
+    const [rows, cols] = program.outputShape;
+    const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
+    this.compileAndRun(program, [x], output);
+    // No need to run another GPGPU program.
+    if (output.shape[1] === 1) {
+      return output;
+    }
+    return this.reduce(output, reduceType, dtype);
+  }
+
+  private argReduce(
+      x: Tensor2D, reduceType: 'max'|'min',
+      bestIndicesA: Tensor2D = null): Tensor2D {
+    let batchSize = x.shape[0];
+    let inSize = x.shape[1];
+    if (bestIndicesA != null) {
+      batchSize = bestIndicesA.shape[0];
+      inSize = bestIndicesA.shape[1];
+    }
+    const windowSize = reduce_util.computeOptimalWindowSize(inSize);
+    const reduceInfo = {windowSize, inSize, batchSize};
+    const program =
+        new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
+    const [rows, cols] = program.outputShape;
+    const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
+    const inputs = [x];
+    if (bestIndicesA != null) {
+      inputs.push(bestIndicesA);
+    }
+    this.compileAndRun(program, inputs, output);
+    // No need to run another GPGPU program.
+    if (output.shape[1] === 1) {
+      return output;
+    }
+    return this.argReduce(x, reduceType, output);
+  }
+
+  sum(x: Tensor, axes: number[]): Tensor {
+    axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    const outputDType = types.sumOutType(x.dtype);
+    return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+  }
+
+  argMin(x: Tensor, axis: number): Tensor {
+    const axes = [axis];
+    axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.argReduce(a2D, 'min').reshape(outShape);
+  }
+
+  argMax(x: Tensor, axis: number): Tensor {
+    const axes = [axis];
+    axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.argReduce(a2D, 'max').reshape(outShape);
+  }
+
+  cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
+      Tensor {
+    if (axis !== x.rank - 1) {
+      throw new Error(
+          `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
+          `but got axis=${axis}`);
+    }
+    const program = new CumSumProgram(x.shape, exclusive, reverse);
+    return this.compileAndRun(program, [x]);
+  }
+
+  equal(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  notEqual(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  less(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.LESS, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  lessEqual(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  greater(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  greaterEqual(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  logicalNot<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.LOGICAL_NOT);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  logicalAnd(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  logicalOr(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
+  where(condition: Tensor, a: Tensor, b: Tensor, dtype: DataType): Tensor {
+    const program = new WhereProgram(condition.rank, a.shape, a.rank);
+    const output = this.makeOutputArray(program.outputShape, dtype);
+    return this.compileAndRun(program, [condition, a, b], output);
+  }
+
+  topKValues<T extends Tensor>(x: T, k: number): Tensor1D {
+    throw new Error('topKValues GPU not yet implemented!');
+  }
+
+  topKIndices(x: Tensor, k: number): Tensor1D {
+    throw new Error('topKIndices GPU not yet implemented!');
+  }
+
+  min(x: Tensor, axes: number[]): Tensor {
+    axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
+  }
+
+  minimum(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]);
+  }
+
+  mod(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]);
+  }
+
+  max(x: Tensor, axes: number[]): Tensor {
+    axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
+  }
+
+  maximum(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]);
+  }
+
+  squaredDifference(a: Tensor, b: Tensor): Tensor {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]);
+  }
+
+  divide(a: Tensor, b: Tensor): Tensor {
+    let op: string;
+    let outputDtype: 'float32'|'int32';
+    if (a.dtype === 'int32' && b.dtype === 'int32') {
+      op = binaryop_gpu.INT_DIV;
+      outputDtype = 'int32';
+    } else {
+      op = binaryop_gpu.DIV;
+      outputDtype = 'float32';
+    }
+
+    const program = new BinaryOpProgram(op, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, outputDtype);
+    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+  }
+
+  add(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+  }
+
+  subtract(a: Tensor, b: Tensor): Tensor {
+    const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+  }
+
+  pow<T extends Tensor>(a: T, b: Tensor): T {
+    const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
+    return this.compileAndRun<Tensor, T>(program, [a, b], output);
+  }
+
+  ceil<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.CEIL);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  floor<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.FLOOR);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  sign<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  round<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  exp<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.EXP);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  expm1<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.EXPM1);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  log<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.LOG);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  log1p<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.LOG1P);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  sqrt<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SQRT);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  rsqrt<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.RSQRT);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  square<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SQUARE);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  reciprocal<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.RECIPROCAL);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  relu<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.RELU);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  elu<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ELU);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  eluDer<T extends Tensor>(dy: T, y: T): T {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
+    return this.compileAndRun(program, [dy, y]) as T;
+  }
+
+  selu<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SELU);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  int<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
+    const output = this.makeOutputArray(program.outputShape, 'int32');
+    return this.compileAndRun(program, [x], output) as T;
+  }
+
+  clip<T extends Tensor>(x: T, min: number, max: number): T {
+    const program = new ClipProgram(x.shape, min, max);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  abs<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ABS);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  sigmoid<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SIGMOID);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  softplus<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SOFTPLUS);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  sin<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SIN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  cos<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.COS);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  tan<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.TAN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  asin<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ASIN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  acos<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ACOS);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  atan<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ATAN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  atan2<T extends Tensor>(a: T, b: T): T {
+    const program = new BinaryOpProgram(binaryop_gpu.ATAN2, a.shape, b.shape);
+    return this.compileAndRun(program, [a, b]) as T;
+  }
+
+  sinh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.SINH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  cosh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.COSH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  tanh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.TANH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  asinh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ASINH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  acosh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  atanh<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  erf<T extends Tensor>(x: T): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.ERF);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  step<T extends Tensor>(x: T, alpha: number): T {
+    const program = new UnaryOpProgram(x.shape, unary_op.STEP(alpha));
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    const program = new Conv2DProgram(convInfo);
+    return this.compileAndRun(program, [x, filter]);
+  }
+
+  conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    const program = new Conv2DDerInputProgram(convInfo);
+    return this.compileAndRun(program, [dy, filter]);
+  }
+
+  conv2dDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    const program = new Conv2DDerFilterProgram(convInfo);
+    return this.compileAndRun(program, [x, dy]);
+  }
+
+  depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    const program = new DepthwiseConv2DProgram(convInfo);
+    return this.compileAndRun(program, [x, filter]);
+  }
+
+  maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    const program = new Pool2DProgram(convInfo, 'max', false);
+    const output =
+        this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
+    return this.compileAndRun(program, [x], output);
+  }
+
+  avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    const program = new Pool2DProgram(convInfo, 'avg', false);
+    const output = this.makeOutputArray(program.outputShape, 'float32');
+    return this.compileAndRun(program, [x], output) as Tensor4D;
+  }
+
+  maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    const getPositions = true;
+    const maxPoolPositionsProgram =
+        new Pool2DProgram(convInfo, 'max', getPositions);
+    const maxPoolPositions: Tensor4D =
+        this.compileAndRun(maxPoolPositionsProgram, [x]);
+
+    const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
+    const output =
+        this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
+    const result = this.compileAndRun(
+        maxPoolBackPropProgram, [dy, maxPoolPositions], output);
+    maxPoolPositions.dispose();
+    return result as Tensor4D;
+  }
+
+  avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
+    const output =
+        this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
+    return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
+  }
+
+  cast<T extends Tensor<types.Rank>>(x: T, dtype: DataType): T {
+    return backend_util.castTensor(x, dtype, this);
+  }
+
+  reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
+      x: T, shape: types.ShapeMap[R]): Tensor<R> {
+    return backend_util.reshapeTensor(x, shape);
+  }
+
+  resizeBilinear(
+      x: Tensor4D, newHeight: number, newWidth: number,
+      alignCorners: boolean): Tensor4D {
+    const program =
+        new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
+    return this.compileAndRun(program, [x]);
+  }
+
+  resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):
+      Tensor4D {
+    const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
+
+    return this.compileAndRun(program, [dy]);
+  }
+
+  resizeNearestNeighbor(
+      x: Tensor4D, newHeight: number, newWidth: number,
+      alignCorners: boolean): Tensor4D {
+    const program = new ResizeNearestNeighborProgram(
+        x.shape, newHeight, newWidth, alignCorners);
+    return this.compileAndRun(program, [x]);
+  }
+
+  multinomial(
+      logits: Tensor2D, normalized: boolean, numSamples: number,
+      seed: number): Tensor2D {
+    const probs = normalized ? logits : ops.softmax(logits);
+    const batchSize = probs.shape[0];
+    const numOutcomes = probs.shape[1];
+    const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
+    const output =
+        this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
+    const customSetup = program.getCustomSetupFunc(seed);
+    return this.compileAndRun(program, [probs], output, customSetup);
+  }
+
+  oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
+      Tensor2D {
+    const program = new OneHotProgram(indices.size, depth, onValue, offValue);
+    return this.compileAndRun(program, [indices]);
+  }
+
+  private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
+      T {
+    return Tensor.make(shape, {}, dtype) as T;
+  }
+
+  private compileAndRun<T extends Tensor, K extends Tensor>(
+      program: GPGPUProgram, inputs: T[], output?: K,
+      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
+      K {
+    if (output == null) {
+      output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+    }
+    const inputsData: Array<TensorData<T>> = inputs.map(input => {
+      this.uploadToGPU(input.dataId);
+      return {tensor: input, texData: this.texData.get(input.dataId)};
+    });
+    this.uploadToGPU(output.dataId);
+    const outputData = {
+      tensor: output,
+      texData: this.texData.get(output.dataId)
+    };
+    const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
+    const binary = this.getAndSaveBinary(key, () => {
+      return gpgpu_math.compileProgram(
+          this.gpgpu, program, inputsData, outputData);
+    });
+    const shouldTimeProgram = this.activeTimers != null;
+    let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
-      this.uploadWaitMs += performance.now() - start;
+      query = this.startTimer();
+    }
+
+    gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
+
+    if (shouldTimeProgram) {
+      query = this.endTimer(query);
+      this.activeTimers.push(this.getQueryTime(query));
+    }
+    return output;
+  }
+
+  private getAndSaveBinary(key: string, getBinary: () => GPGPUBinary):
+      GPGPUBinary {
+    if (!(key in this.binaryCache)) {
+      this.binaryCache[key] = getBinary();
+    }
+    return this.binaryCache[key];
+  }
+
+  getTextureManager(): TextureManager {
+    return this.textureManager;
+  }
+
+  private disposed = false;
+
+  dispose() {
+    if (this.disposed) {
+      return;
+    }
+    for (const key in this.binaryCache) {
+      this.gpgpu.deleteProgram(this.binaryCache[key].webGLProgram);
+    }
+    this.textureManager.dispose();
+    this.canvas.remove();
+    if (this.gpgpuCreatedLocally) {
+      this.gpgpu.dispose();
+    }
+    this.disposed = true;
+  }
+
+  private throwIfNoData(dataId: DataId) {
+    if (!this.texData.has(dataId)) {
+      throw new Error(
+          `WebGL backend: No data found for this tensor. ` +
+          `Did you change your backend in the middle of the program? ` +
+          `New backends can't use Tensors created with previous backends`);
     }
   }
-}
 
-private cacheOnCPU(dataId: DataId, float32Values?: Float32Array) {
-  // In delayed storage mode, when the user reads data, we don't keep a copy
-  // on the gpu, to minimize likelihood of memory leak. We re-upload to gpu
-  // the next time a gpgpu program needs the texture.
-  const dontKeepCopyOnGPU = this.delayedStorage;
-  const texData = this.texData.get(dataId);
-  const {texture, texShape, dtype, texType} = texData;
-  if (dontKeepCopyOnGPU && texture != null) {
-    this.textureManager.releaseTexture(texture, texShape, texType);
-    texData.texture = null;
-    texData.texShape = null;
+  private uploadToGPU(dataId: DataId): void {
+    this.throwIfNoData(dataId);
+    const texData = this.texData.get(dataId);
+    const {shape, values, texture, dtype, texType} = texData;
+    if (texture != null) {
+      // Array is already on GPU. No-op.
+      return;
+    }
+    const shouldTimeProgram = this.activeTimers != null;
+    let start: number;
+    if (shouldTimeProgram) {
+      start = performance.now();
+    }
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+    texData.texShape = texShape;
+    const newTexture = this.textureManager.acquireTexture(texShape, texType);
+    texData.texture = newTexture;
+    if (values != null) {
+      this.gpgpu.uploadMatrixToTexture(
+          newTexture, texShape[0],
+          // TODO(smilkov): Propagate the original typed array to gpgpu.
+          texShape[1], typedArrayToFloat32(values, dtype));
+      // Once uploaded, don't store the values on cpu.
+      texData.values = null;
+      if (shouldTimeProgram) {
+        this.uploadWaitMs += performance.now() - start;
+      }
+    }
   }
-  if (float32Values != null) {
-    texData.values = float32ToTypedArray(float32Values, dtype);
+
+  private cacheOnCPU(dataId: DataId, float32Values?: Float32Array) {
+    // In delayed storage mode, when the user reads data, we don't keep a copy
+    // on the gpu, to minimize likelihood of memory leak. We re-upload to gpu
+    // the next time a gpgpu program needs the texture.
+    const dontKeepCopyOnGPU = this.delayedStorage;
+    const texData = this.texData.get(dataId);
+    const {texture, texShape, dtype, texType} = texData;
+    if (dontKeepCopyOnGPU && texture != null) {
+      this.textureManager.releaseTexture(texture, texShape, texType);
+      texData.texture = null;
+      texData.texShape = null;
+    }
+    if (float32Values != null) {
+      texData.values = float32ToTypedArray(float32Values, dtype);
+    }
   }
-}
 }
 
 ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -120,972 +120,960 @@ export class MathBackendWebGL implements KernelBackend {
 
     if (pixels instanceof HTMLVideoElement) {
       if (this.canvas == null) {
+        if (typeof document === 'undefined') {
+          throw new Error(
+              'Can\'t read pixels from HTMLImageElement outside the browser.');
+        }
         if (document.readyState !== 'complete') {
           throw new Error(
               'The DOM is not ready yet. Please call tf.fromPixels() ' +
               'once the DOM is ready. One way to do that is to add an event ' +
               'listener for `DOMContentLoaded` on the document object');
         }
-        if (typeof document !== 'undefined') {
-          this.canvas = document.createElement('canvas');
-        } else {
-          throw new Error(
-              'Can\'t read pixels from HTMLImageElement outside ' +
-              'the browser.');
-        }
+        this.canvas = document.createElement('canvas');
       }
-      this.canvas.width = pixels.width;
-      this.canvas.height = pixels.height;
-      this.canvas.getContext('2d').drawImage(
-          pixels, 0, 0, pixels.width, pixels.height);
-      pixels = this.canvas;
     }
-    const tempPixelArray = Tensor.make(texShape, {}, 'int32');
-
-    // This is a byte texture with pixels.
-    this.texData.get(tempPixelArray.dataId).texType = TextureType.UNSIGNED_BYTE;
-    this.gpgpu.uploadPixelDataToTexture(
-        this.getTexture(tempPixelArray.dataId), pixels);
-    const program = new FromPixelsProgram(outShape);
-    const res = this.compileAndRun(program, [tempPixelArray]);
-
-    tempPixelArray.dispose();
-
-    return res as Tensor3D;
+    this.canvas.width = pixels.width;
+    this.canvas.height = pixels.height;
+    this.canvas.getContext('2d').drawImage(
+        pixels, 0, 0, pixels.width, pixels.height);
+    pixels = this.canvas;
   }
-  write(dataId: DataId, values: TypedArray): void {
-    if (values == null) {
-      throw new Error('MathBackendWebGL.write(): values can not be null');
-    }
-    this.throwIfNoData(dataId);
+  const tempPixelArray = Tensor.make(texShape, {}, 'int32');
 
-    const texData = this.texData.get(dataId);
-    const {texture, texShape, texType} = texData;
-    if (texture != null) {
-      // Release the old texture.
-      this.textureManager.releaseTexture(texture, texShape, texType);
-      texData.texture = null;
-      texData.texShape = null;
-    }
-    texData.values = values;
+  // This is a byte texture with pixels.
+  this.texData.get(tempPixelArray.dataId).texType = TextureType.UNSIGNED_BYTE;
+  this.gpgpu.uploadPixelDataToTexture(
+      this.getTexture(tempPixelArray.dataId), pixels);
+  const program = new FromPixelsProgram(outShape);
+  const res = this.compileAndRun(program, [tempPixelArray]);
 
-    if (!this.delayedStorage) {
-      this.uploadToGPU(dataId);
-    }
+  tempPixelArray.dispose();
+
+  return res as Tensor3D;
+}
+write(dataId: DataId, values: TypedArray): void {
+  if (values == null) {
+    throw new Error('MathBackendWebGL.write(): values can not be null');
   }
-  readSync(dataId: DataId): TypedArray {
-    this.throwIfNoData(dataId);
-    const texData = this.texData.get(dataId);
-    const {texture, values, texShape} = texData;
-    if (values != null) {
-      this.cacheOnCPU(dataId);
-      return values;
-    }
-    const shouldTimeProgram = this.activeTimers != null;
-    let start: number;
-    if (shouldTimeProgram) {
-      start = performance.now();
-    }
-    const float32Values =
-        this.gpgpu.downloadMatrixFromTexture(texture, texShape[0], texShape[1]);
-    if (shouldTimeProgram) {
-      this.downloadWaitMs += performance.now() - start;
-    }
+  this.throwIfNoData(dataId);
+
+  const texData = this.texData.get(dataId);
+  const {texture, texShape, texType} = texData;
+  if (texture != null) {
+    // Release the old texture.
+    this.textureManager.releaseTexture(texture, texShape, texType);
+    texData.texture = null;
+    texData.texShape = null;
+  }
+  texData.values = values;
+
+  if (!this.delayedStorage) {
+    this.uploadToGPU(dataId);
+  }
+}
+readSync(dataId: DataId): TypedArray {
+  this.throwIfNoData(dataId);
+  const texData = this.texData.get(dataId);
+  const {texture, values, texShape} = texData;
+  if (values != null) {
+    this.cacheOnCPU(dataId);
+    return values;
+  }
+  const shouldTimeProgram = this.activeTimers != null;
+  let start: number;
+  if (shouldTimeProgram) {
+    start = performance.now();
+  }
+  const float32Values =
+      this.gpgpu.downloadMatrixFromTexture(texture, texShape[0], texShape[1]);
+  if (shouldTimeProgram) {
+    this.downloadWaitMs += performance.now() - start;
+  }
+  this.cacheOnCPU(dataId, float32Values);
+  return texData.values;
+}
+async read(dataId: DataId): Promise<TypedArray> {
+  this.throwIfNoData(dataId);
+  const texData = this.texData.get(dataId);
+  const {texture, values, texShape} = texData;
+  if (values != null) {
+    this.cacheOnCPU(dataId);
+    return values;
+  }
+  if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
+    const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
+        texture, texShape[0], texShape[1]);
     this.cacheOnCPU(dataId, float32Values);
     return texData.values;
   }
-  async read(dataId: DataId): Promise<TypedArray> {
-    this.throwIfNoData(dataId);
-    const texData = this.texData.get(dataId);
-    const {texture, values, texShape} = texData;
-    if (values != null) {
-      this.cacheOnCPU(dataId);
-      return values;
-    }
-    if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
-      const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
-          texture, texShape[0], texShape[1]);
-      this.cacheOnCPU(dataId, float32Values);
-      return texData.values;
-    }
 
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 0) {
-      return this.readSync(dataId);
-    }
-
-    // Construct an empty query. We're just interested in getting a callback
-    // when the GPU command queue has executed until this point in time.
-    await this.gpgpu.runQuery(() => {});
+  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 0) {
     return this.readSync(dataId);
   }
 
-  async time(f: () => void): Promise<WebGLTimingInfo> {
-    const oldActiveTimers = this.activeTimers;
-    const newActiveTimers: TimerNode[] = [];
+  // Construct an empty query. We're just interested in getting a callback
+  // when the GPU command queue has executed until this point in time.
+  await this.gpgpu.runQuery(() => {});
+  return this.readSync(dataId);
+}
 
-    let outerMostTime = false;
-    if (this.programTimersStack == null) {
-      this.programTimersStack = newActiveTimers;
-      outerMostTime = true;
-    } else {
-      this.activeTimers.push(newActiveTimers);
-    }
-    this.activeTimers = newActiveTimers;
+async time(f: () => void): Promise<WebGLTimingInfo> {
+  const oldActiveTimers = this.activeTimers;
+  const newActiveTimers: TimerNode[] = [];
 
-    f();
-
-    const flattenedActiveTimers = util.flatten(this.activeTimers);
-    this.activeTimers = oldActiveTimers;
-
-    if (outerMostTime) {
-      this.programTimersStack = null;
-    }
-
-    const kernelMs = await Promise.all(flattenedActiveTimers).then(results => {
-      let sum = 0;
-      results.forEach(result => sum += result);
-      return sum;
-    });
-    const res: WebGLTimingInfo = {
-      uploadWaitMs: this.uploadWaitMs,
-      downloadWaitMs: this.downloadWaitMs,
-      kernelMs,
-      wallMs: null  // will be filled by the engine
-    };
-    this.uploadWaitMs = 0;
-    this.downloadWaitMs = 0;
-    return res;
+  let outerMostTime = false;
+  if (this.programTimersStack == null) {
+    this.programTimersStack = newActiveTimers;
+    outerMostTime = true;
+  } else {
+    this.activeTimers.push(newActiveTimers);
   }
-  memory() {
-    return {unreliable: false};
+  this.activeTimers = newActiveTimers;
+
+  f();
+
+  const flattenedActiveTimers = util.flatten(this.activeTimers);
+  this.activeTimers = oldActiveTimers;
+
+  if (outerMostTime) {
+    this.programTimersStack = null;
   }
 
-  private startTimer(): WebGLQuery|CPUTimerQuery {
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-      return this.gpgpu.beginQuery();
-    }
-    return {startMs: performance.now(), endMs: null};
-  }
+  const kernelMs = await Promise.all(flattenedActiveTimers).then(results => {
+    let sum = 0;
+    results.forEach(result => sum += result);
+    return sum;
+  });
+  const res: WebGLTimingInfo = {
+    uploadWaitMs: this.uploadWaitMs,
+    downloadWaitMs: this.downloadWaitMs,
+    kernelMs,
+    wallMs: null  // will be filled by the engine
+  };
+  this.uploadWaitMs = 0;
+  this.downloadWaitMs = 0;
+  return res;
+}
+memory() {
+  return {unreliable: false};
+}
 
-  private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
-      {startMs: number, endMs: number} {
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-      this.gpgpu.endQuery();
-      return query;
-    }
-    (query as CPUTimerQuery).endMs = performance.now();
+private startTimer(): WebGLQuery|CPUTimerQuery {
+  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+    return this.gpgpu.beginQuery();
+  }
+  return {startMs: performance.now(), endMs: null};
+}
+
+private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
+    {startMs: number, endMs: number} {
+  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+    this.gpgpu.endQuery();
     return query;
   }
+  (query as CPUTimerQuery).endMs = performance.now();
+  return query;
+}
 
-  private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
-      return this.gpgpu.pollQueryTime(query);
+private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
+  if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
+    return this.gpgpu.pollQueryTime(query);
+  }
+  const timerQuery = query as CPUTimerQuery;
+  return timerQuery.endMs - timerQuery.startMs;
+}
+
+disposeData(dataId: DataId): void {
+  if (this.texData.has(dataId)) {
+    const {texture, texShape, texType} = this.texData.get(dataId);
+    if (texture != null) {
+      this.textureManager.releaseTexture(texture, texShape, texType);
     }
-    const timerQuery = query as CPUTimerQuery;
-    return timerQuery.endMs - timerQuery.startMs;
-  }
-
-  disposeData(dataId: DataId): void {
-    if (this.texData.has(dataId)) {
-      const {texture, texShape, texType} = this.texData.get(dataId);
-      if (texture != null) {
-        this.textureManager.releaseTexture(texture, texShape, texType);
-      }
-      this.texData.delete(dataId);
-    }
-  }
-
-  getTexture(dataId: DataId): WebGLTexture {
-    this.uploadToGPU(dataId);
-    return this.texData.get(dataId).texture;
-  }
-
-  getTextureData(dataId: DataId): TextureData {
-    this.uploadToGPU(dataId);
-    return this.texData.get(dataId);
-  }
-
-  private textureManager: TextureManager;
-  private binaryCache: {[key: string]: GPGPUBinary} = {};
-  private gpgpuCreatedLocally: boolean;
-
-  constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
-    if (ENV.get('WEBGL_VERSION') < 1) {
-      throw new Error('WebGL is not supported on this device');
-    }
-    if (gpgpu == null) {
-      this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));
-      this.gpgpuCreatedLocally = true;
-    } else {
-      this.gpgpuCreatedLocally = false;
-    }
-
-    this.textureManager = new TextureManager(this.gpgpu);
-  }
-
-  getGPGPUContext(): GPGPUContext {
-    return this.gpgpu;
-  }
-  getCanvas(): HTMLCanvasElement {
-    return this.canvas;
-  }
-
-  slice<T extends Tensor>(x: T, begin: number[], size: number[]): T {
-    const program = new SliceProgram(size);
-    const customSetup = program.getCustomSetupFunc(begin);
-    return this.compileAndRun(program, [x], null, customSetup);
-  }
-
-  stridedSlice<T extends Tensor>(
-      x: T, begin: number[], end: number[], strides: number[],
-      beginMask: number, endMask: number): T {
-    const [beginIndex, size] =
-        getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
-
-    if (size.some(axis => axis === 0)) {
-      return ops.tensor([], size) as T;
-    }
-
-    const program = new StridedSliceProgram(beginIndex, strides, size);
-    return this.compileAndRun(program, [x]);
-  }
-
-  reverse<T extends Tensor>(x: T, axis: number[]): T {
-    const program = new ReverseProgram(x.shape, axis);
-    return this.compileAndRun(program, [x]);
-  }
-
-  // Concats 2d tensors along axis=1. See comments in MathBackend.concat().
-  concat(a: Tensor2D, b: Tensor2D): Tensor2D {
-    const program = new ConcatProgram(a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
-  }
-
-  neg<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.NEG);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
-      Tensor2D {
-    const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
-    return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
-  }
-
-  multiply(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
-    const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-    return this.compileAndRun(program, [a, b], output) as Tensor;
-  }
-
-  batchNormalization(
-      x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
-      varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
-      offset?: Tensor4D|Tensor1D): Tensor4D {
-    const inputs = [x, mean, variance];
-
-    let offsetShape = null;
-    if (offset != null) {
-      offsetShape = offset.shape;
-      inputs.push(offset);
-    }
-
-    let scaleShape = null;
-    if (scale != null) {
-      scaleShape = scale.shape;
-      inputs.push(scale);
-    }
-
-    const program = new BatchNormProgram(
-        x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
-        varianceEpsilon);
-    return this.compileAndRun(program, inputs);
-  }
-
-  localResponseNormalization4D(
-      x: Tensor4D, radius: number, bias: number, alpha: number,
-      beta: number): Tensor4D {
-    const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
-    return this.compileAndRun(program, [x]);
-  }
-
-  tile<T extends Tensor>(x: T, reps: number[]): T {
-    const program = new TileProgram(x.shape, reps);
-    return this.compileAndRun(program, [x]);
-  }
-
-  pad<T extends Tensor>(
-      x: T, paddings: Array<[number, number]>, constantValue: number): T {
-    const program = new PadProgram(x.shape, paddings, constantValue);
-    return this.compileAndRun(program, [x]);
-  }
-
-  transpose<T extends Tensor>(x: T, perm: number[]): T {
-    const program = new TransposeProgram(x.shape, perm);
-    return this.compileAndRun(program, [x]);
-  }
-
-  gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T {
-    const program = new GatherProgram(x.shape, indices.size, axis);
-    return this.compileAndRun(program, [x, indices]);
-  }
-
-  private reduce(x: Tensor2D, reduceType: 'max'|'min'|'sum', dtype: DataType):
-      Tensor2D {
-    const batchSize = x.shape[0];
-    const inSize = x.shape[1];
-    const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = {windowSize, inSize, batchSize};
-    const program = new ReduceProgram(reduceInfo, reduceType);
-    const [rows, cols] = program.outputShape;
-    const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
-    this.compileAndRun(program, [x], output);
-    // No need to run another GPGPU program.
-    if (output.shape[1] === 1) {
-      return output;
-    }
-    return this.reduce(output, reduceType, dtype);
-  }
-
-  private argReduce(
-      x: Tensor2D, reduceType: 'max'|'min',
-      bestIndicesA: Tensor2D = null): Tensor2D {
-    let batchSize = x.shape[0];
-    let inSize = x.shape[1];
-    if (bestIndicesA != null) {
-      batchSize = bestIndicesA.shape[0];
-      inSize = bestIndicesA.shape[1];
-    }
-    const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = {windowSize, inSize, batchSize};
-    const program =
-        new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
-    const [rows, cols] = program.outputShape;
-    const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
-    const inputs = [x];
-    if (bestIndicesA != null) {
-      inputs.push(bestIndicesA);
-    }
-    this.compileAndRun(program, inputs, output);
-    // No need to run another GPGPU program.
-    if (output.shape[1] === 1) {
-      return output;
-    }
-    return this.argReduce(x, reduceType, output);
-  }
-
-  sum(x: Tensor, axes: number[]): Tensor {
-    axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
-    const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const inSize = util.sizeFromShape(reduceShape);
-    const a2D = x.as2D(-1, inSize);
-    const outputDType = types.sumOutType(x.dtype);
-    return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
-  }
-
-  argMin(x: Tensor, axis: number): Tensor {
-    const axes = [axis];
-    axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
-    const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const inSize = util.sizeFromShape(reduceShape);
-    const a2D = x.as2D(-1, inSize);
-    return this.argReduce(a2D, 'min').reshape(outShape);
-  }
-
-  argMax(x: Tensor, axis: number): Tensor {
-    const axes = [axis];
-    axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
-    const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const inSize = util.sizeFromShape(reduceShape);
-    const a2D = x.as2D(-1, inSize);
-    return this.argReduce(a2D, 'max').reshape(outShape);
-  }
-
-  cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
-      Tensor {
-    if (axis !== x.rank - 1) {
-      throw new Error(
-          `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
-          `but got axis=${axis}`);
-    }
-    const program = new CumSumProgram(x.shape, exclusive, reverse);
-    return this.compileAndRun(program, [x]);
-  }
-
-  equal(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.EQUAL, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  notEqual(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  less(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.LESS, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  lessEqual(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  greater(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  greaterEqual(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  logicalNot<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.LOGICAL_NOT);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  logicalAnd(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  logicalOr(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, 'bool');
-    return this.compileAndRun(program, [a, b], output);
-  }
-
-  where(condition: Tensor, a: Tensor, b: Tensor, dtype: DataType): Tensor {
-    const program = new WhereProgram(condition.rank, a.shape, a.rank);
-    const output = this.makeOutputArray(program.outputShape, dtype);
-    return this.compileAndRun(program, [condition, a, b], output);
-  }
-
-  topKValues<T extends Tensor>(x: T, k: number): Tensor1D {
-    throw new Error('topKValues GPU not yet implemented!');
-  }
-
-  topKIndices(x: Tensor, k: number): Tensor1D {
-    throw new Error('topKIndices GPU not yet implemented!');
-  }
-
-  min(x: Tensor, axes: number[]): Tensor {
-    axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
-    const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const inSize = util.sizeFromShape(reduceShape);
-    const a2D = x.as2D(-1, inSize);
-    return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
-  }
-
-  minimum(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
-  }
-
-  mod(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
-  }
-
-  max(x: Tensor, axes: number[]): Tensor {
-    axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
-    const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const inSize = util.sizeFromShape(reduceShape);
-    const a2D = x.as2D(-1, inSize);
-    return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
-  }
-
-  maximum(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
-  }
-
-  squaredDifference(a: Tensor, b: Tensor): Tensor {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
-  }
-
-  divide(a: Tensor, b: Tensor): Tensor {
-    let op: string;
-    let outputDtype: 'float32'|'int32';
-    if (a.dtype === 'int32' && b.dtype === 'int32') {
-      op = binaryop_gpu.INT_DIV;
-      outputDtype = 'int32';
-    } else {
-      op = binaryop_gpu.DIV;
-      outputDtype = 'float32';
-    }
-
-    const program = new BinaryOpProgram(op, a.shape, b.shape);
-    const output = this.makeOutputArray(program.outputShape, outputDtype);
-    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-  }
-
-  add(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
-    const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-  }
-
-  subtract(a: Tensor, b: Tensor): Tensor {
-    const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
-    const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
-    return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
-  }
-
-  pow<T extends Tensor>(a: T, b: Tensor): T {
-    const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
-    const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
-    return this.compileAndRun<Tensor, T>(program, [a, b], output);
-  }
-
-  ceil<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.CEIL);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  floor<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.FLOOR);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  sign<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  round<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  exp<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.EXP);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  expm1<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.EXPM1);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  log<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.LOG);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  log1p<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.LOG1P);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  sqrt<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SQRT);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  rsqrt<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.RSQRT);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  square<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SQUARE);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  reciprocal<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.RECIPROCAL);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  relu<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.RELU);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  elu<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ELU);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  eluDer<T extends Tensor>(dy: T, y: T): T {
-    const program =
-        new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
-    return this.compileAndRun(program, [dy, y]) as T;
-  }
-
-  selu<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SELU);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  int<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
-    const output = this.makeOutputArray(program.outputShape, 'int32');
-    return this.compileAndRun(program, [x], output) as T;
-  }
-
-  clip<T extends Tensor>(x: T, min: number, max: number): T {
-    const program = new ClipProgram(x.shape, min, max);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  abs<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ABS);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  sigmoid<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SIGMOID);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  softplus<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SOFTPLUS);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  sin<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SIN);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  cos<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.COS);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  tan<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.TAN);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  asin<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ASIN);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  acos<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ACOS);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  atan<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ATAN);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  atan2<T extends Tensor>(a: T, b: T): T {
-    const program = new BinaryOpProgram(binaryop_gpu.ATAN2, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]) as T;
-  }
-
-  sinh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.SINH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  cosh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.COSH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  tanh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.TANH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  asinh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ASINH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  acosh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  atanh<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  erf<T extends Tensor>(x: T): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.ERF);
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  step<T extends Tensor>(x: T, alpha: number): T {
-    const program = new UnaryOpProgram(x.shape, unary_op.STEP(alpha));
-    return this.compileAndRun(program, [x]) as T;
-  }
-
-  conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-    const program = new Conv2DProgram(convInfo);
-    return this.compileAndRun(program, [x, filter]);
-  }
-
-  conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
-    const program = new Conv2DDerInputProgram(convInfo);
-    return this.compileAndRun(program, [dy, filter]);
-  }
-
-  conv2dDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-    const program = new Conv2DDerFilterProgram(convInfo);
-    return this.compileAndRun(program, [x, dy]);
-  }
-
-  depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
-    const program = new DepthwiseConv2DProgram(convInfo);
-    return this.compileAndRun(program, [x, filter]);
-  }
-
-  maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-    const program = new Pool2DProgram(convInfo, 'max', false);
-    const output =
-        this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
-    return this.compileAndRun(program, [x], output);
-  }
-
-  avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-    const program = new Pool2DProgram(convInfo, 'avg', false);
-    const output = this.makeOutputArray(program.outputShape, 'float32');
-    return this.compileAndRun(program, [x], output) as Tensor4D;
-  }
-
-  maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
-    const getPositions = true;
-    const maxPoolPositionsProgram =
-        new Pool2DProgram(convInfo, 'max', getPositions);
-    const maxPoolPositions: Tensor4D =
-        this.compileAndRun(maxPoolPositionsProgram, [x]);
-
-    const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
-    const output =
-        this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
-    const result = this.compileAndRun(
-        maxPoolBackPropProgram, [dy, maxPoolPositions], output);
-    maxPoolPositions.dispose();
-    return result as Tensor4D;
-  }
-
-  avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
-    const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
-    const output =
-        this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
-    return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
-  }
-
-  cast<T extends Tensor<types.Rank>>(x: T, dtype: DataType): T {
-    return backend_util.castTensor(x, dtype, this);
-  }
-
-  reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
-      x: T, shape: types.ShapeMap[R]): Tensor<R> {
-    return backend_util.reshapeTensor(x, shape);
-  }
-
-  resizeBilinear(
-      x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
-    const program =
-        new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
-    return this.compileAndRun(program, [x]);
-  }
-
-  resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):
-      Tensor4D {
-    const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
-
-    return this.compileAndRun(program, [dy]);
-  }
-
-  resizeNearestNeighbor(
-      x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
-    const program = new ResizeNearestNeighborProgram(
-        x.shape, newHeight, newWidth, alignCorners);
-    return this.compileAndRun(program, [x]);
-  }
-
-  multinomial(
-      logits: Tensor2D, normalized: boolean, numSamples: number,
-      seed: number): Tensor2D {
-    const probs = normalized ? logits : ops.softmax(logits);
-    const batchSize = probs.shape[0];
-    const numOutcomes = probs.shape[1];
-    const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
-    const output =
-        this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
-    const customSetup = program.getCustomSetupFunc(seed);
-    return this.compileAndRun(program, [probs], output, customSetup);
-  }
-
-  oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
-      Tensor2D {
-    const program = new OneHotProgram(indices.size, depth, onValue, offValue);
-    return this.compileAndRun(program, [indices]);
-  }
-
-  private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
-      T {
-    return Tensor.make(shape, {}, dtype) as T;
-  }
-
-  private compileAndRun<T extends Tensor, K extends Tensor>(
-      program: GPGPUProgram, inputs: T[], output?: K,
-      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
-      K {
-    if (output == null) {
-      output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
-    }
-    const inputsData: Array<TensorData<T>> = inputs.map(input => {
-      this.uploadToGPU(input.dataId);
-      return {tensor: input, texData: this.texData.get(input.dataId)};
-    });
-    this.uploadToGPU(output.dataId);
-    const outputData = {
-      tensor: output,
-      texData: this.texData.get(output.dataId)
-    };
-    const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
-    const binary = this.getAndSaveBinary(key, () => {
-      return gpgpu_math.compileProgram(
-          this.gpgpu, program, inputsData, outputData);
-    });
-    const shouldTimeProgram = this.activeTimers != null;
-    let query: WebGLQuery|CPUTimerQuery;
-    if (shouldTimeProgram) {
-      query = this.startTimer();
-    }
-
-    gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
-
-    if (shouldTimeProgram) {
-      query = this.endTimer(query);
-      this.activeTimers.push(this.getQueryTime(query));
-    }
+    this.texData.delete(dataId);
+  }
+}
+
+getTexture(dataId: DataId): WebGLTexture {
+  this.uploadToGPU(dataId);
+  return this.texData.get(dataId).texture;
+}
+
+getTextureData(dataId: DataId): TextureData {
+  this.uploadToGPU(dataId);
+  return this.texData.get(dataId);
+}
+
+private textureManager: TextureManager;
+private binaryCache: {[key: string]: GPGPUBinary} = {};
+private gpgpuCreatedLocally: boolean;
+
+constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
+  if (ENV.get('WEBGL_VERSION') < 1) {
+    throw new Error('WebGL is not supported on this device');
+  }
+  if (gpgpu == null) {
+    this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));
+    this.gpgpuCreatedLocally = true;
+  } else {
+    this.gpgpuCreatedLocally = false;
+  }
+
+  this.textureManager = new TextureManager(this.gpgpu);
+}
+
+getGPGPUContext(): GPGPUContext {
+  return this.gpgpu;
+}
+getCanvas(): HTMLCanvasElement {
+  return this.canvas;
+}
+
+slice<T extends Tensor>(x: T, begin: number[], size: number[]): T {
+  const program = new SliceProgram(size);
+  const customSetup = program.getCustomSetupFunc(begin);
+  return this.compileAndRun(program, [x], null, customSetup);
+}
+
+stridedSlice<T extends Tensor>(
+    x: T, begin: number[], end: number[], strides: number[], beginMask: number,
+    endMask: number): T {
+  const [beginIndex, size] =
+      getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
+
+  if (size.some(axis => axis === 0)) {
+    return ops.tensor([], size) as T;
+  }
+
+  const program = new StridedSliceProgram(beginIndex, strides, size);
+  return this.compileAndRun(program, [x]);
+}
+
+reverse<T extends Tensor>(x: T, axis: number[]): T {
+  const program = new ReverseProgram(x.shape, axis);
+  return this.compileAndRun(program, [x]);
+}
+
+// Concats 2d tensors along axis=1. See comments in MathBackend.concat().
+concat(a: Tensor2D, b: Tensor2D): Tensor2D {
+  const program = new ConcatProgram(a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]);
+}
+
+neg<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.NEG);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
+    Tensor2D {
+  const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
+  return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
+}
+
+multiply(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
+  const output =
+      this.makeOutputArray(
+          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+  return this.compileAndRun(program, [a, b], output) as Tensor;
+}
+
+batchNormalization(
+    x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
+    varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
+    offset?: Tensor4D|Tensor1D): Tensor4D {
+  const inputs = [x, mean, variance];
+
+  let offsetShape = null;
+  if (offset != null) {
+    offsetShape = offset.shape;
+    inputs.push(offset);
+  }
+
+  let scaleShape = null;
+  if (scale != null) {
+    scaleShape = scale.shape;
+    inputs.push(scale);
+  }
+
+  const program = new BatchNormProgram(
+      x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
+      varianceEpsilon);
+  return this.compileAndRun(program, inputs);
+}
+
+localResponseNormalization4D(
+    x: Tensor4D, radius: number, bias: number, alpha: number,
+    beta: number): Tensor4D {
+  const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
+  return this.compileAndRun(program, [x]);
+}
+
+tile<T extends Tensor>(x: T, reps: number[]): T {
+  const program = new TileProgram(x.shape, reps);
+  return this.compileAndRun(program, [x]);
+}
+
+pad<T extends Tensor>(
+    x: T, paddings: Array<[number, number]>, constantValue: number): T {
+  const program = new PadProgram(x.shape, paddings, constantValue);
+  return this.compileAndRun(program, [x]);
+}
+
+transpose<T extends Tensor>(x: T, perm: number[]): T {
+  const program = new TransposeProgram(x.shape, perm);
+  return this.compileAndRun(program, [x]);
+}
+
+gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T {
+  const program = new GatherProgram(x.shape, indices.size, axis);
+  return this.compileAndRun(program, [x, indices]);
+}
+
+private reduce(
+    x: Tensor2D, reduceType: 'max'|'min'|'sum', dtype: DataType): Tensor2D {
+  const batchSize = x.shape[0];
+  const inSize = x.shape[1];
+  const windowSize = reduce_util.computeOptimalWindowSize(inSize);
+  const reduceInfo = {windowSize, inSize, batchSize};
+  const program = new ReduceProgram(reduceInfo, reduceType);
+  const [rows, cols] = program.outputShape;
+  const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
+  this.compileAndRun(program, [x], output);
+  // No need to run another GPGPU program.
+  if (output.shape[1] === 1) {
     return output;
   }
+  return this.reduce(output, reduceType, dtype);
+}
 
-  private getAndSaveBinary(key: string, getBinary: () => GPGPUBinary):
-      GPGPUBinary {
-    if (!(key in this.binaryCache)) {
-      this.binaryCache[key] = getBinary();
-    }
-    return this.binaryCache[key];
+private argReduce(
+    x: Tensor2D, reduceType: 'max'|'min',
+    bestIndicesA: Tensor2D = null): Tensor2D {
+  let batchSize = x.shape[0];
+  let inSize = x.shape[1];
+  if (bestIndicesA != null) {
+    batchSize = bestIndicesA.shape[0];
+    inSize = bestIndicesA.shape[1];
+  }
+  const windowSize = reduce_util.computeOptimalWindowSize(inSize);
+  const reduceInfo = {windowSize, inSize, batchSize};
+  const program =
+      new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
+  const [rows, cols] = program.outputShape;
+  const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
+  const inputs = [x];
+  if (bestIndicesA != null) {
+    inputs.push(bestIndicesA);
+  }
+  this.compileAndRun(program, inputs, output);
+  // No need to run another GPGPU program.
+  if (output.shape[1] === 1) {
+    return output;
+  }
+  return this.argReduce(x, reduceType, output);
+}
+
+sum(x: Tensor, axes: number[]): Tensor {
+  axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
+  const [outShape, reduceShape] =
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
+  const inSize = util.sizeFromShape(reduceShape);
+  const a2D = x.as2D(-1, inSize);
+  const outputDType = types.sumOutType(x.dtype);
+  return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
+}
+
+argMin(x: Tensor, axis: number): Tensor {
+  const axes = [axis];
+  axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
+  const [outShape, reduceShape] =
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
+  const inSize = util.sizeFromShape(reduceShape);
+  const a2D = x.as2D(-1, inSize);
+  return this.argReduce(a2D, 'min').reshape(outShape);
+}
+
+argMax(x: Tensor, axis: number): Tensor {
+  const axes = [axis];
+  axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
+  const [outShape, reduceShape] =
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
+  const inSize = util.sizeFromShape(reduceShape);
+  const a2D = x.as2D(-1, inSize);
+  return this.argReduce(a2D, 'max').reshape(outShape);
+}
+
+cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean): Tensor {
+  if (axis !== x.rank - 1) {
+    throw new Error(
+        `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
+        `but got axis=${axis}`);
+  }
+  const program = new CumSumProgram(x.shape, exclusive, reverse);
+  return this.compileAndRun(program, [x]);
+}
+
+equal(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.EQUAL, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+notEqual(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+less(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.LESS, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+lessEqual(a: Tensor, b: Tensor): Tensor {
+  const program =
+      new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+greater(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+greaterEqual(a: Tensor, b: Tensor): Tensor {
+  const program =
+      new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+logicalNot<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.LOGICAL_NOT);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+logicalAnd(a: Tensor, b: Tensor): Tensor {
+  const program =
+      new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+logicalOr(a: Tensor, b: Tensor): Tensor {
+  const program =
+      new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, 'bool');
+  return this.compileAndRun(program, [a, b], output);
+}
+
+where(condition: Tensor, a: Tensor, b: Tensor, dtype: DataType): Tensor {
+  const program = new WhereProgram(condition.rank, a.shape, a.rank);
+  const output = this.makeOutputArray(program.outputShape, dtype);
+  return this.compileAndRun(program, [condition, a, b], output);
+}
+
+topKValues<T extends Tensor>(x: T, k: number): Tensor1D {
+  throw new Error('topKValues GPU not yet implemented!');
+}
+
+topKIndices(x: Tensor, k: number): Tensor1D {
+  throw new Error('topKIndices GPU not yet implemented!');
+}
+
+min(x: Tensor, axes: number[]): Tensor {
+  axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
+  const [outShape, reduceShape] =
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
+  const inSize = util.sizeFromShape(reduceShape);
+  const a2D = x.as2D(-1, inSize);
+  return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
+}
+
+minimum(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]);
+}
+
+mod(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]);
+}
+
+max(x: Tensor, axes: number[]): Tensor {
+  axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
+  const [outShape, reduceShape] =
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
+  const inSize = util.sizeFromShape(reduceShape);
+  const a2D = x.as2D(-1, inSize);
+  return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
+}
+
+maximum(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]);
+}
+
+squaredDifference(a: Tensor, b: Tensor): Tensor {
+  const program =
+      new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]);
+}
+
+divide(a: Tensor, b: Tensor): Tensor {
+  let op: string;
+  let outputDtype: 'float32'|'int32';
+  if (a.dtype === 'int32' && b.dtype === 'int32') {
+    op = binaryop_gpu.INT_DIV;
+    outputDtype = 'int32';
+  } else {
+    op = binaryop_gpu.DIV;
+    outputDtype = 'float32';
   }
 
-  getTextureManager(): TextureManager {
-    return this.textureManager;
+  const program = new BinaryOpProgram(op, a.shape, b.shape);
+  const output = this.makeOutputArray(program.outputShape, outputDtype);
+  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+}
+
+add(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
+  const output =
+      this.makeOutputArray(
+          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+}
+
+subtract(a: Tensor, b: Tensor): Tensor {
+  const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
+  const output =
+      this.makeOutputArray(
+          program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+  return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
+}
+
+pow<T extends Tensor>(a: T, b: Tensor): T {
+  const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
+  const output =
+      this.makeOutputArray(
+          program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
+  return this.compileAndRun<Tensor, T>(program, [a, b], output);
+}
+
+ceil<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.CEIL);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+floor<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.FLOOR);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+sign<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+round<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ROUND);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+exp<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.EXP);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+expm1<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.EXPM1);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+log<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.LOG);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+log1p<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.LOG1P);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+sqrt<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SQRT);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+rsqrt<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.RSQRT);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+square<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SQUARE);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+reciprocal<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.RECIPROCAL);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+relu<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.RELU);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+elu<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ELU);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+eluDer<T extends Tensor>(dy: T, y: T): T {
+  const program = new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
+  return this.compileAndRun(program, [dy, y]) as T;
+}
+
+selu<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SELU);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+int<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
+  const output = this.makeOutputArray(program.outputShape, 'int32');
+  return this.compileAndRun(program, [x], output) as T;
+}
+
+clip<T extends Tensor>(x: T, min: number, max: number): T {
+  const program = new ClipProgram(x.shape, min, max);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+abs<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ABS);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+sigmoid<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SIGMOID);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+softplus<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SOFTPLUS);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+sin<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SIN);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+cos<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.COS);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+tan<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.TAN);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+asin<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ASIN);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+acos<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ACOS);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+atan<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ATAN);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+atan2<T extends Tensor>(a: T, b: T): T {
+  const program = new BinaryOpProgram(binaryop_gpu.ATAN2, a.shape, b.shape);
+  return this.compileAndRun(program, [a, b]) as T;
+}
+
+sinh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.SINH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+cosh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.COSH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+tanh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.TANH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+asinh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ASINH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+acosh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+atanh<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+erf<T extends Tensor>(x: T): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.ERF);
+  return this.compileAndRun(program, [x]) as T;
+}
+
+step<T extends Tensor>(x: T, alpha: number): T {
+  const program = new UnaryOpProgram(x.shape, unary_op.STEP(alpha));
+  return this.compileAndRun(program, [x]) as T;
+}
+
+conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new Conv2DProgram(convInfo);
+  return this.compileAndRun(program, [x, filter]);
+}
+
+conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new Conv2DDerInputProgram(convInfo);
+  return this.compileAndRun(program, [dy, filter]);
+}
+
+conv2dDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new Conv2DDerFilterProgram(convInfo);
+  return this.compileAndRun(program, [x, dy]);
+}
+
+depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new DepthwiseConv2DProgram(convInfo);
+  return this.compileAndRun(program, [x, filter]);
+}
+
+maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new Pool2DProgram(convInfo, 'max', false);
+  const output = this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
+  return this.compileAndRun(program, [x], output);
+}
+
+avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const program = new Pool2DProgram(convInfo, 'avg', false);
+  const output = this.makeOutputArray(program.outputShape, 'float32');
+  return this.compileAndRun(program, [x], output) as Tensor4D;
+}
+
+maxPoolBackprop(
+    dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const getPositions = true;
+  const maxPoolPositionsProgram =
+      new Pool2DProgram(convInfo, 'max', getPositions);
+  const maxPoolPositions: Tensor4D =
+      this.compileAndRun(maxPoolPositionsProgram, [x]);
+
+  const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
+  const output =
+      this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
+  const result = this.compileAndRun(
+      maxPoolBackPropProgram, [dy, maxPoolPositions], output);
+  maxPoolPositions.dispose();
+  return result as Tensor4D;
+}
+
+avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+  const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
+  const output =
+      this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
+  return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
+}
+
+cast<T extends Tensor<types.Rank>>(x: T, dtype: DataType): T {
+  return backend_util.castTensor(x, dtype, this);
+}
+
+reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
+    x: T, shape: types.ShapeMap[R]): Tensor<R> {
+  return backend_util.reshapeTensor(x, shape);
+}
+
+resizeBilinear(
+    x: Tensor4D, newHeight: number, newWidth: number,
+    alignCorners: boolean): Tensor4D {
+  const program =
+      new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
+  return this.compileAndRun(program, [x]);
+}
+
+resizeBilinearBackprop(
+    dy: Tensor4D, x: Tensor4D, alignCorners: boolean): Tensor4D {
+  const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
+
+  return this.compileAndRun(program, [dy]);
+}
+
+resizeNearestNeighbor(
+    x: Tensor4D, newHeight: number, newWidth: number,
+    alignCorners: boolean): Tensor4D {
+  const program = new ResizeNearestNeighborProgram(
+      x.shape, newHeight, newWidth, alignCorners);
+  return this.compileAndRun(program, [x]);
+}
+
+multinomial(
+    logits: Tensor2D, normalized: boolean, numSamples: number,
+    seed: number): Tensor2D {
+  const probs = normalized ? logits : ops.softmax(logits);
+  const batchSize = probs.shape[0];
+  const numOutcomes = probs.shape[1];
+  const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
+  const output = this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
+  const customSetup = program.getCustomSetupFunc(seed);
+  return this.compileAndRun(program, [probs], output, customSetup);
+}
+
+oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
+    Tensor2D {
+  const program = new OneHotProgram(indices.size, depth, onValue, offValue);
+  return this.compileAndRun(program, [indices]);
+}
+
+private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType): T {
+  return Tensor.make(shape, {}, dtype) as T;
+}
+
+private compileAndRun<T extends Tensor, K extends Tensor>(
+    program: GPGPUProgram, inputs: T[], output?: K,
+    customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) =>
+        void): K {
+  if (output == null) {
+    output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
+  }
+  const inputsData: Array<TensorData<T>> = inputs.map(input => {
+    this.uploadToGPU(input.dataId);
+    return {tensor: input, texData: this.texData.get(input.dataId)};
+  });
+  this.uploadToGPU(output.dataId);
+  const outputData = {tensor: output, texData: this.texData.get(output.dataId)};
+  const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
+  const binary = this.getAndSaveBinary(key, () => {
+    return gpgpu_math.compileProgram(
+        this.gpgpu, program, inputsData, outputData);
+  });
+  const shouldTimeProgram = this.activeTimers != null;
+  let query: WebGLQuery|CPUTimerQuery;
+  if (shouldTimeProgram) {
+    query = this.startTimer();
   }
 
-  private disposed = false;
+  gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
 
-  dispose() {
-    if (this.disposed) {
-      return;
-    }
-    for (const key in this.binaryCache) {
-      this.gpgpu.deleteProgram(this.binaryCache[key].webGLProgram);
-    }
-    this.textureManager.dispose();
-    this.canvas.remove();
-    if (this.gpgpuCreatedLocally) {
-      this.gpgpu.dispose();
-    }
-    this.disposed = true;
+  if (shouldTimeProgram) {
+    query = this.endTimer(query);
+    this.activeTimers.push(this.getQueryTime(query));
   }
+  return output;
+}
 
-  private throwIfNoData(dataId: DataId) {
-    if (!this.texData.has(dataId)) {
-      throw new Error(
-          `WebGL backend: No data found for this tensor. ` +
-          `Did you change your backend in the middle of the program? ` +
-          `New backends can't use Tensors created with previous backends`);
-    }
+private getAndSaveBinary(
+    key: string, getBinary: () => GPGPUBinary): GPGPUBinary {
+  if (!(key in this.binaryCache)) {
+    this.binaryCache[key] = getBinary();
   }
+  return this.binaryCache[key];
+}
 
-  private uploadToGPU(dataId: DataId): void {
-    this.throwIfNoData(dataId);
-    const texData = this.texData.get(dataId);
-    const {shape, values, texture, dtype, texType} = texData;
-    if (texture != null) {
-      // Array is already on GPU. No-op.
-      return;
-    }
-    const shouldTimeProgram = this.activeTimers != null;
-    let start: number;
+getTextureManager(): TextureManager {
+  return this.textureManager;
+}
+
+private disposed = false;
+
+dispose() {
+  if (this.disposed) {
+    return;
+  }
+  for (const key in this.binaryCache) {
+    this.gpgpu.deleteProgram(this.binaryCache[key].webGLProgram);
+  }
+  this.textureManager.dispose();
+  this.canvas.remove();
+  if (this.gpgpuCreatedLocally) {
+    this.gpgpu.dispose();
+  }
+  this.disposed = true;
+}
+
+private throwIfNoData(dataId: DataId) {
+  if (!this.texData.has(dataId)) {
+    throw new Error(
+        `WebGL backend: No data found for this tensor. ` +
+        `Did you change your backend in the middle of the program? ` +
+        `New backends can't use Tensors created with previous backends`);
+  }
+}
+
+private uploadToGPU(dataId: DataId): void {
+  this.throwIfNoData(dataId);
+  const texData = this.texData.get(dataId);
+  const {shape, values, texture, dtype, texType} = texData;
+  if (texture != null) {
+    // Array is already on GPU. No-op.
+    return;
+  }
+  const shouldTimeProgram = this.activeTimers != null;
+  let start: number;
+  if (shouldTimeProgram) {
+    start = performance.now();
+  }
+  const texShape =
+      webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+  texData.texShape = texShape;
+  const newTexture = this.textureManager.acquireTexture(texShape, texType);
+  texData.texture = newTexture;
+  if (values != null) {
+    this.gpgpu.uploadMatrixToTexture(
+        newTexture, texShape[0],
+        // TODO(smilkov): Propagate the original typed array to gpgpu.
+        texShape[1], typedArrayToFloat32(values, dtype));
+    // Once uploaded, don't store the values on cpu.
+    texData.values = null;
     if (shouldTimeProgram) {
-      start = performance.now();
-    }
-    const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
-    texData.texShape = texShape;
-    const newTexture = this.textureManager.acquireTexture(texShape, texType);
-    texData.texture = newTexture;
-    if (values != null) {
-      this.gpgpu.uploadMatrixToTexture(
-          newTexture, texShape[0],
-          // TODO(smilkov): Propagate the original typed array to gpgpu.
-          texShape[1], typedArrayToFloat32(values, dtype));
-      // Once uploaded, don't store the values on cpu.
-      texData.values = null;
-      if (shouldTimeProgram) {
-        this.uploadWaitMs += performance.now() - start;
-      }
+      this.uploadWaitMs += performance.now() - start;
     }
   }
+}
 
-  private cacheOnCPU(dataId: DataId, float32Values?: Float32Array) {
-    // In delayed storage mode, when the user reads data, we don't keep a copy
-    // on the gpu, to minimize likelihood of memory leak. We re-upload to gpu
-    // the next time a gpgpu program needs the texture.
-    const dontKeepCopyOnGPU = this.delayedStorage;
-    const texData = this.texData.get(dataId);
-    const {texture, texShape, dtype, texType} = texData;
-    if (dontKeepCopyOnGPU && texture != null) {
-      this.textureManager.releaseTexture(texture, texShape, texType);
-      texData.texture = null;
-      texData.texShape = null;
-    }
-    if (float32Values != null) {
-      texData.values = float32ToTypedArray(float32Values, dtype);
-    }
+private cacheOnCPU(dataId: DataId, float32Values?: Float32Array) {
+  // In delayed storage mode, when the user reads data, we don't keep a copy
+  // on the gpu, to minimize likelihood of memory leak. We re-upload to gpu
+  // the next time a gpgpu program needs the texture.
+  const dontKeepCopyOnGPU = this.delayedStorage;
+  const texData = this.texData.get(dataId);
+  const {texture, texShape, dtype, texType} = texData;
+  if (dontKeepCopyOnGPU && texture != null) {
+    this.textureManager.releaseTexture(texture, texShape, texType);
+    texData.texture = null;
+    texData.texShape = null;
   }
+  if (float32Values != null) {
+    texData.values = float32ToTypedArray(float32Values, dtype);
+  }
+}
 }
 
 ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -120,9 +120,13 @@ export class MathBackendWebGL implements KernelBackend {
 
     if (pixels instanceof HTMLVideoElement) {
       if (this.canvas == null) {
-        throw new Error(
-            'Can\'t read pixels from HTMLImageElement outside ' +
-            'the browser.');
+        if (typeof document !== 'undefined') {
+          this.canvas = document.createElement('canvas');
+        } else {
+          throw new Error(
+              'Can\'t read pixels from HTMLImageElement outside ' +
+              'the browser.');
+        }
       }
       this.canvas.width = pixels.width;
       this.canvas.height = pixels.height;
@@ -302,9 +306,6 @@ export class MathBackendWebGL implements KernelBackend {
   constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
     if (ENV.get('WEBGL_VERSION') < 1) {
       throw new Error('WebGL is not supported on this device');
-    }
-    if (typeof document !== 'undefined') {
-      this.canvas = document.createElement('canvas');
     }
     if (gpgpu == null) {
       this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -120,6 +120,12 @@ export class MathBackendWebGL implements KernelBackend {
 
     if (pixels instanceof HTMLVideoElement) {
       if (this.canvas == null) {
+        if (document.readyState !== 'complete') {
+          throw new Error(
+              'The DOM is not ready yet. Please call tf.fromPixels() ' +
+              'once the DOM is ready. One way to do that is to add an event ' +
+              'listener for `DOMContentLoaded` on the document object');
+        }
         if (typeof document !== 'undefined') {
           this.canvas = document.createElement('canvas');
         } else {


### PR DESCRIPTION
BUG Since a newer version of Chrome, you have to create the canvas element when the DOM is ready in order to get a 2d rendering context. This PR postpones the creation of the canvas element until the user calls fromPixels(). This makes the webcam-transfer-learning example work.

Fixes https://github.com/tensorflow/tfjs/issues/313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1064)
<!-- Reviewable:end -->
