### PR TITLE
Use karma's dots reporter instead of progress for travis log

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,6 +54,9 @@ module.exports = function(config) {
         flags: ['--blacklist-accelerated-compositing', '--blacklist-webgl']
       }
     },
-    client: {args: ['--grep', config.grep || '']}
+    client: {
+      jasmine: {random: false},
+      args: ['--grep', config.grep || '']
+    }
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,14 +40,14 @@ module.exports = function(config) {
         browser: 'chrome',
         browser_version: 'latest',
         os: 'OS X',
-        os_version: 'Sierra'
+        os_version: 'High Sierra'
       },
       bs_firefox_mac: {
         base: 'BrowserStack',
         browser: 'firefox',
         browser_version: 'latest',
         os: 'OS X',
-        os_version: 'Sierra'
+        os_version: 'High Sierra'
       },
       chrome_with_swift_shader: {
         base: 'Chrome',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "publish-local": "yarn build-npm && yalc push",
     "lint": "tslint -p . -t verbose",
     "test": "karma start",
-    "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun"
+    "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun --reporters='dots,karma-typescript'"
   },
   "dependencies": {
     "seedrandom": "~2.4.3"


### PR DESCRIPTION
DEV Using dots reporter in Travis cleans up the log (see this [PR's log](https://travis-ci.org/tensorflow/tfjs-core/jobs/387161264)) and makes it easier to see the failed tests. Also switch BrowserStack tests to High Sierra (10.3.x)

Also since karma 3.x, the tests run in randomized order. This caused some tests to look flaky (e.g. some local storage tests were changing a global state and not resetting it properly). I'm reverting the order of tests to a non-random behavior by adding the following to karma.conf.js
```js
client: {
  ...,
  jasmine: {random: false}
}
```

We should do the same in other repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1075)
<!-- Reviewable:end -->
