### PR TITLE
Fixing various nan related issues impacted by floating point precision and NaN

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -15,71 +15,71 @@
  * =============================================================================
  */
 
-import {MemoryInfo, TimingInfo} from '../engine';
-import {ENV} from '../environment';
+import { MemoryInfo, TimingInfo } from '../engine';
+import { ENV } from '../environment';
 import * as axis_util from '../ops/axis_util';
-import {Conv2DInfo} from '../ops/conv_util';
+import { Conv2DInfo } from '../ops/conv_util';
 import * as ops from '../ops/ops';
 import * as reduce_util from '../ops/reduce_util';
 import * as segment_util from '../ops/segment_util';
-import {getStridedSlicedInfo} from '../ops/slice_util';
+import { getStridedSlicedInfo } from '../ops/slice_util';
 // tslint:disable-next-line:max-line-length
-import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
+import { DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D } from '../tensor';
 import * as types from '../types';
-import {DataType, DataTypeMap, RecursiveArray, TypedArray} from '../types';
+import { DataType, DataTypeMap, RecursiveArray, TypedArray } from '../types';
 import * as util from '../util';
 
-import {KernelBackend} from './backend';
+import { KernelBackend } from './backend';
 import * as backend_util from './backend_util';
-import {ArgMinMaxProgram} from './webgl/argminmax_gpu';
-import {AvgPool2DBackpropProgram} from './webgl/avg_pool_backprop_gpu';
-import {BatchNormProgram} from './webgl/batchnorm_gpu';
+import { ArgMinMaxProgram } from './webgl/argminmax_gpu';
+import { AvgPool2DBackpropProgram } from './webgl/avg_pool_backprop_gpu';
+import { BatchNormProgram } from './webgl/batchnorm_gpu';
 import * as binaryop_gpu from './webgl/binaryop_gpu';
-import {BinaryOpProgram} from './webgl/binaryop_gpu';
-import {ClipProgram} from './webgl/clip_gpu';
-import {ConcatProgram} from './webgl/concat_gpu';
+import { BinaryOpProgram } from './webgl/binaryop_gpu';
+import { ClipProgram } from './webgl/clip_gpu';
+import { ConcatProgram } from './webgl/concat_gpu';
 // tslint:disable-next-line:max-line-length
-import {Conv2DDerFilterProgram, Conv2DDerInputProgram} from './webgl/conv_backprop_gpu';
+import { Conv2DDerFilterProgram, Conv2DDerInputProgram } from './webgl/conv_backprop_gpu';
 // tslint:disable-next-line:max-line-length
-import {DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram} from './webgl/conv_backprop_gpu_depthwise';
-import {Conv2DProgram} from './webgl/conv_gpu';
-import {DepthwiseConv2DProgram} from './webgl/conv_gpu_depthwise';
-import {CumSumProgram} from './webgl/cumsum_gpu';
-import {EncodeFloatProgram} from './webgl/encode_float_gpu';
-import {FromPixelsProgram} from './webgl/from_pixels_gpu';
-import {GatherProgram} from './webgl/gather_gpu';
-import {GPGPUContext} from './webgl/gpgpu_context';
+import { DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram } from './webgl/conv_backprop_gpu_depthwise';
+import { Conv2DProgram } from './webgl/conv_gpu';
+import { DepthwiseConv2DProgram } from './webgl/conv_gpu_depthwise';
+import { CumSumProgram } from './webgl/cumsum_gpu';
+import { EncodeFloatProgram } from './webgl/encode_float_gpu';
+import { FromPixelsProgram } from './webgl/from_pixels_gpu';
+import { GatherProgram } from './webgl/gather_gpu';
+import { GPGPUContext } from './webgl/gpgpu_context';
 import * as gpgpu_math from './webgl/gpgpu_math';
-import {GPGPUBinary, GPGPUProgram, TensorData} from './webgl/gpgpu_math';
+import { GPGPUBinary, GPGPUProgram, TensorData } from './webgl/gpgpu_math';
 import * as gpgpu_util from './webgl/gpgpu_util';
-import {WhereProgram} from './webgl/logical_gpu';
-import {LRNProgram} from './webgl/lrn_gpu';
-import {MaxPool2DBackpropProgram} from './webgl/max_pool_backprop_gpu';
-import {MatMulProgram} from './webgl/mulmat_gpu';
-import {MultinomialProgram} from './webgl/multinomial_gpu';
-import {OneHotProgram} from './webgl/onehot_gpu';
-import {PadProgram} from './webgl/pad_gpu';
-import {Pool2DProgram} from './webgl/pool_gpu';
-import {ReduceProgram} from './webgl/reduce_gpu';
+import { WhereProgram } from './webgl/logical_gpu';
+import { LRNProgram } from './webgl/lrn_gpu';
+import { MaxPool2DBackpropProgram } from './webgl/max_pool_backprop_gpu';
+import { MatMulProgram } from './webgl/mulmat_gpu';
+import { MultinomialProgram } from './webgl/multinomial_gpu';
+import { OneHotProgram } from './webgl/onehot_gpu';
+import { PadProgram } from './webgl/pad_gpu';
+import { Pool2DProgram } from './webgl/pool_gpu';
+import { ReduceProgram } from './webgl/reduce_gpu';
 // tslint:disable-next-line:max-line-length
-import {ResizeBilinearBackpropProgram} from './webgl/resize_bilinear_backprop_gpu';
-import {ResizeBilinearProgram} from './webgl/resize_bilinear_gpu';
+import { ResizeBilinearBackpropProgram } from './webgl/resize_bilinear_backprop_gpu';
+import { ResizeBilinearProgram } from './webgl/resize_bilinear_gpu';
 // tslint:disable-next-line:max-line-length
-import {ResizeNearestNeighborProgram} from './webgl/resize_nearest_neighbor_gpu';
-import {ReverseProgram} from './webgl/reverse_gpu';
-import {SegmentOpProgram} from './webgl/segment_gpu';
-import {SliceProgram} from './webgl/slice_gpu';
-import {StridedSliceProgram} from './webgl/strided_slice_gpu';
-import {TextureData, TextureUsage} from './webgl/tex_util';
-import {TextureManager} from './webgl/texture_manager';
-import {TileProgram} from './webgl/tile_gpu';
-import {TransposeProgram} from './webgl/transpose_gpu';
+import { ResizeNearestNeighborProgram } from './webgl/resize_nearest_neighbor_gpu';
+import { ReverseProgram } from './webgl/reverse_gpu';
+import { SegmentOpProgram } from './webgl/segment_gpu';
+import { SliceProgram } from './webgl/slice_gpu';
+import { StridedSliceProgram } from './webgl/strided_slice_gpu';
+import { TextureData, TextureUsage } from './webgl/tex_util';
+import { TextureManager } from './webgl/texture_manager';
+import { TileProgram } from './webgl/tile_gpu';
+import { TransposeProgram } from './webgl/transpose_gpu';
 import * as unary_op from './webgl/unaryop_gpu';
-import {UnaryOpProgram} from './webgl/unaryop_gpu';
-import {WebGLQuery} from './webgl/webgl_types';
+import { UnaryOpProgram } from './webgl/unaryop_gpu';
+import { WebGLQuery } from './webgl/webgl_types';
 import * as webgl_util from './webgl/webgl_util';
 
-type TimerNode = RecursiveArray<Promise<number>>|Promise<number>;
+type TimerNode = RecursiveArray<Promise<number>> | Promise<number>;
 export interface CPUTimerQuery {
   startMs: number;
   endMs?: number;
@@ -142,8 +142,8 @@ export class MathBackendWebGL implements KernelBackend {
     });
   }
   fromPixels(
-      pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
-      numChannels: number): Tensor3D {
+    pixels: ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+    numChannels: number): Tensor3D {
     if (pixels == null) {
       throw new Error('MathBackendWebGL.writePixels(): pixels can not be null');
     }
@@ -154,20 +154,20 @@ export class MathBackendWebGL implements KernelBackend {
       if (this.fromPixelsCanvas == null) {
         if (!ENV.get('IS_BROWSER')) {
           throw new Error(
-              'Can\'t read pixels from HTMLImageElement outside the browser.');
+            'Can\'t read pixels from HTMLImageElement outside the browser.');
         }
         if (document.readyState !== 'complete') {
           throw new Error(
-              'The DOM is not ready yet. Please call tf.fromPixels() ' +
-              'once the DOM is ready. One way to do that is to add an event ' +
-              'listener for `DOMContentLoaded` on the document object');
+            'The DOM is not ready yet. Please call tf.fromPixels() ' +
+            'once the DOM is ready. One way to do that is to add an event ' +
+            'listener for `DOMContentLoaded` on the document object');
         }
         this.fromPixelsCanvas = document.createElement('canvas');
       }
       this.fromPixelsCanvas.width = pixels.width;
       this.fromPixelsCanvas.height = pixels.height;
       this.fromPixelsCanvas.getContext('2d').drawImage(
-          pixels, 0, 0, pixels.width, pixels.height);
+        pixels, 0, 0, pixels.width, pixels.height);
       pixels = this.fromPixelsCanvas;
     }
     const tempPixelArray = Tensor.make(texShape, {}, 'int32');
@@ -175,7 +175,7 @@ export class MathBackendWebGL implements KernelBackend {
     // This is a byte texture with pixels.
     this.texData.get(tempPixelArray.dataId).usage = TextureUsage.PIXELS;
     this.gpgpu.uploadPixelDataToTexture(
-        this.getTexture(tempPixelArray.dataId), pixels);
+      this.getTexture(tempPixelArray.dataId), pixels);
     const program = new FromPixelsProgram(outShape);
     const res = this.compileAndRun(program, [tempPixelArray]);
 
@@ -190,7 +190,7 @@ export class MathBackendWebGL implements KernelBackend {
     this.throwIfNoData(dataId);
 
     const texData = this.texData.get(dataId);
-    const {texture, texShape, usage} = texData;
+    const { texture, texShape, usage } = texData;
     if (texture != null) {
       // Release the old texture.
       this.releaseTexture(dataId, texture, texShape, usage);
@@ -207,7 +207,7 @@ export class MathBackendWebGL implements KernelBackend {
   readSync(dataId: DataId): TypedArray {
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const {shape, texture, values, texShape, dtype} = texData;
+    const { shape, texture, values, texShape, dtype } = texData;
     if (values != null) {
       this.cacheOnCPU(dataId);
       return values;
@@ -221,19 +221,19 @@ export class MathBackendWebGL implements KernelBackend {
     let float32Values;
     if (ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
       float32Values = this.gpgpu.downloadFloat32MatrixFromOutputTexture(
-          texture, texShape[0], texShape[1]);
+        texture, texShape[0], texShape[1]);
     } else {
       const tmpTarget = Tensor.make(shape, {});
       this.texData.get(tmpTarget.dataId).usage = TextureUsage.DOWNLOAD;
 
-      const tmpInput = Tensor.make(shape, {dataId}, dtype);
+      const tmpInput = Tensor.make(shape, { dataId }, dtype);
       const program = new EncodeFloatProgram(shape);
       const res = this.compileAndRun(program, [tmpInput], tmpTarget);
 
       const tmpData = this.texData.get(tmpTarget.dataId);
       float32Values =
-          this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(
-              tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
+        this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(
+          tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
 
       res.dispose();
       tmpInput.dispose();
@@ -253,14 +253,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const {texture, values, texShape} = texData;
+    const { texture, values, texShape } = texData;
     if (values != null) {
       this.cacheOnCPU(dataId);
       return values;
     }
     if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
       const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
-          texture, texShape[0], texShape[1]);
+        texture, texShape[0], texShape[1]);
       this.cacheOnCPU(dataId, float32Values);
       return texData.values;
     }
@@ -272,7 +272,7 @@ export class MathBackendWebGL implements KernelBackend {
     this.pendingRead.set(dataId, []);
     // Construct an empty query. We're just interested in getting a callback
     // when the GPU command queue has executed until this point in time.
-    await this.gpgpu.runQuery(() => {});
+    await this.gpgpu.runQuery(() => { });
     const subscribers = this.pendingRead.get(dataId);
     this.pendingRead.delete(dataId);
     const vals = this.readSync(dataId);
@@ -323,19 +323,19 @@ export class MathBackendWebGL implements KernelBackend {
     return res;
   }
   memory(): WebGLMemoryInfo {
-    return {unreliable: false, numBytesInGPU: this.numBytesInGPU} as
-        WebGLMemoryInfo;
+    return { unreliable: false, numBytesInGPU: this.numBytesInGPU } as
+      WebGLMemoryInfo;
   }
 
-  private startTimer(): WebGLQuery|CPUTimerQuery {
+  private startTimer(): WebGLQuery | CPUTimerQuery {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       return this.gpgpu.beginQuery();
     }
-    return {startMs: performance.now(), endMs: null};
+    return { startMs: performance.now(), endMs: null };
   }
 
-  private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
-      {startMs: number, endMs: number} {
+  private endTimer(query: WebGLQuery | CPUTimerQuery): WebGLQuery |
+    { startMs: number, endMs: number } {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       this.gpgpu.endQuery();
       return query;
@@ -344,7 +344,7 @@ export class MathBackendWebGL implements KernelBackend {
     return query;
   }
 
-  private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
+  private async getQueryTime(query: WebGLQuery | CPUTimerQuery): Promise<number> {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       return this.gpgpu.pollQueryTime(query);
     }
@@ -361,7 +361,7 @@ export class MathBackendWebGL implements KernelBackend {
       return;
     }
     if (this.texData.has(dataId)) {
-      const {texture, texShape, usage} = this.texData.get(dataId);
+      const { texture, texShape, usage } = this.texData.get(dataId);
       if (texture != null) {
         this.releaseTexture(dataId, texture, texShape, usage);
       }
@@ -375,7 +375,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private textureManager: TextureManager;
-  private binaryCache: {[key: string]: GPGPUBinary} = {};
+  private binaryCache: { [key: string]: GPGPUBinary } = {};
   private gpgpuCreatedLocally: boolean;
 
   constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
@@ -394,8 +394,8 @@ export class MathBackendWebGL implements KernelBackend {
     // Use the device screen's resolution as a heuristic to decide on the
     // maximum memory allocated on the GPU before starting to page.
     this.NUM_BYTES_BEFORE_PAGING =
-        (window.screen.height * window.screen.width * window.devicePixelRatio) *
-        BEFORE_PAGING_CONSTANT;
+      (window.screen.height * window.screen.width * window.devicePixelRatio) *
+      BEFORE_PAGING_CONSTANT;
     this.textureManager = new TextureManager(this.gpgpu);
   }
 
@@ -413,10 +413,10 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   stridedSlice<T extends Tensor>(
-      x: T, begin: number[], end: number[], strides: number[],
-      beginMask: number, endMask: number): T {
+    x: T, begin: number[], end: number[], strides: number[],
+    beginMask: number, endMask: number): T {
     const [beginIndex, size] =
-        getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
+      getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
 
     if (size.some(axis => axis === 0)) {
       return ops.tensor([], size) as T;
@@ -443,7 +443,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
-      Tensor2D {
+    Tensor2D {
     const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
     return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
   }
@@ -451,15 +451,15 @@ export class MathBackendWebGL implements KernelBackend {
   multiply(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
     const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+      this.makeOutputArray(
+        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun(program, [a, b], output) as Tensor;
   }
 
   batchNormalization(
-      x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
-      varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
-      offset?: Tensor4D|Tensor1D): Tensor4D {
+    x: Tensor4D, mean: Tensor4D | Tensor1D, variance: Tensor4D | Tensor1D,
+    varianceEpsilon: number, scale?: Tensor4D | Tensor1D,
+    offset?: Tensor4D | Tensor1D): Tensor4D {
     const inputs = [x, mean, variance];
 
     let offsetShape = null;
@@ -475,14 +475,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     const program = new BatchNormProgram(
-        x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
-        varianceEpsilon);
+      x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
+      varianceEpsilon);
     return this.compileAndRun(program, inputs);
   }
 
   localResponseNormalization4D(
-      x: Tensor4D, radius: number, bias: number, alpha: number,
-      beta: number): Tensor4D {
+    x: Tensor4D, radius: number, bias: number, alpha: number,
+    beta: number): Tensor4D {
     const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
     return this.compileAndRun(program, [x]);
   }
@@ -493,7 +493,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   pad<T extends Tensor>(
-      x: T, paddings: Array<[number, number]>, constantValue: number): T {
+    x: T, paddings: Array<[number, number]>, constantValue: number): T {
     const program = new PadProgram(x.shape, paddings, constantValue);
     return this.compileAndRun(program, [x]);
   }
@@ -508,12 +508,12 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [x, indices]);
   }
 
-  private reduce(x: Tensor2D, reduceType: 'max'|'min'|'sum', dtype: DataType):
-      Tensor2D {
+  private reduce(x: Tensor2D, reduceType: 'max' | 'min' | 'sum', dtype: DataType):
+    Tensor2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = {windowSize, inSize, batchSize};
+    const reduceInfo = { windowSize, inSize, batchSize };
     const program = new ReduceProgram(reduceInfo, reduceType);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
@@ -526,8 +526,8 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private argReduce(
-      x: Tensor2D, reduceType: 'max'|'min',
-      bestIndicesA: Tensor2D = null): Tensor2D {
+    x: Tensor2D, reduceType: 'max' | 'min',
+    bestIndicesA: Tensor2D = null): Tensor2D {
     let batchSize = x.shape[0];
     let inSize = x.shape[1];
     if (bestIndicesA != null) {
@@ -535,9 +535,9 @@ export class MathBackendWebGL implements KernelBackend {
       inSize = bestIndicesA.shape[1];
     }
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = {windowSize, inSize, batchSize};
+    const reduceInfo = { windowSize, inSize, batchSize };
     const program =
-        new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
+      new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
     const inputs = [x];
@@ -555,7 +555,7 @@ export class MathBackendWebGL implements KernelBackend {
   sum(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
     const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     const outputDType = types.sumOutType(x.dtype);
@@ -563,7 +563,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   unsortedSegmentSum<T extends Tensor>(
-      x: T, segmentIds: Tensor1D, numSegments: number): Tensor {
+    x: T, segmentIds: Tensor1D, numSegments: number): Tensor {
     let axis = 0;
     const permutation = axis_util.getAxesPermutation([axis], x.rank);
     let permutedX = x;
@@ -573,14 +573,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     const outShape =
-        segment_util.computeOutShape(permutedX.shape, axis, numSegments);
+      segment_util.computeOutShape(permutedX.shape, axis, numSegments);
     const inSize = util.sizeFromShape([permutedX.shape[axis]]);
     const a2D = permutedX.as2D(-1, inSize);
     const outputDType = types.sumOutType(x.dtype);
     let result =
-        this.segOpCompute(
-                a2D, 'unsortedSegmentSum', segmentIds, outputDType, numSegments)
-            .reshape(outShape);
+      this.segOpCompute(
+        a2D, 'unsortedSegmentSum', segmentIds, outputDType, numSegments)
+        .reshape(outShape);
     if (permutation != null) {
       result = result.transpose(axis_util.getUndoAxesPermutation(permutation));
     }
@@ -588,13 +588,13 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private segOpCompute(
-      x: Tensor2D, segOpType: 'unsortedSegmentSum', segmentIds: Tensor1D,
-      dtype: DataType, numSegments: number): Tensor2D {
+    x: Tensor2D, segOpType: 'unsortedSegmentSum', segmentIds: Tensor1D,
+    dtype: DataType, numSegments: number): Tensor2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize =
-        segment_util.segOpComputeOptimalWindowSize(inSize, numSegments);
-    const segOpInfo = {windowSize, inSize, batchSize, numSegments};
+      segment_util.segOpComputeOptimalWindowSize(inSize, numSegments);
+    const segOpInfo = { windowSize, inSize, batchSize, numSegments };
     const program = new SegmentOpProgram(segOpInfo, segOpType);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
@@ -611,7 +611,7 @@ export class MathBackendWebGL implements KernelBackend {
     const axes = [axis];
     axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
     const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.argReduce(a2D, 'min').reshape(outShape);
@@ -621,18 +621,18 @@ export class MathBackendWebGL implements KernelBackend {
     const axes = [axis];
     axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
     const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.argReduce(a2D, 'max').reshape(outShape);
   }
 
   cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
-      Tensor {
+    Tensor {
     if (axis !== x.rank - 1) {
       throw new Error(
-          `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
-          `but got axis=${axis}`);
+        `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
+        `but got axis=${axis}`);
     }
     const program = new CumSumProgram(x.shape, exclusive, reverse);
     return this.compileAndRun(program, [x]);
@@ -646,7 +646,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   notEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -659,7 +659,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   lessEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -672,7 +672,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   greaterEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -684,14 +684,14 @@ export class MathBackendWebGL implements KernelBackend {
 
   logicalAnd(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
   logicalOr(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -713,7 +713,7 @@ export class MathBackendWebGL implements KernelBackend {
   min(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
     const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
@@ -726,13 +726,14 @@ export class MathBackendWebGL implements KernelBackend {
 
   mod(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
-    return this.compileAndRun(program, [a, b]);
+    const customSetup = program.getCustomSetupFunc();
+    return this.compileAndRun(program, [a, b], null, customSetup);
   }
 
   max(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
     const [outShape, reduceShape] =
-        axis_util.computeOutAndReduceShapes(x.shape, axes);
+      axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
@@ -745,7 +746,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   squaredDifference(a: Tensor, b: Tensor): Tensor {
     const program =
-        new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
+      new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]);
   }
 
@@ -768,24 +769,24 @@ export class MathBackendWebGL implements KernelBackend {
   add(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
     const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+      this.makeOutputArray(
+        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
   }
 
   subtract(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
     const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+      this.makeOutputArray(
+        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
   }
 
   pow<T extends Tensor>(a: T, b: Tensor): T {
     const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
     const output =
-        this.makeOutputArray(
-            program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
+      this.makeOutputArray(
+        program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
     return this.compileAndRun<Tensor, T>(program, [a, b], output);
   }
 
@@ -821,7 +822,8 @@ export class MathBackendWebGL implements KernelBackend {
 
   log<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.LOG);
-    return this.compileAndRun(program, [x]) as T;
+    const customSetup = program.getCustomSetupFunc();
+    return this.compileAndRun(program, [x], null, customSetup) as T;
   }
 
   log1p<T extends Tensor>(x: T): T {
@@ -861,7 +863,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   eluDer<T extends Tensor>(dy: T, y: T): T {
     const program =
-        new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
+      new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
     return this.compileAndRun(program, [dy, y]) as T;
   }
 
@@ -953,12 +955,14 @@ export class MathBackendWebGL implements KernelBackend {
 
   acosh<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
-    return this.compileAndRun(program, [x]) as T;
+    const customSetup = program.getCustomSetupFunc();
+    return this.compileAndRun(program, [x], null, customSetup) as T;
   }
 
   atanh<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
-    return this.compileAndRun(program, [x]) as T;
+    const customSetup = program.getCustomSetupFunc();
+    return this.compileAndRun(program, [x], null, customSetup) as T;
   }
 
   erf<T extends Tensor>(x: T): T {
@@ -977,7 +981,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
+    Tensor4D {
     const program = new Conv2DDerInputProgram(convInfo);
     return this.compileAndRun(program, [dy, filter]);
   }
@@ -988,19 +992,19 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
+    Tensor4D {
     const program = new DepthwiseConv2DProgram(convInfo);
     return this.compileAndRun(program, [x, filter]);
   }
 
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
+    Tensor4D {
     const program = new DepthwiseConv2DDerInputProgram(convInfo);
     return this.compileAndRun(program, [dy, filter]);
   }
 
   depthwiseConv2DDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
+    Tensor4D {
     const program = new DepthwiseConv2DDerFilterProgram(convInfo);
     return this.compileAndRun(program, [x, dy]);
   }
@@ -1008,7 +1012,7 @@ export class MathBackendWebGL implements KernelBackend {
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
     const program = new Pool2DProgram(convInfo, 'max', false);
     const output =
-        this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
+      this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
     return this.compileAndRun(program, [x], output);
   }
 
@@ -1019,18 +1023,18 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D {
+    Tensor4D {
     const getPositions = true;
     const maxPoolPositionsProgram =
-        new Pool2DProgram(convInfo, 'max', getPositions);
+      new Pool2DProgram(convInfo, 'max', getPositions);
     const maxPoolPositions: Tensor4D =
-        this.compileAndRun(maxPoolPositionsProgram, [x]);
+      this.compileAndRun(maxPoolPositionsProgram, [x]);
 
     const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
     const output =
-        this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
+      this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
     const result = this.compileAndRun(
-        maxPoolBackPropProgram, [dy, maxPoolPositions], output);
+      maxPoolBackPropProgram, [dy, maxPoolPositions], output);
     maxPoolPositions.dispose();
     return result as Tensor4D;
   }
@@ -1038,7 +1042,7 @@ export class MathBackendWebGL implements KernelBackend {
   avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
     const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
     const output =
-        this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
+      this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
     return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
   }
 
@@ -1047,61 +1051,61 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
-      x: T, shape: types.ShapeMap[R]): Tensor<R> {
+    x: T, shape: types.ShapeMap[R]): Tensor<R> {
     return backend_util.reshapeTensor(x, shape);
   }
 
   resizeBilinear(
-      x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
+    x: Tensor4D, newHeight: number, newWidth: number,
+    alignCorners: boolean): Tensor4D {
     const program =
-        new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
+      new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
     return this.compileAndRun(program, [x]);
   }
 
   resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):
-      Tensor4D {
+    Tensor4D {
     const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
 
     return this.compileAndRun(program, [dy]);
   }
 
   resizeNearestNeighbor(
-      x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D {
+    x: Tensor4D, newHeight: number, newWidth: number,
+    alignCorners: boolean): Tensor4D {
     const program = new ResizeNearestNeighborProgram(
-        x.shape, newHeight, newWidth, alignCorners);
+      x.shape, newHeight, newWidth, alignCorners);
     return this.compileAndRun(program, [x]);
   }
 
   multinomial(
-      logits: Tensor2D, normalized: boolean, numSamples: number,
-      seed: number): Tensor2D {
+    logits: Tensor2D, normalized: boolean, numSamples: number,
+    seed: number): Tensor2D {
     const probs = normalized ? logits : ops.softmax(logits);
     const batchSize = probs.shape[0];
     const numOutcomes = probs.shape[1];
     const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
     const output =
-        this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
+      this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
     const customSetup = program.getCustomSetupFunc(seed);
     return this.compileAndRun(program, [probs], output, customSetup);
   }
 
   oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
-      Tensor2D {
+    Tensor2D {
     const program = new OneHotProgram(indices.size, depth, onValue, offValue);
     return this.compileAndRun(program, [indices]);
   }
 
   private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
-      T {
+    T {
     return Tensor.make(shape, {}, dtype) as T;
   }
 
   private compileAndRun<T extends Tensor, K extends Tensor>(
-      program: GPGPUProgram, inputs: T[], output?: K,
-      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
-      K {
+    program: GPGPUProgram, inputs: T[], output?: K,
+    customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
+    K {
     if (output == null) {
       output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
     }
@@ -1109,10 +1113,10 @@ export class MathBackendWebGL implements KernelBackend {
       const texData = this.texData.get(tensor.dataId);
       // Upload small tensors that live on the CPU as uniforms, not as textures.
       if (texData.texture == null && tensor.size <= SIZE_UPLOAD_UNIFORM) {
-        return {tensor, texData: null, isUniform: true};
+        return { tensor, texData: null, isUniform: true };
       }
       this.uploadToGPU(tensor.dataId);
-      return {tensor, texData, isUniform: false};
+      return { tensor, texData, isUniform: false };
     });
     this.uploadToGPU(output.dataId);
     const outputData = {
@@ -1123,10 +1127,10 @@ export class MathBackendWebGL implements KernelBackend {
     const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
     const binary = this.getAndSaveBinary(key, () => {
       return gpgpu_math.compileProgram(
-          this.gpgpu, program, inputsData, outputData);
+        this.gpgpu, program, inputsData, outputData);
     });
     const shouldTimeProgram = this.activeTimers != null;
-    let query: WebGLQuery|CPUTimerQuery;
+    let query: WebGLQuery | CPUTimerQuery;
     if (shouldTimeProgram) {
       query = this.startTimer();
     }
@@ -1137,7 +1141,7 @@ export class MathBackendWebGL implements KernelBackend {
       let numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
       while (numBytesToPage > 0) {
         const dataId = this.lruDataGPU.shift();
-        const {shape, dtype} = this.texData.get(dataId);
+        const { shape, dtype } = this.texData.get(dataId);
         numBytesToPage -= this.computeBytes(shape, dtype);
         this.read(dataId);
       }
@@ -1151,7 +1155,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private getAndSaveBinary(key: string, getBinary: () => GPGPUBinary):
-      GPGPUBinary {
+    GPGPUBinary {
     if (!(key in this.binaryCache)) {
       this.binaryCache[key] = getBinary();
     }
@@ -1185,16 +1189,16 @@ export class MathBackendWebGL implements KernelBackend {
   private throwIfNoData(dataId: DataId) {
     if (!this.texData.has(dataId)) {
       throw new Error(
-          `WebGL backend: No data found for this tensor. ` +
-          `Did you change your backend in the middle of the program? ` +
-          `New backends can't use Tensors created with previous backends`);
+        `WebGL backend: No data found for this tensor. ` +
+        `Did you change your backend in the middle of the program? ` +
+        `New backends can't use Tensors created with previous backends`);
     }
   }
 
   private uploadToGPU(dataId: DataId): void {
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const {shape, values, texture, dtype, usage} = texData;
+    const { shape, values, texture, dtype, usage } = texData;
     if (texture != null) {
       // Array is already on GPU. No-op.
       // Touching the texture.
@@ -1208,15 +1212,15 @@ export class MathBackendWebGL implements KernelBackend {
       start = performance.now();
     }
     const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+      webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
     texData.texShape = texShape;
     const newTexture = this.acquireTexture(dataId, texShape, usage);
     texData.texture = newTexture;
     if (values != null) {
       this.gpgpu.uploadMatrixToTexture(
-          newTexture, texShape[0],
-          // TODO(smilkov): Propagate the original typed array to gpgpu.
-          texShape[1], typedArrayToFloat32(values, dtype));
+        newTexture, texShape[0],
+        // TODO(smilkov): Propagate the original typed array to gpgpu.
+        texShape[1], typedArrayToFloat32(values, dtype));
       // Once uploaded, don't store the values on cpu.
       texData.values = null;
       if (shouldTimeProgram) {
@@ -1231,7 +1235,7 @@ export class MathBackendWebGL implements KernelBackend {
     // the next time a gpgpu program needs the texture.
     const dontKeepCopyOnGPU = this.delayedStorage;
     const texData = this.texData.get(dataId);
-    const {texture, texShape, dtype, usage} = texData;
+    const { texture, texShape, dtype, usage } = texData;
     if (dontKeepCopyOnGPU && texture != null) {
       this.releaseTexture(dataId, texture, texShape, usage);
       texData.texture = null;
@@ -1243,9 +1247,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private releaseTexture(
-      dataId: DataId, texture: WebGLTexture, texShape: [number, number],
-      texType: TextureUsage) {
-    const {shape, dtype} = this.texData.get(dataId);
+    dataId: DataId, texture: WebGLTexture, texShape: [number, number],
+    texType: TextureUsage) {
+    const { shape, dtype } = this.texData.get(dataId);
     const idx = this.lruDataGPU.indexOf(dataId);
     if (idx >= 0) {
       this.lruDataGPU.splice(idx, 1);
@@ -1255,9 +1259,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private acquireTexture(
-      dataId: DataId, texShape: [number, number],
-      texType: TextureUsage): WebGLTexture {
-    const {shape, dtype} = this.texData.get(dataId);
+    dataId: DataId, texShape: [number, number],
+    texType: TextureUsage): WebGLTexture {
+    const { shape, dtype } = this.texData.get(dataId);
     this.lruDataGPU.push(dataId);
     this.numBytesInGPU += this.computeBytes(shape, dtype);
     return this.textureManager.acquireTexture(texShape, texType);
@@ -1273,12 +1277,12 @@ if (ENV.get('IS_BROWSER')) {
 }
 
 function float32ToTypedArray<D extends DataType>(
-    a: Float32Array, dtype: D): DataTypeMap[D] {
+  a: Float32Array, dtype: D): DataTypeMap[D] {
   if (dtype === 'float32') {
     return a;
   } else if (dtype === 'int32' || dtype === 'bool') {
     const result = (dtype === 'int32') ? new Int32Array(a.length) :
-                                         new Uint8Array(a.length);
+      new Uint8Array(a.length);
     for (let i = 0; i < result.length; ++i) {
       result[i] = Math.round(a[i]);
     }
@@ -1289,6 +1293,6 @@ function float32ToTypedArray<D extends DataType>(
 }
 
 function typedArrayToFloat32<D extends DataType>(
-    a: DataTypeMap[D], dtype: D): Float32Array {
+  a: DataTypeMap[D], dtype: D): Float32Array {
   return (a instanceof Float32Array) ? a : new Float32Array(a);
 }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -508,8 +508,9 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [x, indices]);
   }
 
-  private reduce(x: Tensor2D, reduceType: 'max' | 'min' | 'sum', dtype: DataType):
-    Tensor2D {
+  private reduce(
+      x: Tensor2D, reduceType: 'max' | 'min' | 'sum',
+      dtype: DataType): Tensor2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -15,71 +15,71 @@
  * =============================================================================
  */
 
-import { MemoryInfo, TimingInfo } from '../engine';
-import { ENV } from '../environment';
+import {MemoryInfo, TimingInfo} from '../engine';
+import {ENV} from '../environment';
 import * as axis_util from '../ops/axis_util';
-import { Conv2DInfo } from '../ops/conv_util';
+import {Conv2DInfo} from '../ops/conv_util';
 import * as ops from '../ops/ops';
 import * as reduce_util from '../ops/reduce_util';
 import * as segment_util from '../ops/segment_util';
-import { getStridedSlicedInfo } from '../ops/slice_util';
+import {getStridedSlicedInfo} from '../ops/slice_util';
 // tslint:disable-next-line:max-line-length
-import { DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D } from '../tensor';
+import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import * as types from '../types';
-import { DataType, DataTypeMap, RecursiveArray, TypedArray } from '../types';
+import {DataType, DataTypeMap, RecursiveArray, TypedArray} from '../types';
 import * as util from '../util';
 
-import { KernelBackend } from './backend';
+import {KernelBackend} from './backend';
 import * as backend_util from './backend_util';
-import { ArgMinMaxProgram } from './webgl/argminmax_gpu';
-import { AvgPool2DBackpropProgram } from './webgl/avg_pool_backprop_gpu';
-import { BatchNormProgram } from './webgl/batchnorm_gpu';
+import {ArgMinMaxProgram} from './webgl/argminmax_gpu';
+import {AvgPool2DBackpropProgram} from './webgl/avg_pool_backprop_gpu';
+import {BatchNormProgram} from './webgl/batchnorm_gpu';
 import * as binaryop_gpu from './webgl/binaryop_gpu';
-import { BinaryOpProgram } from './webgl/binaryop_gpu';
-import { ClipProgram } from './webgl/clip_gpu';
-import { ConcatProgram } from './webgl/concat_gpu';
+import {BinaryOpProgram} from './webgl/binaryop_gpu';
+import {ClipProgram} from './webgl/clip_gpu';
+import {ConcatProgram} from './webgl/concat_gpu';
 // tslint:disable-next-line:max-line-length
-import { Conv2DDerFilterProgram, Conv2DDerInputProgram } from './webgl/conv_backprop_gpu';
+import {Conv2DDerFilterProgram, Conv2DDerInputProgram} from './webgl/conv_backprop_gpu';
 // tslint:disable-next-line:max-line-length
-import { DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram } from './webgl/conv_backprop_gpu_depthwise';
-import { Conv2DProgram } from './webgl/conv_gpu';
-import { DepthwiseConv2DProgram } from './webgl/conv_gpu_depthwise';
-import { CumSumProgram } from './webgl/cumsum_gpu';
-import { EncodeFloatProgram } from './webgl/encode_float_gpu';
-import { FromPixelsProgram } from './webgl/from_pixels_gpu';
-import { GatherProgram } from './webgl/gather_gpu';
-import { GPGPUContext } from './webgl/gpgpu_context';
+import {DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram} from './webgl/conv_backprop_gpu_depthwise';
+import {Conv2DProgram} from './webgl/conv_gpu';
+import {DepthwiseConv2DProgram} from './webgl/conv_gpu_depthwise';
+import {CumSumProgram} from './webgl/cumsum_gpu';
+import {EncodeFloatProgram} from './webgl/encode_float_gpu';
+import {FromPixelsProgram} from './webgl/from_pixels_gpu';
+import {GatherProgram} from './webgl/gather_gpu';
+import {GPGPUContext} from './webgl/gpgpu_context';
 import * as gpgpu_math from './webgl/gpgpu_math';
-import { GPGPUBinary, GPGPUProgram, TensorData } from './webgl/gpgpu_math';
+import {GPGPUBinary, GPGPUProgram, TensorData} from './webgl/gpgpu_math';
 import * as gpgpu_util from './webgl/gpgpu_util';
-import { WhereProgram } from './webgl/logical_gpu';
-import { LRNProgram } from './webgl/lrn_gpu';
-import { MaxPool2DBackpropProgram } from './webgl/max_pool_backprop_gpu';
-import { MatMulProgram } from './webgl/mulmat_gpu';
-import { MultinomialProgram } from './webgl/multinomial_gpu';
-import { OneHotProgram } from './webgl/onehot_gpu';
-import { PadProgram } from './webgl/pad_gpu';
-import { Pool2DProgram } from './webgl/pool_gpu';
-import { ReduceProgram } from './webgl/reduce_gpu';
+import {WhereProgram} from './webgl/logical_gpu';
+import {LRNProgram} from './webgl/lrn_gpu';
+import {MaxPool2DBackpropProgram} from './webgl/max_pool_backprop_gpu';
+import {MatMulProgram} from './webgl/mulmat_gpu';
+import {MultinomialProgram} from './webgl/multinomial_gpu';
+import {OneHotProgram} from './webgl/onehot_gpu';
+import {PadProgram} from './webgl/pad_gpu';
+import {Pool2DProgram} from './webgl/pool_gpu';
+import {ReduceProgram} from './webgl/reduce_gpu';
 // tslint:disable-next-line:max-line-length
-import { ResizeBilinearBackpropProgram } from './webgl/resize_bilinear_backprop_gpu';
-import { ResizeBilinearProgram } from './webgl/resize_bilinear_gpu';
+import {ResizeBilinearBackpropProgram} from './webgl/resize_bilinear_backprop_gpu';
+import {ResizeBilinearProgram} from './webgl/resize_bilinear_gpu';
 // tslint:disable-next-line:max-line-length
-import { ResizeNearestNeighborProgram } from './webgl/resize_nearest_neighbor_gpu';
-import { ReverseProgram } from './webgl/reverse_gpu';
-import { SegmentOpProgram } from './webgl/segment_gpu';
-import { SliceProgram } from './webgl/slice_gpu';
-import { StridedSliceProgram } from './webgl/strided_slice_gpu';
-import { TextureData, TextureUsage } from './webgl/tex_util';
-import { TextureManager } from './webgl/texture_manager';
-import { TileProgram } from './webgl/tile_gpu';
-import { TransposeProgram } from './webgl/transpose_gpu';
+import {ResizeNearestNeighborProgram} from './webgl/resize_nearest_neighbor_gpu';
+import {ReverseProgram} from './webgl/reverse_gpu';
+import {SegmentOpProgram} from './webgl/segment_gpu';
+import {SliceProgram} from './webgl/slice_gpu';
+import {StridedSliceProgram} from './webgl/strided_slice_gpu';
+import {TextureData, TextureUsage} from './webgl/tex_util';
+import {TextureManager} from './webgl/texture_manager';
+import {TileProgram} from './webgl/tile_gpu';
+import {TransposeProgram} from './webgl/transpose_gpu';
 import * as unary_op from './webgl/unaryop_gpu';
-import { UnaryOpProgram } from './webgl/unaryop_gpu';
-import { WebGLQuery } from './webgl/webgl_types';
+import {UnaryOpProgram} from './webgl/unaryop_gpu';
+import {WebGLQuery} from './webgl/webgl_types';
 import * as webgl_util from './webgl/webgl_util';
 
-type TimerNode = RecursiveArray<Promise<number>> | Promise<number>;
+type TimerNode = RecursiveArray<Promise<number>>|Promise<number>;
 export interface CPUTimerQuery {
   startMs: number;
   endMs?: number;
@@ -142,8 +142,8 @@ export class MathBackendWebGL implements KernelBackend {
     });
   }
   fromPixels(
-    pixels: ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
-    numChannels: number): Tensor3D {
+      pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
+      numChannels: number): Tensor3D {
     if (pixels == null) {
       throw new Error('MathBackendWebGL.writePixels(): pixels can not be null');
     }
@@ -154,20 +154,20 @@ export class MathBackendWebGL implements KernelBackend {
       if (this.fromPixelsCanvas == null) {
         if (!ENV.get('IS_BROWSER')) {
           throw new Error(
-            'Can\'t read pixels from HTMLImageElement outside the browser.');
+              'Can\'t read pixels from HTMLImageElement outside the browser.');
         }
         if (document.readyState !== 'complete') {
           throw new Error(
-            'The DOM is not ready yet. Please call tf.fromPixels() ' +
-            'once the DOM is ready. One way to do that is to add an event ' +
-            'listener for `DOMContentLoaded` on the document object');
+              'The DOM is not ready yet. Please call tf.fromPixels() ' +
+              'once the DOM is ready. One way to do that is to add an event ' +
+              'listener for `DOMContentLoaded` on the document object');
         }
         this.fromPixelsCanvas = document.createElement('canvas');
       }
       this.fromPixelsCanvas.width = pixels.width;
       this.fromPixelsCanvas.height = pixels.height;
       this.fromPixelsCanvas.getContext('2d').drawImage(
-        pixels, 0, 0, pixels.width, pixels.height);
+          pixels, 0, 0, pixels.width, pixels.height);
       pixels = this.fromPixelsCanvas;
     }
     const tempPixelArray = Tensor.make(texShape, {}, 'int32');
@@ -175,7 +175,7 @@ export class MathBackendWebGL implements KernelBackend {
     // This is a byte texture with pixels.
     this.texData.get(tempPixelArray.dataId).usage = TextureUsage.PIXELS;
     this.gpgpu.uploadPixelDataToTexture(
-      this.getTexture(tempPixelArray.dataId), pixels);
+        this.getTexture(tempPixelArray.dataId), pixels);
     const program = new FromPixelsProgram(outShape);
     const res = this.compileAndRun(program, [tempPixelArray]);
 
@@ -190,7 +190,7 @@ export class MathBackendWebGL implements KernelBackend {
     this.throwIfNoData(dataId);
 
     const texData = this.texData.get(dataId);
-    const { texture, texShape, usage } = texData;
+    const {texture, texShape, usage} = texData;
     if (texture != null) {
       // Release the old texture.
       this.releaseTexture(dataId, texture, texShape, usage);
@@ -207,7 +207,7 @@ export class MathBackendWebGL implements KernelBackend {
   readSync(dataId: DataId): TypedArray {
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const { shape, texture, values, texShape, dtype } = texData;
+    const {shape, texture, values, texShape, dtype} = texData;
     if (values != null) {
       this.cacheOnCPU(dataId);
       return values;
@@ -221,19 +221,19 @@ export class MathBackendWebGL implements KernelBackend {
     let float32Values;
     if (ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
       float32Values = this.gpgpu.downloadFloat32MatrixFromOutputTexture(
-        texture, texShape[0], texShape[1]);
+          texture, texShape[0], texShape[1]);
     } else {
       const tmpTarget = Tensor.make(shape, {});
       this.texData.get(tmpTarget.dataId).usage = TextureUsage.DOWNLOAD;
 
-      const tmpInput = Tensor.make(shape, { dataId }, dtype);
+      const tmpInput = Tensor.make(shape, {dataId}, dtype);
       const program = new EncodeFloatProgram(shape);
       const res = this.compileAndRun(program, [tmpInput], tmpTarget);
 
       const tmpData = this.texData.get(tmpTarget.dataId);
       float32Values =
-        this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(
-          tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
+          this.gpgpu.downloadByteEncodedFloatMatrixFromOutputTexture(
+              tmpData.texture, tmpData.texShape[0], tmpData.texShape[1]);
 
       res.dispose();
       tmpInput.dispose();
@@ -253,14 +253,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const { texture, values, texShape } = texData;
+    const {texture, values, texShape} = texData;
     if (values != null) {
       this.cacheOnCPU(dataId);
       return values;
     }
     if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED')) {
       const float32Values = await this.gpgpu.downloadMatrixFromTextureAsync(
-        texture, texShape[0], texShape[1]);
+          texture, texShape[0], texShape[1]);
       this.cacheOnCPU(dataId, float32Values);
       return texData.values;
     }
@@ -272,7 +272,7 @@ export class MathBackendWebGL implements KernelBackend {
     this.pendingRead.set(dataId, []);
     // Construct an empty query. We're just interested in getting a callback
     // when the GPU command queue has executed until this point in time.
-    await this.gpgpu.runQuery(() => { });
+    await this.gpgpu.runQuery(() => {});
     const subscribers = this.pendingRead.get(dataId);
     this.pendingRead.delete(dataId);
     const vals = this.readSync(dataId);
@@ -323,19 +323,19 @@ export class MathBackendWebGL implements KernelBackend {
     return res;
   }
   memory(): WebGLMemoryInfo {
-    return { unreliable: false, numBytesInGPU: this.numBytesInGPU } as
-      WebGLMemoryInfo;
+    return {unreliable: false, numBytesInGPU: this.numBytesInGPU} as
+        WebGLMemoryInfo;
   }
 
-  private startTimer(): WebGLQuery | CPUTimerQuery {
+  private startTimer(): WebGLQuery|CPUTimerQuery {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       return this.gpgpu.beginQuery();
     }
-    return { startMs: performance.now(), endMs: null };
+    return {startMs: performance.now(), endMs: null};
   }
 
-  private endTimer(query: WebGLQuery | CPUTimerQuery): WebGLQuery |
-    { startMs: number, endMs: number } {
+  private endTimer(query: WebGLQuery|CPUTimerQuery): WebGLQuery|
+      {startMs: number, endMs: number} {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       this.gpgpu.endQuery();
       return query;
@@ -344,7 +344,7 @@ export class MathBackendWebGL implements KernelBackend {
     return query;
   }
 
-  private async getQueryTime(query: WebGLQuery | CPUTimerQuery): Promise<number> {
+  private async getQueryTime(query: WebGLQuery|CPUTimerQuery): Promise<number> {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0) {
       return this.gpgpu.pollQueryTime(query);
     }
@@ -361,7 +361,7 @@ export class MathBackendWebGL implements KernelBackend {
       return;
     }
     if (this.texData.has(dataId)) {
-      const { texture, texShape, usage } = this.texData.get(dataId);
+      const {texture, texShape, usage} = this.texData.get(dataId);
       if (texture != null) {
         this.releaseTexture(dataId, texture, texShape, usage);
       }
@@ -375,7 +375,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private textureManager: TextureManager;
-  private binaryCache: { [key: string]: GPGPUBinary } = {};
+  private binaryCache: {[key: string]: GPGPUBinary} = {};
   private gpgpuCreatedLocally: boolean;
 
   constructor(private gpgpu?: GPGPUContext, private delayedStorage = true) {
@@ -394,8 +394,8 @@ export class MathBackendWebGL implements KernelBackend {
     // Use the device screen's resolution as a heuristic to decide on the
     // maximum memory allocated on the GPU before starting to page.
     this.NUM_BYTES_BEFORE_PAGING =
-      (window.screen.height * window.screen.width * window.devicePixelRatio) *
-      BEFORE_PAGING_CONSTANT;
+        (window.screen.height * window.screen.width * window.devicePixelRatio) *
+        BEFORE_PAGING_CONSTANT;
     this.textureManager = new TextureManager(this.gpgpu);
   }
 
@@ -413,10 +413,10 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   stridedSlice<T extends Tensor>(
-    x: T, begin: number[], end: number[], strides: number[],
-    beginMask: number, endMask: number): T {
+      x: T, begin: number[], end: number[], strides: number[],
+      beginMask: number, endMask: number): T {
     const [beginIndex, size] =
-      getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
+        getStridedSlicedInfo(x.shape, begin, end, strides, beginMask, endMask);
 
     if (size.some(axis => axis === 0)) {
       return ops.tensor([], size) as T;
@@ -443,7 +443,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   matMul(a: Tensor2D, b: Tensor2D, transposeA: boolean, transposeB: boolean):
-    Tensor2D {
+      Tensor2D {
     const program = new MatMulProgram(a.shape, b.shape, transposeA, transposeB);
     return this.compileAndRun<Tensor2D, Tensor2D>(program, [a, b]);
   }
@@ -451,15 +451,15 @@ export class MathBackendWebGL implements KernelBackend {
   multiply(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
     const output =
-      this.makeOutputArray(
-        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun(program, [a, b], output) as Tensor;
   }
 
   batchNormalization(
-    x: Tensor4D, mean: Tensor4D | Tensor1D, variance: Tensor4D | Tensor1D,
-    varianceEpsilon: number, scale?: Tensor4D | Tensor1D,
-    offset?: Tensor4D | Tensor1D): Tensor4D {
+      x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
+      varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
+      offset?: Tensor4D|Tensor1D): Tensor4D {
     const inputs = [x, mean, variance];
 
     let offsetShape = null;
@@ -475,14 +475,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     const program = new BatchNormProgram(
-      x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
-      varianceEpsilon);
+        x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
+        varianceEpsilon);
     return this.compileAndRun(program, inputs);
   }
 
   localResponseNormalization4D(
-    x: Tensor4D, radius: number, bias: number, alpha: number,
-    beta: number): Tensor4D {
+      x: Tensor4D, radius: number, bias: number, alpha: number,
+      beta: number): Tensor4D {
     const program = new LRNProgram(x.shape, radius, bias, alpha, beta);
     return this.compileAndRun(program, [x]);
   }
@@ -493,7 +493,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   pad<T extends Tensor>(
-    x: T, paddings: Array<[number, number]>, constantValue: number): T {
+      x: T, paddings: Array<[number, number]>, constantValue: number): T {
     const program = new PadProgram(x.shape, paddings, constantValue);
     return this.compileAndRun(program, [x]);
   }
@@ -509,12 +509,12 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private reduce(
-      x: Tensor2D, reduceType: 'max' | 'min' | 'sum',
+      x: Tensor2D, reduceType: 'all'|'any'|'max'|'min'|'sum',
       dtype: DataType): Tensor2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = { windowSize, inSize, batchSize };
+    const reduceInfo = {windowSize, inSize, batchSize};
     const program = new ReduceProgram(reduceInfo, reduceType);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
@@ -527,8 +527,8 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private argReduce(
-    x: Tensor2D, reduceType: 'max' | 'min',
-    bestIndicesA: Tensor2D = null): Tensor2D {
+      x: Tensor2D, reduceType: 'max'|'min',
+      bestIndicesA: Tensor2D = null): Tensor2D {
     let batchSize = x.shape[0];
     let inSize = x.shape[1];
     if (bestIndicesA != null) {
@@ -536,9 +536,9 @@ export class MathBackendWebGL implements KernelBackend {
       inSize = bestIndicesA.shape[1];
     }
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);
-    const reduceInfo = { windowSize, inSize, batchSize };
+    const reduceInfo = {windowSize, inSize, batchSize};
     const program =
-      new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
+        new ArgMinMaxProgram(reduceInfo, reduceType, bestIndicesA == null);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], 'int32');
     const inputs = [x];
@@ -556,7 +556,7 @@ export class MathBackendWebGL implements KernelBackend {
   sum(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
     const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     const outputDType = types.sumOutType(x.dtype);
@@ -564,7 +564,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   unsortedSegmentSum<T extends Tensor>(
-    x: T, segmentIds: Tensor1D, numSegments: number): Tensor {
+      x: T, segmentIds: Tensor1D, numSegments: number): Tensor {
     let axis = 0;
     const permutation = axis_util.getAxesPermutation([axis], x.rank);
     let permutedX = x;
@@ -574,14 +574,14 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     const outShape =
-      segment_util.computeOutShape(permutedX.shape, axis, numSegments);
+        segment_util.computeOutShape(permutedX.shape, axis, numSegments);
     const inSize = util.sizeFromShape([permutedX.shape[axis]]);
     const a2D = permutedX.as2D(-1, inSize);
     const outputDType = types.sumOutType(x.dtype);
     let result =
-      this.segOpCompute(
-        a2D, 'unsortedSegmentSum', segmentIds, outputDType, numSegments)
-        .reshape(outShape);
+        this.segOpCompute(
+                a2D, 'unsortedSegmentSum', segmentIds, outputDType, numSegments)
+            .reshape(outShape);
     if (permutation != null) {
       result = result.transpose(axis_util.getUndoAxesPermutation(permutation));
     }
@@ -589,13 +589,13 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private segOpCompute(
-    x: Tensor2D, segOpType: 'unsortedSegmentSum', segmentIds: Tensor1D,
-    dtype: DataType, numSegments: number): Tensor2D {
+      x: Tensor2D, segOpType: 'unsortedSegmentSum', segmentIds: Tensor1D,
+      dtype: DataType, numSegments: number): Tensor2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize =
-      segment_util.segOpComputeOptimalWindowSize(inSize, numSegments);
-    const segOpInfo = { windowSize, inSize, batchSize, numSegments };
+        segment_util.segOpComputeOptimalWindowSize(inSize, numSegments);
+    const segOpInfo = {windowSize, inSize, batchSize, numSegments};
     const program = new SegmentOpProgram(segOpInfo, segOpType);
     const [rows, cols] = program.outputShape;
     const output = this.makeOutputArray<Tensor2D>([rows, cols], dtype);
@@ -612,7 +612,7 @@ export class MathBackendWebGL implements KernelBackend {
     const axes = [axis];
     axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
     const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.argReduce(a2D, 'min').reshape(outShape);
@@ -622,18 +622,18 @@ export class MathBackendWebGL implements KernelBackend {
     const axes = [axis];
     axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
     const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.argReduce(a2D, 'max').reshape(outShape);
   }
 
   cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
-    Tensor {
+      Tensor {
     if (axis !== x.rank - 1) {
       throw new Error(
-        `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
-        `but got axis=${axis}`);
+          `WebGL cumsum shader expects an inner-most axis=${x.rank - 1} ` +
+          `but got axis=${axis}`);
     }
     const program = new CumSumProgram(x.shape, exclusive, reverse);
     return this.compileAndRun(program, [x]);
@@ -647,7 +647,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   notEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -660,7 +660,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   lessEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -673,7 +673,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   greaterEqual(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -685,14 +685,14 @@ export class MathBackendWebGL implements KernelBackend {
 
   logicalAnd(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
   logicalOr(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
@@ -714,7 +714,7 @@ export class MathBackendWebGL implements KernelBackend {
   min(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
     const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
@@ -734,7 +734,7 @@ export class MathBackendWebGL implements KernelBackend {
   max(x: Tensor, axes: number[]): Tensor {
     axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
     const [outShape, reduceShape] =
-      axis_util.computeOutAndReduceShapes(x.shape, axes);
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
     return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
@@ -745,9 +745,27 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [a, b]);
   }
 
+  all(x: Tensor, axes: number[]): Tensor {
+    axis_util.assertAxesAreInnerMostDims('all', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.reduce(a2D, 'all', a2D.dtype).reshape(outShape);
+  }
+
+  any(x: Tensor, axes: number[]): Tensor {
+    axis_util.assertAxesAreInnerMostDims('any', axes, x.rank);
+    const [outShape, reduceShape] =
+        axis_util.computeOutAndReduceShapes(x.shape, axes);
+    const inSize = util.sizeFromShape(reduceShape);
+    const a2D = x.as2D(-1, inSize);
+    return this.reduce(a2D, 'any', a2D.dtype).reshape(outShape);
+  }
+
   squaredDifference(a: Tensor, b: Tensor): Tensor {
     const program =
-      new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
+        new BinaryOpProgram(binaryop_gpu.SQUARED_DIFFERENCE, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]);
   }
 
@@ -770,24 +788,24 @@ export class MathBackendWebGL implements KernelBackend {
   add(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
     const output =
-      this.makeOutputArray(
-        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
   }
 
   subtract(a: Tensor, b: Tensor): Tensor {
     const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
     const output =
-      this.makeOutputArray(
-        program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as Tensor;
     return this.compileAndRun<Tensor, Tensor>(program, [a, b], output);
   }
 
   pow<T extends Tensor>(a: T, b: Tensor): T {
     const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
     const output =
-      this.makeOutputArray(
-        program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
     return this.compileAndRun<Tensor, T>(program, [a, b], output);
   }
 
@@ -864,7 +882,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   eluDer<T extends Tensor>(dy: T, y: T): T {
     const program =
-      new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
+        new BinaryOpProgram(binaryop_gpu.ELU_DER, dy.shape, y.shape);
     return this.compileAndRun(program, [dy, y]) as T;
   }
 
@@ -982,7 +1000,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-    Tensor4D {
+      Tensor4D {
     const program = new Conv2DDerInputProgram(convInfo);
     return this.compileAndRun(program, [dy, filter]);
   }
@@ -993,19 +1011,19 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   depthwiseConv2D(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-    Tensor4D {
+      Tensor4D {
     const program = new DepthwiseConv2DProgram(convInfo);
     return this.compileAndRun(program, [x, filter]);
   }
 
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-    Tensor4D {
+      Tensor4D {
     const program = new DepthwiseConv2DDerInputProgram(convInfo);
     return this.compileAndRun(program, [dy, filter]);
   }
 
   depthwiseConv2DDerFilter(x: Tensor4D, dy: Tensor4D, convInfo: Conv2DInfo):
-    Tensor4D {
+      Tensor4D {
     const program = new DepthwiseConv2DDerFilterProgram(convInfo);
     return this.compileAndRun(program, [x, dy]);
   }
@@ -1013,7 +1031,7 @@ export class MathBackendWebGL implements KernelBackend {
   maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
     const program = new Pool2DProgram(convInfo, 'max', false);
     const output =
-      this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
+        this.makeOutputArray(program.outputShape, x.dtype) as Tensor4D;
     return this.compileAndRun(program, [x], output);
   }
 
@@ -1024,18 +1042,18 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):
-    Tensor4D {
+      Tensor4D {
     const getPositions = true;
     const maxPoolPositionsProgram =
-      new Pool2DProgram(convInfo, 'max', getPositions);
+        new Pool2DProgram(convInfo, 'max', getPositions);
     const maxPoolPositions: Tensor4D =
-      this.compileAndRun(maxPoolPositionsProgram, [x]);
+        this.compileAndRun(maxPoolPositionsProgram, [x]);
 
     const maxPoolBackPropProgram = new MaxPool2DBackpropProgram(convInfo);
     const output =
-      this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
+        this.makeOutputArray(maxPoolBackPropProgram.outputShape, x.dtype);
     const result = this.compileAndRun(
-      maxPoolBackPropProgram, [dy, maxPoolPositions], output);
+        maxPoolBackPropProgram, [dy, maxPoolPositions], output);
     maxPoolPositions.dispose();
     return result as Tensor4D;
   }
@@ -1043,7 +1061,7 @@ export class MathBackendWebGL implements KernelBackend {
   avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
     const avgPoolBackpropProgram = new AvgPool2DBackpropProgram(convInfo);
     const output =
-      this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
+        this.makeOutputArray(avgPoolBackpropProgram.outputShape, x.dtype);
     return this.compileAndRun(avgPoolBackpropProgram, [dy], output) as Tensor4D;
   }
 
@@ -1052,61 +1070,61 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   reshape<T extends Tensor<types.Rank>, R extends types.Rank>(
-    x: T, shape: types.ShapeMap[R]): Tensor<R> {
+      x: T, shape: types.ShapeMap[R]): Tensor<R> {
     return backend_util.reshapeTensor(x, shape);
   }
 
   resizeBilinear(
-    x: Tensor4D, newHeight: number, newWidth: number,
-    alignCorners: boolean): Tensor4D {
+      x: Tensor4D, newHeight: number, newWidth: number,
+      alignCorners: boolean): Tensor4D {
     const program =
-      new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
+        new ResizeBilinearProgram(x.shape, newHeight, newWidth, alignCorners);
     return this.compileAndRun(program, [x]);
   }
 
   resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):
-    Tensor4D {
+      Tensor4D {
     const program = new ResizeBilinearBackpropProgram(dy, x, alignCorners);
 
     return this.compileAndRun(program, [dy]);
   }
 
   resizeNearestNeighbor(
-    x: Tensor4D, newHeight: number, newWidth: number,
-    alignCorners: boolean): Tensor4D {
+      x: Tensor4D, newHeight: number, newWidth: number,
+      alignCorners: boolean): Tensor4D {
     const program = new ResizeNearestNeighborProgram(
-      x.shape, newHeight, newWidth, alignCorners);
+        x.shape, newHeight, newWidth, alignCorners);
     return this.compileAndRun(program, [x]);
   }
 
   multinomial(
-    logits: Tensor2D, normalized: boolean, numSamples: number,
-    seed: number): Tensor2D {
+      logits: Tensor2D, normalized: boolean, numSamples: number,
+      seed: number): Tensor2D {
     const probs = normalized ? logits : ops.softmax(logits);
     const batchSize = probs.shape[0];
     const numOutcomes = probs.shape[1];
     const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
     const output =
-      this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
+        this.makeOutputArray(program.outputShape, 'int32') as Tensor2D;
     const customSetup = program.getCustomSetupFunc(seed);
     return this.compileAndRun(program, [probs], output, customSetup);
   }
 
   oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
-    Tensor2D {
+      Tensor2D {
     const program = new OneHotProgram(indices.size, depth, onValue, offValue);
     return this.compileAndRun(program, [indices]);
   }
 
   private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
-    T {
+      T {
     return Tensor.make(shape, {}, dtype) as T;
   }
 
   private compileAndRun<T extends Tensor, K extends Tensor>(
-    program: GPGPUProgram, inputs: T[], output?: K,
-    customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
-    K {
+      program: GPGPUProgram, inputs: T[], output?: K,
+      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
+      K {
     if (output == null) {
       output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
     }
@@ -1114,10 +1132,10 @@ export class MathBackendWebGL implements KernelBackend {
       const texData = this.texData.get(tensor.dataId);
       // Upload small tensors that live on the CPU as uniforms, not as textures.
       if (texData.texture == null && tensor.size <= SIZE_UPLOAD_UNIFORM) {
-        return { tensor, texData: null, isUniform: true };
+        return {tensor, texData: null, isUniform: true};
       }
       this.uploadToGPU(tensor.dataId);
-      return { tensor, texData, isUniform: false };
+      return {tensor, texData, isUniform: false};
     });
     this.uploadToGPU(output.dataId);
     const outputData = {
@@ -1128,10 +1146,10 @@ export class MathBackendWebGL implements KernelBackend {
     const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
     const binary = this.getAndSaveBinary(key, () => {
       return gpgpu_math.compileProgram(
-        this.gpgpu, program, inputsData, outputData);
+          this.gpgpu, program, inputsData, outputData);
     });
     const shouldTimeProgram = this.activeTimers != null;
-    let query: WebGLQuery | CPUTimerQuery;
+    let query: WebGLQuery|CPUTimerQuery;
     if (shouldTimeProgram) {
       query = this.startTimer();
     }
@@ -1142,7 +1160,7 @@ export class MathBackendWebGL implements KernelBackend {
       let numBytesToPage = this.numBytesInGPU - this.NUM_BYTES_BEFORE_PAGING;
       while (numBytesToPage > 0) {
         const dataId = this.lruDataGPU.shift();
-        const { shape, dtype } = this.texData.get(dataId);
+        const {shape, dtype} = this.texData.get(dataId);
         numBytesToPage -= this.computeBytes(shape, dtype);
         this.read(dataId);
       }
@@ -1156,7 +1174,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private getAndSaveBinary(key: string, getBinary: () => GPGPUBinary):
-    GPGPUBinary {
+      GPGPUBinary {
     if (!(key in this.binaryCache)) {
       this.binaryCache[key] = getBinary();
     }
@@ -1190,16 +1208,16 @@ export class MathBackendWebGL implements KernelBackend {
   private throwIfNoData(dataId: DataId) {
     if (!this.texData.has(dataId)) {
       throw new Error(
-        `WebGL backend: No data found for this tensor. ` +
-        `Did you change your backend in the middle of the program? ` +
-        `New backends can't use Tensors created with previous backends`);
+          `WebGL backend: No data found for this tensor. ` +
+          `Did you change your backend in the middle of the program? ` +
+          `New backends can't use Tensors created with previous backends`);
     }
   }
 
   private uploadToGPU(dataId: DataId): void {
     this.throwIfNoData(dataId);
     const texData = this.texData.get(dataId);
-    const { shape, values, texture, dtype, usage } = texData;
+    const {shape, values, texture, dtype, usage} = texData;
     if (texture != null) {
       // Array is already on GPU. No-op.
       // Touching the texture.
@@ -1213,15 +1231,15 @@ export class MathBackendWebGL implements KernelBackend {
       start = performance.now();
     }
     const texShape =
-      webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+        webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
     texData.texShape = texShape;
     const newTexture = this.acquireTexture(dataId, texShape, usage);
     texData.texture = newTexture;
     if (values != null) {
       this.gpgpu.uploadMatrixToTexture(
-        newTexture, texShape[0],
-        // TODO(smilkov): Propagate the original typed array to gpgpu.
-        texShape[1], typedArrayToFloat32(values, dtype));
+          newTexture, texShape[0],
+          // TODO(smilkov): Propagate the original typed array to gpgpu.
+          texShape[1], typedArrayToFloat32(values, dtype));
       // Once uploaded, don't store the values on cpu.
       texData.values = null;
       if (shouldTimeProgram) {
@@ -1236,7 +1254,7 @@ export class MathBackendWebGL implements KernelBackend {
     // the next time a gpgpu program needs the texture.
     const dontKeepCopyOnGPU = this.delayedStorage;
     const texData = this.texData.get(dataId);
-    const { texture, texShape, dtype, usage } = texData;
+    const {texture, texShape, dtype, usage} = texData;
     if (dontKeepCopyOnGPU && texture != null) {
       this.releaseTexture(dataId, texture, texShape, usage);
       texData.texture = null;
@@ -1248,9 +1266,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private releaseTexture(
-    dataId: DataId, texture: WebGLTexture, texShape: [number, number],
-    texType: TextureUsage) {
-    const { shape, dtype } = this.texData.get(dataId);
+      dataId: DataId, texture: WebGLTexture, texShape: [number, number],
+      texType: TextureUsage) {
+    const {shape, dtype} = this.texData.get(dataId);
     const idx = this.lruDataGPU.indexOf(dataId);
     if (idx >= 0) {
       this.lruDataGPU.splice(idx, 1);
@@ -1260,9 +1278,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private acquireTexture(
-    dataId: DataId, texShape: [number, number],
-    texType: TextureUsage): WebGLTexture {
-    const { shape, dtype } = this.texData.get(dataId);
+      dataId: DataId, texShape: [number, number],
+      texType: TextureUsage): WebGLTexture {
+    const {shape, dtype} = this.texData.get(dataId);
     this.lruDataGPU.push(dataId);
     this.numBytesInGPU += this.computeBytes(shape, dtype);
     return this.textureManager.acquireTexture(texShape, texType);
@@ -1278,12 +1296,12 @@ if (ENV.get('IS_BROWSER')) {
 }
 
 function float32ToTypedArray<D extends DataType>(
-  a: Float32Array, dtype: D): DataTypeMap[D] {
+    a: Float32Array, dtype: D): DataTypeMap[D] {
   if (dtype === 'float32') {
     return a;
   } else if (dtype === 'int32' || dtype === 'bool') {
     const result = (dtype === 'int32') ? new Int32Array(a.length) :
-      new Uint8Array(a.length);
+                                         new Uint8Array(a.length);
     for (let i = 0; i < result.length; ++i) {
       result[i] = Math.round(a[i]);
     }
@@ -1294,6 +1312,6 @@ function float32ToTypedArray<D extends DataType>(
 }
 
 function typedArrayToFloat32<D extends DataType>(
-  a: DataTypeMap[D], dtype: D): Float32Array {
+    a: DataTypeMap[D], dtype: D): Float32Array {
   return (a instanceof Float32Array) ? a : new Float32Array(a);
 }

--- a/src/kernels/webgl/binaryop_gpu.ts
+++ b/src/kernels/webgl/binaryop_gpu.ts
@@ -97,6 +97,7 @@ export class BinaryOpProgram implements GPGPUProgram {
     this.outputShape =
       broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
     this.userCode = `
+      uniform float NAN;
       float binaryOperation(float a, float b) {
         ${op}
       }

--- a/src/kernels/webgl/binaryop_gpu.ts
+++ b/src/kernels/webgl/binaryop_gpu.ts
@@ -16,7 +16,8 @@
  */
 
 import * as broadcast_util from '../../ops/broadcast_util';
-import {GPGPUProgram} from './gpgpu_math';
+import { GPGPUProgram } from './gpgpu_math';
+import { GPGPUContext } from './gpgpu_context';
 
 const CHECK_NAN_SNIPPET = `
   if (isNaN(a)) return a;
@@ -26,7 +27,8 @@ const CHECK_NAN_SNIPPET = `
 export const ADD = 'return a + b;';
 export const SUB = 'return a - b;';
 export const MUL = 'return a * b;';
-export const DIV = 'return a / b;';
+export const DIV = `if (a == b) return 1.0;
+  return a / b;`;
 
 // We use native integer division to deal with floating point imprecision. Since
 // we implement floor division and glsl implements truncated division, we
@@ -73,7 +75,8 @@ export const MAX = CHECK_NAN_SNIPPET + `
 export const MIN = CHECK_NAN_SNIPPET + `
   return min(a, b);
 `;
-export const MOD = `return mod(a, b);`;
+export const MOD = `if (b == 0.0) return NAN;
+  return mod(a, b);`;
 
 export const ATAN2 = CHECK_NAN_SNIPPET + `
   return atan(a, b);
@@ -87,9 +90,12 @@ export class BinaryOpProgram implements GPGPUProgram {
   userCode: string;
   supportsBroadcasting = true;
 
+  // Caching uniform location for speed.
+  startLoc: WebGLUniformLocation;
+
   constructor(op: string, aShape: number[], bShape: number[]) {
     this.outputShape =
-        broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
+      broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
     this.userCode = `
       float binaryOperation(float a, float b) {
         ${op}
@@ -101,5 +107,19 @@ export class BinaryOpProgram implements GPGPUProgram {
         setOutput(binaryOperation(a, b));
       }
     `;
+  }
+
+  getCustomSetupFunc() {
+    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
+      if (this.startLoc == null) {
+        this.startLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'NAN');
+        if (this.startLoc == null) {
+          // This means the compiler has optimized and realized it doesn't need
+          // the uniform.
+          return;
+        }
+      }
+      gpgpu.gl.uniform1f(this.startLoc, NaN);
+    };
   }
 }

--- a/src/kernels/webgl/binaryop_gpu.ts
+++ b/src/kernels/webgl/binaryop_gpu.ts
@@ -16,8 +16,8 @@
  */
 
 import * as broadcast_util from '../../ops/broadcast_util';
-import { GPGPUProgram } from './gpgpu_math';
-import { GPGPUContext } from './gpgpu_context';
+import {GPGPUProgram} from './gpgpu_math';
+import {GPGPUContext} from './gpgpu_context';
 
 const CHECK_NAN_SNIPPET = `
   if (isNaN(a)) return a;

--- a/src/kernels/webgl/binaryop_gpu.ts
+++ b/src/kernels/webgl/binaryop_gpu.ts
@@ -95,7 +95,7 @@ export class BinaryOpProgram implements GPGPUProgram {
 
   constructor(op: string, aShape: number[], bShape: number[]) {
     this.outputShape =
-      broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
+        broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
     this.userCode = `
       uniform float NAN;
       float binaryOperation(float a, float b) {

--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -18,8 +18,8 @@
 import * as erf_util from '../../ops/erf_util';
 import * as selu_util from '../../ops/selu_util';
 
-import { GPGPUProgram } from './gpgpu_math';
-import { GPGPUContext } from './gpgpu_context';
+import {GPGPUProgram} from './gpgpu_math';
+import {GPGPUContext} from './gpgpu_context';
 
 export class UnaryOpProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -18,16 +18,21 @@
 import * as erf_util from '../../ops/erf_util';
 import * as selu_util from '../../ops/selu_util';
 
-import {GPGPUProgram} from './gpgpu_math';
+import { GPGPUProgram } from './gpgpu_math';
+import { GPGPUContext } from './gpgpu_context';
 
 export class UnaryOpProgram implements GPGPUProgram {
   variableNames = ['A'];
   userCode: string;
   outputShape: number[];
 
+  // Caching uniform location for speed.
+  startLoc: WebGLUniformLocation;
+
   constructor(aShape: number[], opSnippet: string) {
     this.outputShape = aShape;
     this.userCode = `
+      uniform float NAN;
       float unaryOperation(float x) {
         ${opSnippet}
       }
@@ -39,6 +44,20 @@ export class UnaryOpProgram implements GPGPUProgram {
         setOutput(y);
       }
     `;
+  }
+
+  getCustomSetupFunc() {
+    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
+      if (this.startLoc == null) {
+        this.startLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'NAN');
+        if (this.startLoc == null) {
+          // This means the compiler has optimized and realized it doesn't need
+          // the uniform.
+          return;
+        }
+      }
+      gpgpu.gl.uniform1f(this.startLoc, NaN);
+    };
   }
 }
 
@@ -98,7 +117,8 @@ export const EXP = `return exp(x);`;
 
 export const EXPM1 = `return exp(x) - 1.0;`;
 
-export const LOG = `return log(x);`;
+export const LOG = `if (x < 0.0) return NAN;
+  return log(x);`;
 
 export const LOG1P = `return log(1.0 + x);`;
 
@@ -178,9 +198,13 @@ export const TANH = `
 
 export const ASINH = `return log(x + sqrt(x * x + 1.0));`;
 
-export const ACOSH = `return log(x + sqrt(x * x - 1.0));`;
+export const ACOSH = CHECK_NAN_SNIPPET + `
+  if (x < 1.0) return NAN;
+  return log(x + sqrt(x * x - 1.0));`;
 
-export const ATANH = `return (log(1.0 + x) - log(1.0 - x)) / 2.0;`;
+export const ATANH = CHECK_NAN_SNIPPET + `
+  if ((x < -1.0) || (x > 1.0)) return NAN;
+  return (log(1.0 + x) - log(1.0 - x)) / 2.0;`;
 
 export const ERF = `
   // Error function is calculated approximately with elementary function.


### PR DESCRIPTION
This is fixing issue: https://github.com/tensorflow/tfjs/issues/291

On the newer macs we had issues computing pow, mod, acosh, and atanh due to various issues related to NaN not being properly handled at the GPU level. 

In the case of **acosh** and **mod** the problem stemmed from Div not successfully dividing 3/3 (or 6/6, 7/7, etc). In those cases the result would be .99999 and when floor was applied we got 0 instead of 1. 

In the case of **pow** the problem stemmed from **log** not catching NaN for negative numbers.

Lastly, **atanh** failed due to not checking the inputs for values outside of the range [-1, 1]. For those values **atanh** needed to just return NaN directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1116)
<!-- Reviewable:end -->
