### PR TITLE
Upload small tensors that live on CPU as uniforms

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1036,7 +1036,7 @@ export class MathBackendWebGL implements KernelBackend {
     const inputsData: Array<TensorData<T>> = inputs.map(tensor => {
       const texData = this.texData.get(tensor.dataId);
       // Upload scalar/1d tensor that lives on CPU as uniform, not as texture.
-      if (texData.texture == null && tensor.rank <= 1 && tensor.size <= 8) {
+      if (texData.texture == null && tensor.rank <= 1 && tensor.size <= 256) {
         return {tensor, texData: null, isUniform: true};
       }
       this.uploadToGPU(tensor.dataId);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -96,7 +96,7 @@ export interface WebGLTimingInfo extends TimingInfo {
 // before we start paging. The bytes are this constant * screen area * dpi.
 const BEFORE_PAGING_CONSTANT = 300;
 // Tensors with size <= than this will be uploaded as uniforms, not textures.
-const SIZE_UPLOAD_UNIFORM = 32;
+export const SIZE_UPLOAD_UNIFORM = 32;
 
 export class MathBackendWebGL implements KernelBackend {
   private texData = new WeakMap<DataId, TextureData>();

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -95,6 +95,8 @@ export interface WebGLTimingInfo extends TimingInfo {
 // Empirically determined constant used to decide the number of bytes on GPU
 // before we start paging. The bytes are this constant * screen area * dpi.
 const BEFORE_PAGING_CONSTANT = 300;
+// Tensors with size <= than this will be uploaded as uniforms, not textures.
+const SIZE_UPLOAD_UNIFORM = 32;
 
 export class MathBackendWebGL implements KernelBackend {
   private texData = new WeakMap<DataId, TextureData>();
@@ -1035,8 +1037,8 @@ export class MathBackendWebGL implements KernelBackend {
     }
     const inputsData: Array<TensorData<T>> = inputs.map(tensor => {
       const texData = this.texData.get(tensor.dataId);
-      // Upload scalar/1d tensor that lives on CPU as uniform, not as texture.
-      if (texData.texture == null && tensor.rank <= 1 && tensor.size <= 256) {
+      // Upload small tensors that live on the CPU as uniforms, not as textures.
+      if (texData.texture == null && tensor.size <= SIZE_UPLOAD_UNIFORM) {
         return {tensor, texData: null, isUniform: true};
       }
       this.uploadToGPU(tensor.dataId);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1035,9 +1035,8 @@ export class MathBackendWebGL implements KernelBackend {
     }
     const inputsData: Array<TensorData<T>> = inputs.map(tensor => {
       const texData = this.texData.get(tensor.dataId);
-      // Don't upload scalars that live on CPU as texture. We will upload them
-      // as uniforms.
-      if (texData.texture == null && tensor.rank === 0) {
+      // Upload scalar/1d tensor that lives on CPU as uniform, not as texture.
+      if (texData.texture == null && tensor.rank <= 1 && tensor.size <= 8) {
         return {tensor, texData: null, isUniform: true};
       }
       this.uploadToGPU(tensor.dataId);

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -106,7 +106,7 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
 });
 
 describe('Custom window size', () => {
-  it('Set screen area to be 1x1', () => {
+  it('Set screen area to be 1x1', async () => {
     // This will set the screen size to 1x1 to make sure the page limit is
     // very small.
     spyOnProperty(window, 'screen', 'get')
@@ -121,7 +121,7 @@ describe('Custom window size', () => {
     // No gpu memory used yet because of delayed storage.
     expect((tf.memory() as tf.webgl.WebGLMemoryInfo).numBytesInGPU).toBe(0);
 
-    a.square();
+    await a.square().data();
     // Everything got paged out of gpu after the run finished.
     expect((tf.memory() as tf.webgl.WebGLMemoryInfo).numBytesInGPU).toBe(0);
 

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -111,10 +111,8 @@ function validateBinaryAndProgram(
 
   shapeInfos.forEach((s, i) => {
     const shapeA = s.logicalShape;
-    const texShapeA = s.texShape;
     const input = inputs[i];
     const shapeB = input.tensor.shape;
-    const texShapeB = input.isUniform ? null : input.texData.texShape;
 
     if (!util.arraysEqual(shapeA, shapeB)) {
       throw Error(
@@ -122,9 +120,12 @@ function validateBinaryAndProgram(
           `the current args. Shapes ${shapeA} and ${shapeB} must match`);
     }
     // The input is uploaded as uniform.
-    if (texShapeA == null && texShapeB == null) {
+    if (s.isUniform && input.isUniform) {
       return;
     }
+
+    const texShapeA = s.texShape;
+    const texShapeB = input.isUniform ? null : input.texData.texShape;
     if (!util.arraysEqual(texShapeA, texShapeB)) {
       throw Error(
           `Binary was compiled with different texture shapes than the` +

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -18,9 +18,10 @@
 import {ENV} from '../../environment';
 import {Tensor} from '../../tensor';
 import * as util from '../../util';
+
 import {GPGPUContext} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
-import {ShapeInfo} from './shader_compiler';
+import {InputInfo, ShapeInfo} from './shader_compiler';
 import {TextureData} from './tex_util';
 
 export interface GPGPUProgram {
@@ -49,23 +50,26 @@ function shouldUploadNaNUniform(): boolean {
 export interface TensorData<T extends Tensor> {
   tensor: T;
   texData: TextureData;
+  isUniform: boolean;
 }
 
 export function compileProgram<T extends Tensor, K extends Tensor>(
     gpgpu: GPGPUContext, program: GPGPUProgram, inputs: Array<TensorData<T>>,
     output: TensorData<K>): GPGPUBinary {
   const userCode = program.userCode;
-  const inputInfos = inputs.map((input, i) => {
+  const inputInfos: InputInfo[] = inputs.map((input, i) => {
     const shapeInfo = {
       logicalShape: input.tensor.shape,
-      texShape: input.texData.texShape
+      texShape: input.isUniform ? null : input.texData.texShape,
+      isUniform: input.isUniform
     };
     return {name: program.variableNames[i], shapeInfo};
   });
   const inShapeInfos = inputInfos.map(x => x.shapeInfo);
   const outShapeInfo = {
     logicalShape: output.tensor.shape,
-    texShape: output.texData.texShape
+    texShape: output.texData.texShape,
+    isUniform: false
   };
   const source = shader_compiler.makeShader(
       inputInfos, outShapeInfo, userCode,
@@ -108,13 +112,18 @@ function validateBinaryAndProgram(
   shapeInfos.forEach((s, i) => {
     const shapeA = s.logicalShape;
     const texShapeA = s.texShape;
-    const shapeB = inputs[i].tensor.shape;
-    const texShapeB = inputs[i].texData.texShape;
+    const input = inputs[i];
+    const shapeB = input.tensor.shape;
+    const texShapeB = input.isUniform ? null : input.texData.texShape;
 
     if (!util.arraysEqual(shapeA, shapeB)) {
       throw Error(
           `Binary was compiled with different shapes than ` +
           `the current args. Shapes ${shapeA} and ${shapeB} must match`);
+    }
+    // The input is uploaded as uniform.
+    if (texShapeA == null && texShapeB == null) {
+      return;
     }
     if (!util.arraysEqual(texShapeA, texShapeB)) {
       throw Error(
@@ -137,9 +146,13 @@ export function runProgram<T extends Tensor, K extends Tensor>(
   gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
   gpgpu.setProgram(binary.webGLProgram);
   inputs.forEach((input, i) => {
-    const tex = input.texData.texture;
     const variableName = binary.program.variableNames[i];
     const variableUniformLocation = binary.uniformLocations[variableName];
+    if (input.isUniform) {
+      gpgpu.gl.uniform1f(variableUniformLocation, input.tensor.get());
+      return;
+    }
+    const tex = input.texData.texture;
     gpgpu.setInputMatrixTexture(tex, variableUniformLocation, i);
   });
 
@@ -158,7 +171,8 @@ export function makeShaderKey(
     output: TensorData<Tensor>): string {
   let keyInputs = '';
   inputs.concat(output).forEach(x => {
-    keyInputs += `${x.tensor.shape}_${x.texData.texShape}`;
+    keyInputs +=
+        `${x.tensor.shape}_${x.isUniform ? 'uniform' : x.texData.texShape}`;
   });
   const keyUserCode = program.userCode;
   const keyBroadcast = (program.supportsBroadcasting === true).toString();

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -149,11 +149,14 @@ export function runProgram<T extends Tensor, K extends Tensor>(
     const variableName = binary.program.variableNames[i];
     const variableUniformLocation = binary.uniformLocations[variableName];
     if (input.isUniform) {
-      if (input.tensor.rank === 0) {
-        gpgpu.gl.uniform1f(variableUniformLocation, input.tensor.get());
-      } else if (input.tensor.rank === 1) {
-        gpgpu.gl.uniform1fv(
-            variableUniformLocation, input.tensor.dataSync() as Float32Array);
+      if (input.tensor.size === 1) {
+        gpgpu.gl.uniform1f(variableUniformLocation, input.tensor.dataSync()[0]);
+      } else {
+        let vals = input.tensor.dataSync();
+        if (!(vals instanceof Float32Array)) {
+          vals = new Float32Array(vals);
+        }
+        gpgpu.gl.uniform1fv(variableUniformLocation, vals);
       }
       return;
     }

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -149,7 +149,12 @@ export function runProgram<T extends Tensor, K extends Tensor>(
     const variableName = binary.program.variableNames[i];
     const variableUniformLocation = binary.uniformLocations[variableName];
     if (input.isUniform) {
-      gpgpu.gl.uniform1f(variableUniformLocation, input.tensor.get());
+      if (input.tensor.rank === 0) {
+        gpgpu.gl.uniform1f(variableUniformLocation, input.tensor.get());
+      } else if (input.tensor.rank === 1) {
+        gpgpu.gl.uniform1fv(
+            variableUniformLocation, input.tensor.dataSync() as Float32Array);
+      }
       return;
     }
     const tex = input.texData.texture;

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -16,13 +16,15 @@
  */
 
 import {ENV} from '../../environment';
-import * as util from '../../util';
 import * as broadcast_util from '../../ops/broadcast_util';
+import * as util from '../../util';
+
 import * as tex_util from './tex_util';
 
 export type ShapeInfo = {
   logicalShape: number[],
-  texShape: [number, number]
+  texShape: [number, number],
+  isUniform: boolean
 };
 
 export type InputInfo = {
@@ -169,7 +171,7 @@ vec2 UVfrom5D(int texNumR, int texNumC, int stride0,
     int stride1, int stride2, int stride3, int row, int col, int depth,
     int depth2, int depth3) {
   // Explicitly use integer operations as dot() only works on floats.
-  int index = row * stride0 + col * stride1 + 
+  int index = row * stride0 + col * stride1 +
               depth * stride2 + depth2 * stride3 + depth3;
   int texR = index / texNumC;
   int texC = index - texR * texNumC;
@@ -837,7 +839,7 @@ export function getCoordsDataType(rank: number): string {
     return 'ivec4';
   } else if (rank === 5) {
     return 'ivec5';
-  }else {
+  } else {
     throw Error(`GPU for rank ${rank} is not yet supported`);
   }
 }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -489,7 +489,6 @@ function getSampler2D(inputInfo: InputInfo): string {
   const shape = inputInfo.shapeInfo.logicalShape;
   const texName = inputInfo.name;
   const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
-  const inSize = util.sizeFromShape(shape);
 
   const texShape = inputInfo.shapeInfo.texShape;
   if (texShape != null && util.arraysEqual(shape, texShape)) {
@@ -520,11 +519,7 @@ function getSampler2D(inputInfo: InputInfo): string {
     return `
       float ${funcName}(int row, int col) {
         int index = row * ${shape[1]} + col;
-        for (int i = 0; i < ${inSize}; i++) {
-          if (i == index) {
-            return ${texName}[i];
-          }
-        }
+        return ${funcName}Flat(index);
       }
     `;
   }
@@ -563,7 +558,6 @@ function getSampler3D(inputInfo: InputInfo): string {
   const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
   const stride0 = shape[1] * shape[2];
   const stride1 = shape[2];
-  const inSize = util.sizeFromShape(shape);
 
   const {newShape, keptDims} = util.squeezeShape(shape);
   const squeezedShape = newShape;
@@ -582,11 +576,7 @@ function getSampler3D(inputInfo: InputInfo): string {
     return `
       float ${funcName}(int row, int col, int depth) {
         int index = row * ${stride0} + col * ${stride1} + depth;
-        for (int i = 0; i < ${inSize}; i++) {
-          if (i == index) {
-            return ${texName}[i];
-          }
-        }
+        return ${funcName}Flat(index);
       }
     `;
   }
@@ -633,7 +623,6 @@ function getSampler4D(inputInfo: InputInfo): string {
   const stride2 = shape[3];
   const stride1 = shape[2] * stride2;
   const stride0 = shape[1] * stride1;
-  const inSize = util.sizeFromShape(shape);
 
   const {newShape, keptDims} = util.squeezeShape(shape);
   if (newShape.length < shape.length) {
@@ -652,11 +641,7 @@ function getSampler4D(inputInfo: InputInfo): string {
       float ${funcName}(int row, int col, int depth, int depth2) {
         int index = row * ${stride0} + col * ${stride1} +
             depth * ${stride2} + depth2;
-        for (int i = 0; i < ${inSize}; i++) {
-          if (i == index) {
-            return ${texName}[i];
-          }
-        }
+        return ${funcName}Flat(index);
       }
     `;
   }
@@ -703,7 +688,6 @@ function getSampler5D(inputInfo: InputInfo): string {
   const stride2 = shape[3] * stride3;
   const stride1 = shape[2] * stride2;
   const stride0 = shape[1] * stride1;
-  const inSize = util.sizeFromShape(shape);
 
   const {newShape, keptDims} = util.squeezeShape(shape);
   if (newShape.length < shape.length) {
@@ -722,11 +706,7 @@ function getSampler5D(inputInfo: InputInfo): string {
       float ${funcName}(int row, int col, int depth, int depth2, int depth3) {
         int index = row * ${stride0} + col * ${stride1} +
             depth * ${stride2} + depth2 * ${stride3} + depth3;
-        for (int i = 0; i < ${inSize}; i++) {
-          if (i == index) {
-            return ${texName}[i];
-          }
-        }
+        return ${funcName}Flat(index);
       }
     `;
   }
@@ -910,11 +890,7 @@ function getSamplerAtOutputCoords(
                               vec2(${outTexShape[0]}, ${outTexShape[1]}));
         int index = resTexRC.x * ${outTexShape[1]} + resTexRC.y;
         ${broadcastSnippet}
-        for (int i = 0; i < ${inSize}; i++) {
-          if (i == index) {
-            return ${texName}[i];
-          }
-        }
+        return get${texFuncSnippet}Flat(index);
       }
     `;
   }

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -475,24 +475,4 @@ describeWithFlags('dot', WEBGL_ENVS, () => {
     expect(() => tf.dot(a, d)).toThrowError();
     expect(() => tf.dot(a, e)).toThrowError();
   });
-
-  // tslint:disable-next-line:ban
-  fit('benchmark dot', () => {
-    const size = 256;
-    const a = tf.randomUniform([size]);
-    let res: tf.Tensor;
-
-    tf.square(tf.randomUniform([size])).dataSync();  // warmup.
-
-    const start = performance.now();
-    const numIter = 10000;
-    for (let i = 0; i < numIter; i++) {
-      res = tf.square(a);
-      if (i < numIter - 1) {
-        res.dispose();
-      }
-    }
-    res.dataSync();
-    console.log(performance.now() - start, 'ms');
-  });
 });

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -16,9 +16,9 @@
  */
 
 import * as tf from '../index';
+import {describeWithFlags} from '../jasmine_util';
 // tslint:disable-next-line:max-line-length
 import {ALL_ENVS, expectArraysClose, expectNumbersClose, WEBGL_ENVS} from '../test_util';
-import {describeWithFlags} from '../jasmine_util';
 import {Rank} from '../types';
 import {MatmulOps} from './matmul';
 
@@ -421,7 +421,7 @@ describeWithFlags('matmul webgl-only', WEBGL_ENVS, () => {
   });
 });
 
-describeWithFlags('dot', ALL_ENVS, () => {
+describeWithFlags('dot', WEBGL_ENVS, () => {
   let a: tf.Tensor1D;
   let b: tf.Tensor2D;
   let c: tf.Tensor2D;
@@ -474,5 +474,25 @@ describeWithFlags('dot', ALL_ENVS, () => {
   it('throws error when inputs are not rank 1 or 2', () => {
     expect(() => tf.dot(a, d)).toThrowError();
     expect(() => tf.dot(a, e)).toThrowError();
+  });
+
+  // tslint:disable-next-line:ban
+  fit('benchmark dot', () => {
+    const size = 256;
+    const a = tf.randomUniform([size]);
+    let res: tf.Tensor;
+
+    tf.square(tf.randomUniform([size])).dataSync();  // warmup.
+
+    const start = performance.now();
+    const numIter = 10000;
+    for (let i = 0; i < numIter; i++) {
+      res = tf.square(a);
+      if (i < numIter - 1) {
+        res.dispose();
+      }
+    }
+    res.dataSync();
+    console.log(performance.now() - start, 'ms');
   });
 });

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -421,7 +421,7 @@ describeWithFlags('matmul webgl-only', WEBGL_ENVS, () => {
   });
 });
 
-describeWithFlags('dot', WEBGL_ENVS, () => {
+describeWithFlags('dot', ALL_ENVS, () => {
   let a: tf.Tensor1D;
   let b: tf.Tensor2D;
   let c: tf.Tensor2D;


### PR DESCRIPTION
Tensors that live in GPU and have <= 32 values, are uploaded and sampled as uniforms. 32 is determined empirically. This has no perf impact on sampling, while reducing texture allocation, gpu memory and potential memory leaks since uniforms are cleaned up automatically after the shader finishes.

Fixes https://github.com/tensorflow/tfjs/issues/104

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1087)
<!-- Reviewable:end -->
