### PR TITLE
Fix clipByValue gradient

### DIFF
--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -357,11 +357,9 @@ export class UnaryOps {
 
     const grad = (dy: T) => {
       return {
-        // TODO(cais): Fix gradients for the case where x = min or x
-        // = max.
         x: () => dy.where(
-                     x.greater(ops.scalar(clipValueMin))
-                         .logicalAnd(x.less(ops.scalar(clipValueMax))),
+                     x.greaterEqual(ops.scalar(clipValueMin))
+                         .logicalAnd(x.lessEqual(ops.scalar(clipValueMax))),
                      zerosLike(dy)) as T,
       };
     };

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2090,6 +2090,18 @@ describeWithFlags('clip', ALL_ENVS, () => {
     expectArraysClose(gradients, [0, 0, 500]);
   });
 
+  it('derivative: 1D tensor with max or min value', () => {
+    const min = -1;
+    const max = 2;
+    const x = tf.tensor1d([-1, 1, 2, 3]);
+    const dy = tf.tensor1d([1, 10, 100, 1000]);
+    const gradients = tf.grad(x => x.clipByValue(min, max))(x, dy);
+
+    expect(gradients.shape).toEqual(x.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [1, 10, 100, 0]);
+  });
+
   it('derivative: scalar', () => {
     const min = -1;
     const max = 2;


### PR DESCRIPTION
#### Description

BUG Fix clipByValue gradient

The graidents of `clipByValue` should be zeros only when the value is less than min or greater than max. In the case when it is equal to min or max, the graidnets should be kept as it is. This is same behavior to [`tf.clip_by_value`](https://github.com/tensorflow/tensorflow/blob/a3aa84f28c09b86e4961632d0e2581d06bb4a47e/tensorflow/python/ops/clip_ops.py#L92-L96) in TensorFlow.

<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1076)
<!-- Reviewable:end -->
