### PR TITLE
update raw byte calculation to use byteLength

### DIFF
--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -122,10 +122,10 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
   xs.forEach(x => {
     // tslint:disable-next-line:no-any
     if (x as any instanceof Float32Array || x as any instanceof Int32Array) {
-      totalByteLength += x.length * 4;
+      totalByteLength += x.buffer.byteLength;
       // tslint:disable-next-line:no-any
     } else if (x as any instanceof Uint8Array) {
-      totalByteLength += x.length;
+      totalByteLength += x.buffer.byteLength;
     } else {
       throw new Error(`Unsupported TypedArray subtype: ${x.constructor.name}`);
     }
@@ -135,11 +135,7 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
   let offset = 0;
   xs.forEach(x => {
     y.set(new Uint8Array(x.buffer), offset);
-    if (x instanceof Float32Array || x instanceof Int32Array) {
-      offset += x.length * 4;
-    } else {
-      offset += x.length;
-    }
+    offset += x.buffer.byteLength;
   });
 
   return y.buffer;


### PR DESCRIPTION
#### Description
This fixes issue https://github.com/tensorflow/tfjs/issues/432. 

Instead of calculating the expected number of bytes by magic number in `concatenateTypedArrays`, use `buffer.byteLength` instead.
---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1107)
<!-- Reviewable:end -->
