### PR TITLE
When disposing a kept tensor, remove it from the keep tensors array.

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -161,6 +161,9 @@ export class Engine implements TensorManager {
     if (!this.refCounter.has(a.dataId)) {
       return;
     }
+    if (this.keepTensors.has(a.id)) {
+      this.keepTensors.delete(a.id);
+    }
     this.numTensors--;
     const refCount = this.refCounter.get(a.dataId);
     if (refCount <= 1) {
@@ -231,6 +234,7 @@ export class Engine implements TensorManager {
           'tf.tidy(() => {...}) to avoid memory leaks.');
     }
     this.keepTensors.add(result.id);
+    console.log('keep size:', this.keepTensors.size);
     return result;
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -234,7 +234,6 @@ export class Engine implements TensorManager {
           'tf.tidy(() => {...}) to avoid memory leaks.');
     }
     this.keepTensors.add(result.id);
-    console.log('keep size:', this.keepTensors.size);
     return result;
   }
 


### PR DESCRIPTION
By not removing it from the keepTensors array, we introduce a CPU memory leak which causes a very gradual linear slowdown.

Verified this fixes https://github.com/tensorflow/tfjs/issues/448

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1113)
<!-- Reviewable:end -->
