### PR TITLE
fix index for min

### DIFF
--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -560,7 +560,7 @@ export class MathBackendCPU implements KernelBackend {
     const aVals = x.dataSync();
     for (let i = 0; i < vals.length; ++i) {
       const offset = i * reduceSize;
-      let min = aVals[0];
+      let min = aVals[offset];
       for (let j = 0; j < reduceSize; ++j) {
         const value = aVals[offset + j];
         if (value < min) {


### PR DESCRIPTION
#### Description
This PR fixes a bug in `tf.min` for the cpu backend where if you compute the min along an axis it returns the global min for each element, e.g.
```
tf.setBackend('cpu');
tf.tensor([[1, 2], [3, 4]]).min(0).print();
```
returns
```
Tensor
    [1, 1]
```
I'm not super familiar with these operations but the index of the flat typed array was fixed at 0 instead of using the offset that the other reduction operations use. Changing that seems to fix the behavior I was seeing.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1105)
<!-- Reviewable:end -->
