### PR TITLE
Generalize the tensor container to arbitrary depth

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -268,7 +268,7 @@ export class Engine implements TensorManager {
 
     const tensorsToKeep = new Set(this.keepTensors);
 
-    const tensorsToTrackInParent = util.extractTensorsFromContainer(result);
+    const tensorsToTrackInParent = util.getTensorsInContainer(result);
     tensorsToTrackInParent.forEach(tensor => tensorsToKeep.add(tensor.id));
 
     // Dispose the arrays tracked in this scope.

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -20,7 +20,7 @@ import {ScopeFn, TimingInfo} from './engine';
 import {ENV} from './environment';
 import {Tensor} from './tensor';
 import {TensorContainer} from './types';
-import {extractTensorsFromAny} from './util';
+import {getTensorsInContainer} from './util';
 
 export class Tracking {
   /**
@@ -111,7 +111,7 @@ export class Tracking {
    */
   // tslint:disable-next-line:no-any
   static dispose(container: any) {
-    const tensors = extractTensorsFromAny(container);
+    const tensors = getTensorsInContainer(container);
     tensors.forEach(tensor => tensor.dispose());
   }
 

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -101,7 +101,7 @@ export class Tracking {
   }
 
   /**
-   * Disposes any `Tensor`s found within the provided object up to depth 1.
+   * Disposes any `Tensor`s found within the provided object.
    *
    * @param container an object that may be a `Tensor` or may directly contain
    *     `Tensor`s, such as a `Tensor[]` or `{key: Tensor, ...}`.  If the
@@ -109,8 +109,8 @@ export class Tracking {
    *     happens. In general it is safe to pass any object here, except that
    *     `Promise`s are not supported.
    */
-  // tslint:disable-next-line:no-any
-  static dispose(container: any) {
+  @doc({heading: 'Performance', subheading: 'Memory'})
+  static dispose(container: TensorContainer) {
     const tensors = getTensorsInContainer(container);
     tensors.forEach(tensor => tensor.dispose());
   }

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -17,7 +17,8 @@
 
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
-import {ALL_ENVS, CPU_ENVS, expectArraysClose, WEBGL_ENVS} from './test_util';
+// tslint:disable-next-line:max-line-length
+import {ALL_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, WEBGL_ENVS} from './test_util';
 
 describeWithFlags('time webgl', WEBGL_ENVS, () => {
   it('upload + compute', async () => {
@@ -261,5 +262,16 @@ describeWithFlags('tidy', ALL_ENVS, () => {
       // tslint:disable-next-line:no-any
       tf.tidy('name', 'another name' as any);
     }).toThrowError();
+  });
+
+  it('works with arbitrary depth of result', () => {
+    const res = tf.tidy(() => {
+      return [tf.scalar(1), [[tf.scalar(2)]], {list: [tf.scalar(3)]}];
+    });
+    expectArraysEqual(res[0] as tf.Tensor, [1]);
+    // tslint:disable-next-line:no-any
+    expectArraysEqual((res[1] as any)[0][0], [2]);
+    // tslint:disable-next-line:no-any
+    expectArraysEqual((res[2] as any).list[0], [3]);
   });
 });

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -265,13 +265,19 @@ describeWithFlags('tidy', ALL_ENVS, () => {
   });
 
   it('works with arbitrary depth of result', () => {
-    const res = tf.tidy(() => {
-      return [tf.scalar(1), [[tf.scalar(2)]], {list: [tf.scalar(3)]}];
+    tf.tidy(() => {
+      const res = tf.tidy(() => {
+        return [tf.scalar(1), [[tf.scalar(2)]], {list: [tf.scalar(3)]}];
+      });
+      expectArraysEqual(res[0] as tf.Tensor, [1]);
+      // tslint:disable-next-line:no-any
+      expectArraysEqual((res[1] as any)[0][0], [2]);
+      // tslint:disable-next-line:no-any
+      expectArraysEqual((res[2] as any).list[0], [3]);
+      expect(tf.memory().numTensors).toBe(3);
+      return res[0];
     });
-    expectArraysEqual(res[0] as tf.Tensor, [1]);
-    // tslint:disable-next-line:no-any
-    expectArraysEqual((res[1] as any)[0][0], [2]);
-    // tslint:disable-next-line:no-any
-    expectArraysEqual((res[2] as any).list[0], [3]);
+    // Everything but scalar(1) got disposed.
+    expect(tf.memory().numTensors).toBe(1);
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -441,7 +441,7 @@ export function isFunction(f: Function) {
 }
 
 /**
- * Extracts any `Tensor`s found within the provided object up to depth 1.
+ * Extracts any `Tensor`s found within the provided object.
  *
  * @param container an object that may be a `Tensor` or may directly contain
  *   `Tensor`s, such as a `Tensor[]` or `{key: Tensor, ...}`.  In general it
@@ -449,9 +449,7 @@ export function isFunction(f: Function) {
  *   supported.
  * @returns An array of `Tensors` found within the passed object.  If the
  *   argument is simply a `Tensor', a list containing that `Tensor` is
- *   returned.  If the argument directly contains `Tensor`s, a list of them
- *   will be returned.  `Tensor`s nested more deeply within the argument will
- *   however not be found.  If the object is not a `Tensor` or does not
+ *   returned. If the object is not a `Tensor` or does not
  *   contain `Tensors`, an empty list is returned.
  */
 export function getTensorsInContainer(result: TensorContainer): Tensor[] {


### PR DESCRIPTION
FEATURE

Currently, calling `tf.dispose(obj)` or `tf.tidy(() => obj)` results in walking the `obj` for depth of 1 and disposing of any tensors found.

With this change `obj` is walked to arbitrary depth with cycle-detection to defend against cyclical objects.

This makes `tf.tidy()` and `tf.dispose()` more useful in practice.

Also rename `util.extractTensorsFromContainer` to `util.getTensorsFromContainer` since we are not modifying (extracting from) the container.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1083)
<!-- Reviewable:end -->
