### PR TITLE
gradients for depthwise 2d convolutions

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -166,6 +166,8 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
 
   depthwiseConv2D(input: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
       Tensor4D;
+  depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D;
 
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
   maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -168,6 +168,8 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
       Tensor4D;
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
       Tensor4D;
+  depthwiseConv2DDerFilter(x: Tensor4D, dY: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D;
 
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
   maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -1243,10 +1243,8 @@ export class MathBackendCPU implements KernelBackend {
                 const fltOffset = fltS0 * (filterHeight - 1 - wR) +
                     fltS1 * (filterWidth - 1 - wC) + fltS2 * d1;
 
-                const d2Min = d1 * chMul;
-                const d2Max = d2Min + chMul;
-                for (let d2 = d2Min; d2 < d2Max; ++d2) {
-                  const dm = d2 - d2Min;
+                for (let dm = 0; dm < chMul; ++dm) {
+                  const d2 = d1 * chMul + dm;
                   const pixel = dyValues[dyOffset + d2];
                   const weight = fltValues[fltOffset + dm];
                   dotProd += pixel * weight;

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -1193,6 +1193,116 @@ export class MathBackendCPU implements KernelBackend {
     return y.toTensor();
   }
 
+  depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    const dx = ops.buffer<Rank.R4>(convInfo.inShape, 'float32');
+    const dxValues = dx.values;
+    const [dxS0, dxS1, dxS2] = dx.strides;
+    const dyValues = dy.dataSync();
+    const [dyS0, dyS1, dyS2] = dy.strides;
+    const fltValues = filter.dataSync();
+    const [fltS0, fltS1, fltS2] = filter.strides;
+    const {
+      batchSize,
+      filterHeight,
+      filterWidth,
+      inChannels,
+      inHeight,
+      inWidth,
+      outChannels,
+      outHeight,
+      outWidth,
+      strideHeight,
+      strideWidth
+    } = convInfo;
+    const topPad = filterHeight - 1 - convInfo.padInfo.top;
+    const leftPad = filterWidth - 1 - convInfo.padInfo.left;
+    const chMul = outChannels / inChannels;
+
+    for (let b = 0; b < batchSize; ++b) {
+      for (let d1 = 0; d1 < inChannels; ++d1) {
+        for (let xR = 0; xR < inHeight; ++xR) {
+          const xRCorner = xR - topPad;
+          const xRMin = Math.max(0, Math.ceil(xRCorner / strideHeight));
+          const yRMax =
+              Math.min(outHeight, (filterHeight + xRCorner) / strideHeight);
+
+          for (let xC = 0; xC < inWidth; ++xC) {
+            const xCCorner = xC - leftPad;
+            const xCMin = Math.max(0, Math.ceil(xCCorner / strideWidth));
+            const yCMax =
+                Math.min(outWidth, (filterWidth + xCCorner) / strideWidth);
+
+            let dotProd = 0;
+            for (let yR = xRMin; yR < yRMax; ++yR) {
+              const wR = yR * strideHeight - xRCorner;
+
+              for (let yC = xCMin; yC < yCMax; ++yC) {
+                const wC = yC * strideWidth - xCCorner;
+                const dyOffset = dyS0 * b + dyS1 * yR + dyS2 * yC;
+                const fltOffset = fltS0 * (filterHeight - 1 - wR) +
+                    fltS1 * (filterWidth - 1 - wC) + fltS2 * d1;
+
+                const d2Min = d1 * chMul;
+                const d2Max = d2Min + chMul;
+                for (let d2 = d2Min; d2 < d2Max; ++d2) {
+                  const dm = d2 - d2Min;
+                  const pixel = dyValues[dyOffset + d2];
+                  const weight = fltValues[fltOffset + dm];
+                  dotProd += pixel * weight;
+                }
+              }
+            }
+            dxValues[dxS0 * b + dxS1 * xR + dxS2 * xC + d1] = dotProd;
+          }
+        }
+      }
+    }
+    return dx.toTensor();
+  }
+
+  /*depthwiseConv2DDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    const strideHeight = convInfo.strideHeight;
+    const strideWidth = convInfo.strideWidth;
+    const filterHeight = convInfo.filterHeight;
+    const filterWidth = convInfo.filterWidth;
+    const dW = ops.buffer<Rank.R4>(convInfo.filterShape, 'float32');
+
+    const leftPad = convInfo.padInfo.left;
+    const topPad = convInfo.padInfo.top;
+
+    for (let wR = 0; wR < filterHeight; ++wR) {
+      const yRMin = Math.max(0, Math.ceil((topPad - wR) / strideHeight));
+      const yRMax = Math.min(
+          convInfo.outHeight, (convInfo.inHeight + topPad - wR) / strideHeight);
+
+      for (let wC = 0; wC < filterWidth; ++wC) {
+        const yCMin = Math.max(0, Math.ceil((leftPad - wC) / strideWidth));
+        const yCMax = Math.min(
+            convInfo.outWidth, (convInfo.inWidth + leftPad - wC) / strideWidth);
+
+        for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
+          for (let d2 = 0; d2 < convInfo.outChannels; ++d2) {
+            // Need to convolve.
+            let dotProd = 0;
+            for (let b = 0; b < convInfo.batchSize; ++b) {
+              for (let yR = yRMin; yR < yRMax; ++yR) {
+                const xR = wR + yR * strideHeight - topPad;
+                for (let yC = yCMin; yC < yCMax; ++yC) {
+                  const xC = wC + yC * strideWidth - leftPad;
+                  dotProd += x.get(b, xR, xC, d1) * dy.get(b, yR, yC, d2);
+                }
+              }
+            }
+            dW.set(dotProd, wR, wC, d1, d2);
+          }
+        }
+      }
+    }
+    return dW.toTensor();
+  }*/
+
   tile<T extends Tensor>(x: T, reps: number[]): T {
     const newShape: number[] = new Array(x.rank);
     for (let i = 0; i < newShape.length; i++) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -39,6 +39,8 @@ import {ClipProgram} from './webgl/clip_gpu';
 import {ConcatProgram} from './webgl/concat_gpu';
 // tslint:disable-next-line:max-line-length
 import {Conv2DDerFilterProgram, Conv2DDerInputProgram} from './webgl/conv_backprop_gpu';
+// tslint:disable-next-line:max-line-length
+import {DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram} from './webgl/conv_backprop_gpu_depthwise';
 import {Conv2DProgram} from './webgl/conv_gpu';
 import {DepthwiseConv2DProgram} from './webgl/conv_gpu_depthwise';
 import {CumSumProgram} from './webgl/cumsum_gpu';
@@ -876,16 +878,14 @@ export class MathBackendWebGL implements KernelBackend {
 
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
       Tensor4D {
-    // TODO: implement
-    util.assert(false, 'not implemented');
-    return dy;
+    const program = new DepthwiseConv2DDerInputProgram(convInfo);
+    return this.compileAndRun(program, [dy, filter]);
   }
 
   depthwiseConv2DDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo):
       Tensor4D {
-    // TODO: implement
-    util.assert(false, 'not implemented');
-    return dy;
+    const program = new DepthwiseConv2DDerFilterProgram(convInfo);
+    return this.compileAndRun(program, [x, dy]);
   }
 
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -876,6 +876,15 @@ export class MathBackendWebGL implements KernelBackend {
 
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
       Tensor4D {
+    // TODO: implement
+    util.assert(false, 'not implemented');
+    return dy;
+  }
+
+  depthwiseConv2DDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    // TODO: implement
+    util.assert(false, 'not implemented');
     return dy;
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -874,6 +874,11 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [x, filter]);
   }
 
+  depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
+      Tensor4D {
+    return dy;
+  }
+
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
     const program = new Pool2DProgram(convInfo, 'max', false);
     const output =

--- a/src/kernels/webgl/conv_backprop_gpu_depthwise.ts
+++ b/src/kernels/webgl/conv_backprop_gpu_depthwise.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Conv2DInfo} from '../../ops/conv_util';
+import {GPGPUProgram} from './gpgpu_math';
+
+export class DepthwiseConv2DDerFilterProgram implements GPGPUProgram {
+  variableNames = ['x', 'dy'];
+  outputShape: number[];
+  userCode: string;
+
+  constructor(convInfo: Conv2DInfo) {
+    this.outputShape = convInfo.filterShape;
+
+    const strideHeight = convInfo.strideHeight;
+    const strideWidth = convInfo.strideWidth;
+    const padTop = convInfo.padInfo.top;
+    const padLeft = convInfo.padInfo.left;
+    const channelMul = convInfo.outChannels / convInfo.inChannels;
+
+    this.userCode = `
+      void main() {
+        ivec4 coords = getOutputCoords();
+        int wR = coords.x;
+        int wC = coords.y;
+        int d1 = coords.z;
+        int dm = coords.w;
+        int d2 = d1 * ${channelMul} + dm;
+
+        float dotProd = 0.0;
+
+        for (int b = 0; b < ${convInfo.batchSize}; b++) {
+          for (int yR = 0; yR < ${convInfo.outHeight}; yR++) {
+            int xR = wR + yR * ${strideHeight} - ${padTop};
+
+            if (xR < 0 || xR >= ${convInfo.inHeight}) {
+              continue;
+            }
+
+            for (int yC = 0; yC < ${convInfo.outWidth}; yC++) {
+              int xC = wC + yC * ${strideWidth} - ${padLeft};
+
+              if (xC < 0 || xC >= ${convInfo.inWidth}) {
+                continue;
+              }
+
+              float dyValue = getDy(b, yR, yC, d2);
+              float xValue = getX(b, xR, xC, d1);
+              dotProd += (xValue * dyValue);
+            }
+          }
+        }
+        setOutput(dotProd);
+      }
+    `;
+  }
+}
+
+export class DepthwiseConv2DDerInputProgram implements GPGPUProgram {
+  variableNames = ['dy', 'W'];
+  outputShape: number[];
+  userCode: string;
+
+  constructor(convInfo: Conv2DInfo) {
+    this.outputShape = convInfo.inShape;
+
+    const filterHeight = convInfo.filterHeight;
+    const filterWidth = convInfo.filterWidth;
+    const strideHeight = convInfo.strideHeight;
+    const strideWidth = convInfo.strideWidth;
+
+    const padTop = filterHeight - 1 - convInfo.padInfo.top;
+    const padLeft = filterWidth - 1 - convInfo.padInfo.left;
+    const channelMul = convInfo.outChannels / convInfo.inChannels;
+
+    this.userCode = `
+      const ivec2 pads = ivec2(${padTop}, ${padLeft});
+
+      void main() {
+        ivec4 coords = getOutputCoords();
+        int batch = coords[0];
+        int d1 = coords[3];
+        ivec2 dyCorner = coords.yz - pads;
+        int dyRCorner = dyCorner.x;
+        int dyCCorner = dyCorner.y;
+
+        float dotProd = 0.0;
+
+        for (int wR = 0; wR < ${filterHeight}; wR++) {
+          float dyR = float(dyRCorner + wR) / ${strideHeight}.0;
+
+          if (dyR < 0.0 || dyR >= ${convInfo.outHeight}.0 || fract(dyR) > 0.0) {
+            continue;
+          }
+          int idyR = int(dyR);
+
+          int wRPerm = ${filterHeight} - 1 - wR;
+
+          for (int wC = 0; wC < ${filterWidth}; wC++) {
+            float dyC = float(dyCCorner + wC) / ${strideWidth}.0;
+
+            if (dyC < 0.0 || dyC >= ${convInfo.outWidth}.0 ||
+                fract(dyC) > 0.0) {
+              continue;
+            }
+            int idyC = int(dyC);
+
+            int wCPerm = ${filterWidth} - 1 - wC;
+
+            for (int dm = 0; dm < ${channelMul}; dm++) {
+              int d2 = d1 * ${channelMul} + dm;
+              float xValue = getDy(batch, idyR, idyC, d2);
+              float wValue = getW(wRPerm, wCPerm, d1, dm);
+              dotProd += xValue * wValue;
+            }
+          }
+        }
+        setOutput(dotProd);
+      }
+    `;
+  }
+}

--- a/src/kernels/webgl/conv_backprop_gpu_depthwise.ts
+++ b/src/kernels/webgl/conv_backprop_gpu_depthwise.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,6 +43,7 @@ export class DepthwiseConv2DDerFilterProgram implements GPGPUProgram {
 
         float dotProd = 0.0;
 
+        // TODO: Vec4 over the batch size
         for (int b = 0; b < ${convInfo.batchSize}; b++) {
           for (int yR = 0; yR < ${convInfo.outHeight}; yR++) {
             int xR = wR + yR * ${strideHeight} - ${padTop};
@@ -121,6 +122,7 @@ export class DepthwiseConv2DDerInputProgram implements GPGPUProgram {
 
             int wCPerm = ${filterWidth} - 1 - wC;
 
+            // TODO: Vec4 over the channelMul
             for (int dm = 0; dm < ${channelMul}; dm++) {
               int d2 = d1 * ${channelMul} + dm;
               float xValue = getDy(batch, idyR, idyC, d2);

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -546,8 +546,8 @@ export class ConvOps {
     const outDepth = dy4D.shape[3];
     util.assert(
         xShape4D.length === 4,
-        `Error in depthwiseConv2DDerInput: inShape must be length 4, but got length ` +
-            `${xShape4D.length}.`);
+        `Error in depthwiseConv2DDerInput: inShape must be length 4, but ` +
+            `got length ${xShape4D.length}.`);
     util.assert(
         dy4D.rank === 4,
         `Error in depthwiseConv2DDerInput: dy must be rank 4, but got ` +
@@ -568,8 +568,8 @@ export class ConvOps {
     if (dimRoundingMode != null) {
       util.assert(
           util.isInt(pad as number),
-          `Error in depthwiseConv2DDerInput: pad must be an integer when using, ` +
-              `dimRoundingMode ${dimRoundingMode} but got pad ${pad}.`);
+          `Error in depthwiseConv2DDerInput: pad must be an integer when ` +
+              `using dimRoundingMode ${dimRoundingMode}, but got pad ${pad}.`);
     }
 
     const dilations = 1;
@@ -621,21 +621,20 @@ export class ConvOps {
     }
     util.assert(
         x4D.rank === 4,
-        `Error in depthwiseConv2DDerFilter: input must be rank 4, but got shape ` +
-            `${x4D.shape}.`);
+        `Error in depthwiseConv2DDerFilter: input must be rank 4, ` +
+            `but got shape ${x4D.shape}.`);
     util.assert(
         dy4D.rank === 4,
-        `Error in depthwiseConv2DDerFilter: dy must be rank 4, but got shape ` +
-            `${dy4D.shape}.`);
+        `Error in depthwiseConv2DDerFilter: dy must be rank 4, ` +
+            `but got shape ${dy4D.shape}.`);
     util.assert(
         filterShape.length === 4,
-        `Error in depthwiseConv2DDerFilter: filterShape must be length 4, but got ` +
-            `${filterShape}.`);
+        `Error in depthwiseConv2DDerFilter: filterShape must be length 4, ` +
+            `but got shape ${filterShape}.`);
     util.assert(
         x4D.shape[3] === filterShape[2],
-        `Error in depthwiseConv2DDerFilter: depth of input ${
-            x4D.shape[3]}) must ` +
-            `match input depth in filter (${filterShape[2]}.`);
+        `Error in depthwiseConv2DDerFilter: depth of input ${x4D.shape[3]}) ` +
+            `must match input depth in filter (${filterShape[2]}.`);
     util.assert(
         dy4D.shape[3] === filterShape[3] * x4D.shape[3],
         `Error in depthwiseConv2DDerFilter: depth of dy (${dy4D.shape[3]}) ` +
@@ -643,8 +642,8 @@ export class ConvOps {
     if (dimRoundingMode != null) {
       util.assert(
           util.isInt(pad as number),
-          `Error in depthwiseConv2DDerFilter: pad must be an integer when using, ` +
-              `dimRoundingMode ${dimRoundingMode} but got pad ${pad}.`);
+          `Error in depthwiseConv2DDerFilter: pad must be an integer when ` +
+              `using dimRoundingMode ${dimRoundingMode}, but got pad ${pad}.`);
     }
 
     const dilations = 1;

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -484,6 +484,10 @@ export class ConvOps {
         true /* depthwise */);
 
     const grad = (dy: Tensor4D) => {
+      util.assert(
+          tupleValuesAreOne(dilations),
+          'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
+              `1 are not yet supported. Got dilations '${dilations}'`);
       return {
         x: () =>
             ConvOps.depthwiseConv2dDerInput(x4D.shape, dy, filter, convInfo),
@@ -504,10 +508,6 @@ export class ConvOps {
   static depthwiseConv2dDerInput<T extends Tensor3D|Tensor4D>(
       xShape: [number, number, number, number]|[number, number, number], dy: T,
       filter: Tensor4D, convInfo: conv_util.Conv2DInfo): T {
-    util.assert(
-        convInfo.dilationHeight == 1 && convInfo.dilationWidth == 1,
-        `Error in depthwiseConv2dDerInput: gradients of 2D convolutions ` +
-            `do not currently support height/width dilations larger than 1`);
     let dy4D = dy as Tensor4D;
     let reshapedTo4D = false;
     if (dy.rank === 3) {
@@ -526,10 +526,6 @@ export class ConvOps {
   static depthwiseConv2dDerFilter<T extends Tensor3D|Tensor4D>(
       x: T, dy: T, filterShape: [number, number, number, number],
       convInfo: conv_util.Conv2DInfo): Tensor4D {
-    util.assert(
-        convInfo.dilationHeight == 1 && convInfo.dilationWidth == 1,
-        `Error in depthwiseConv2dDerFilter: gradients of 2d convolutions ` +
-            `do not currently support height/width dilations larger than 1`);
     let x4D = x as Tensor4D;
     if (x.rank === 3) {
       x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -489,10 +489,8 @@ export class ConvOps {
           'Error in gradient of depthwiseConv2d: dilation rates greater than ' +
               `1 are not yet supported. Got dilations '${dilations}'`);
       return {
-        x: () =>
-            ConvOps.depthwiseConv2dDerInput(x4D.shape, dy, filter, convInfo),
-        filter: () =>
-            ConvOps.depthwiseConv2dDerFilter(x4D, dy, filter.shape, convInfo),
+        x: () => depthwiseConv2dDerInput(x4D.shape, dy, filter, convInfo),
+        filter: () => depthwiseConv2dDerFilter(x4D, dy, filter.shape, convInfo),
       };
     };
 
@@ -503,40 +501,6 @@ export class ConvOps {
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  }
-
-  static depthwiseConv2dDerInput<T extends Tensor3D|Tensor4D>(
-      xShape: [number, number, number, number]|[number, number, number], dy: T,
-      filter: Tensor4D, convInfo: conv_util.Conv2DInfo): T {
-    let dy4D = dy as Tensor4D;
-    let reshapedTo4D = false;
-    if (dy.rank === 3) {
-      reshapedTo4D = true;
-      dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
-    }
-    const res = ENV.engine.runKernel(
-        backend => backend.depthwiseConv2DDerInput(dy4D, filter, convInfo),
-        {dy4D});
-    if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
-    }
-    return res as T;
-  }
-
-  static depthwiseConv2dDerFilter<T extends Tensor3D|Tensor4D>(
-      x: T, dy: T, filterShape: [number, number, number, number],
-      convInfo: conv_util.Conv2DInfo): Tensor4D {
-    let x4D = x as Tensor4D;
-    if (x.rank === 3) {
-      x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
-    }
-    let dy4D = dy as Tensor4D;
-    if (dy4D.rank === 3) {
-      dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
-    }
-    return ENV.engine.runKernel(
-        backend => backend.depthwiseConv2DDerFilter(x4D, dy4D, convInfo),
-        {x4D, dy4D});
   }
 
   /**
@@ -659,4 +623,38 @@ function eitherStridesOrDilationsAreOne(
     strides: number|[number, number],
     dilations: number|[number, number]): boolean {
   return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
+}
+
+function depthwiseConv2dDerInput<T extends Tensor3D|Tensor4D>(
+    xShape: [number, number, number, number]|[number, number, number], dy: T,
+    filter: Tensor4D, convInfo: conv_util.Conv2DInfo): T {
+  let dy4D = dy as Tensor4D;
+  let reshapedTo4D = false;
+  if (dy.rank === 3) {
+    reshapedTo4D = true;
+    dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
+  }
+  const res = ENV.engine.runKernel(
+      backend => backend.depthwiseConv2DDerInput(dy4D, filter, convInfo),
+      {dy4D});
+  if (reshapedTo4D) {
+    return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
+  }
+  return res as T;
+}
+
+function depthwiseConv2dDerFilter<T extends Tensor3D|Tensor4D>(
+    x: T, dy: T, filterShape: [number, number, number, number],
+    convInfo: conv_util.Conv2DInfo): Tensor4D {
+  let x4D = x as Tensor4D;
+  if (x.rank === 3) {
+    x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
+  }
+  let dy4D = dy as Tensor4D;
+  if (dy4D.rank === 3) {
+    dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
+  }
+  return ENV.engine.runKernel(
+      backend => backend.depthwiseConv2DDerFilter(x4D, dy4D, convInfo),
+      {x4D, dy4D});
 }

--- a/src/ops/conv2d_depthwise_test.ts
+++ b/src/ops/conv2d_depthwise_test.ts
@@ -388,7 +388,7 @@ describeWithFlags('depthwiseConv2d gradients', CPU_ENVS, () => {
     ], [
       [[2,1,0],[0,3,3]],
       [[4,0,1],[1,4,1]]
-    ]])
+    ]]);
     //2x2 filters, multiplier = 2 => 2x2x3x2
     filter = tf.tensor4d([[
       [[1,1],[1,1],[0,0]],
@@ -438,7 +438,7 @@ describeWithFlags('depthwiseConv2d gradients', CPU_ENVS, () => {
     ], [
       [[8,8], [9,9], [6,6]],
       [[4,4], [5,5], [4,4]]
-    ]])
+    ]]);
 
     expectArraysClose(grad, expectedGrad);
   });


### PR DESCRIPTION
#### Description

This PR addresses https://github.com/tensorflow/tfjs/issues/71 by introducing gradient support for `depthwiseConv2D` (letting users train or compute saliency maps for models using depthwise convolutions).

Gradient functions are very similar to the corresponding functions for regular 2D convolutions (and actually return the same results in the special case that no further transformations of the output occur), except instead of iterating over all the output channels, we only iterate over a subset. The indexing into filter weights also becomes different than the indexing into outputs.

In implementing this, I found [reference](https://github.com/tensorflow/tensorflow/blob/51ef16057b4625e0a3e2943a9f1bbf856cf098ca/tensorflow/core/kernels/depthwise_conv_grad_op.cc#L940-L986) [implementations](https://github.com/tensorflow/tensorflow/blob/51ef16057b4625e0a3e2943a9f1bbf856cf098ca/tensorflow/core/kernels/depthwise_conv_grad_op.cc#L459-L513) in C++ very helpful.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1069)
<!-- Reviewable:end -->
