### PR TITLE
Add a message for users running tf.js in node without the node backend

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -32,6 +32,8 @@ export interface Features {
   'DEBUG'?: boolean;
   // Whether we are in a browser (as versus, say, node.js) environment.
   'IS_BROWSER'?: boolean;
+  // Whether we are in the Node.js environment.
+  'IS_NODE'?: boolean;
   // The disjoint_query_timer extension version.
   // 0: disabled, 1: EXT_disjoint_timer_query, 2:
   // EXT_disjoint_timer_query_webgl2.
@@ -75,7 +77,7 @@ function hasExtension(gl: WebGLRenderingContext, extensionName: string) {
 }
 
 function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {
-  if (webGLVersion === 0) {
+  if (webGLVersion === 0 || !ENV.get('IS_BROWSER')) {
     throw new Error('Cannot get WebGL rendering context, WebGL is disabled.');
   }
 
@@ -307,6 +309,9 @@ export class Environment {
       return false;
     } else if (feature === 'IS_BROWSER') {
       return typeof window !== 'undefined';
+    } else if (feature === 'IS_NODE') {
+      return (typeof process !== 'undefined') &&
+          (typeof process.versions.node !== 'undefined');
     } else if (feature === 'BACKEND') {
       return this.getBestBackendType();
     } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -388,7 +388,8 @@ export class Environment {
       this.registry[name] = {backend, priority};
       return true;
     } catch (err) {
-      console.warn(err.message);
+      console.warn(`Registration of backend ${name} failed`);
+      console.warn(err.stack || err.message);
       return false;
     }
   }

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -54,9 +54,12 @@ export class MathBackendCPU implements KernelBackend {
         console.warn(
             '\n============================\n' +
             'Hi there 👋. Looks like you are running TensorFlow.js in ' +
-            'Node.js. To speed up dramatically, install our node backend ' +
-            'which binds to TensorFlow C++ by running ' +
-            '`npm i @tensorflow/tfjs-node` and import it in your program. ' +
+            'Node.js. To speed things up dramatically, install our node ' +
+            'backend, which binds to TensorFlow C++, by running ' +
+            'npm i @tensorflow/tfjs-node, ' +
+            'or npm i @tensorflow/tfjs-node-gpu if you have CUDA. ' +
+            'Then call require(\'tensorflow/tfjs-node\'); (-gpu ' +
+            'suffix for CUDA) at the start of your program. ' +
             'Visit https://github.com/tensorflow/tfjs-node for more details. ' +
             '\n============================\n');
       }

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -41,8 +41,16 @@ export class MathBackendCPU implements KernelBackend {
   private canvas: HTMLCanvasElement;
 
   constructor() {
-    if (typeof document !== 'undefined') {
+    if (ENV.get('IS_BROWSER')) {
       this.canvas = document.createElement('canvas');
+    }
+    if (ENV.get('IS_NODE')) {
+      console.warn(
+          'Hi there 👋. Looks like you are running TensorFlow.js in Node.js. ' +
+          'To speed up dramatically, install our node backend which binds to ' +
+          'TensorFlow C++ by running `npm i @tensorflow/tfjs-node` and ' +
+          'import it in your program. Visit ' +
+          'https://github.com/tensorflow/tfjs-node for more details.');
     }
   }
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -60,7 +60,7 @@ export class MathBackendCPU implements KernelBackend {
             'or npm i @tensorflow/tfjs-node-gpu if you have CUDA. ' +
             'Then call require(\'tensorflow/tfjs-node\'); (-gpu ' +
             'suffix for CUDA) at the start of your program. ' +
-            'Visit https://github.com/tensorflow/tfjs-node for more details. ' +
+            'Visit https://github.com/tensorflow/tfjs-node for more details.' +
             '\n============================\n');
       }
     }

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -39,22 +39,28 @@ import * as backend_util from './backend_util';
 export class MathBackendCPU implements KernelBackend {
   private data = new WeakMap<DataId, DataTypeMap[DataType]>();
   private canvas: HTMLCanvasElement;
+  private firstUse = true;
 
   constructor() {
     if (ENV.get('IS_BROWSER')) {
       this.canvas = document.createElement('canvas');
     }
-    if (ENV.get('IS_NODE')) {
-      console.warn(
-          'Hi there 👋. Looks like you are running TensorFlow.js in Node.js. ' +
-          'To speed up dramatically, install our node backend which binds to ' +
-          'TensorFlow C++ by running `npm i @tensorflow/tfjs-node` and ' +
-          'import it in your program. Visit ' +
-          'https://github.com/tensorflow/tfjs-node for more details.');
-    }
   }
 
   register(dataId: DataId, shape: number[], dtype: DataType): void {
+    if (this.firstUse) {
+      this.firstUse = false;
+      if (ENV.get('IS_NODE')) {
+        console.warn(
+            '\n============================\n' +
+            'Hi there 👋. Looks like you are running TensorFlow.js in ' +
+            'Node.js. To speed up dramatically, install our node backend ' +
+            'which binds to TensorFlow C++ by running ' +
+            '`npm i @tensorflow/tfjs-node` and import it in your program. ' +
+            'Visit https://github.com/tensorflow/tfjs-node for more details. ' +
+            '\n============================\n');
+      }
+    }
     if (this.data.has(dataId)) {
       throw new Error(`Data buffer is already registered`);
     }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -147,7 +147,7 @@ export class MathBackendWebGL implements KernelBackend {
 
     if (pixels instanceof HTMLVideoElement) {
       if (this.fromPixelsCanvas == null) {
-        if (typeof document === 'undefined') {
+        if (!ENV.get('IS_BROWSER')) {
           throw new Error(
               'Can\'t read pixels from HTMLImageElement outside the browser.');
         }
@@ -355,7 +355,7 @@ export class MathBackendWebGL implements KernelBackend {
     if (ENV.get('WEBGL_VERSION') < 1) {
       throw new Error('WebGL is not supported on this device');
     }
-    if (typeof document !== 'undefined') {
+    if (ENV.get('IS_BROWSER')) {
       this.canvas = document.createElement('canvas');
     }
     if (gpgpu == null) {
@@ -1190,7 +1190,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 }
 
-ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);
+if (ENV.get('IS_BROWSER')) {
+  ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);
+}
 
 function float32ToTypedArray<D extends DataType>(
     a: Float32Array, dtype: D): DataTypeMap[D] {


### PR DESCRIPTION
This PR adds a user-friendly message to remind people that we have node backend whenever they use tf.js in node with the vanilla cpu backend.

Also fixes a problem where a message saying `document is not defined` shows up at the top of the program. This was a side-effect of trying to access `document` when registering a WebGL backend.

<img width="719" alt="screen shot 2018-06-06 at 9 46 25 pm" src="https://user-images.githubusercontent.com/2294279/41073866-3fc504d4-69d3-11e8-98cf-17a08e44a3f1.png">


DOC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1085)
<!-- Reviewable:end -->
