### PR TITLE
Add concatenateArrayBuffers to tf.io export for Node.js HTTP

### DIFF
--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -23,7 +23,7 @@ import './local_storage';
 
 import {browserFiles} from './browser_files';
 import {browserHTTPRequest} from './browser_http';
-import {decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
+import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {ModelManagement} from './model_management';
 import {IORouterRegistry} from './router_registry';
 
@@ -44,6 +44,7 @@ const removeModel = ModelManagement.removeModel;
 export {
   browserFiles,
   browserHTTPRequest,
+  concatenateArrayBuffers,
   copyModel,
   decodeWeights,
   encodeWeights,


### PR DESCRIPTION
The method is required by Node.js HTTP loader currently being worked
on in tfjs-node.

Towards: https://github.com/tensorflow/tfjs/issues/343
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1099)
<!-- Reviewable:end -->
