### PR TITLE
Loss Ops: Broadcast weights before reduction

### DIFF
--- a/src/ops/loss_ops.ts
+++ b/src/ops/loss_ops.ts
@@ -19,8 +19,10 @@ import {doc} from '../doc';
 import {Tensor} from '../tensor';
 import {assertArgumentsAreTensors} from '../tensor_util';
 import * as util from '../util';
+
 import {BinaryOps} from './binary_ops';
 import {operation} from './operation';
+import {ones} from './ops';
 import {TensorOps} from './tensor_ops';
 
 export enum Reduction {
@@ -66,8 +68,10 @@ export class LossOps {
       if (weights == null) {
         return weightedLoss.sum().div(TensorOps.scalar(losses.size));
       } else {
+        const broadcastedWeights = weights.mul(ones(losses.shape));
+
         const numNonZeros =
-            weights.notEqual(TensorOps.scalar(0)).sum().toFloat();
+            broadcastedWeights.notEqual(TensorOps.scalar(0)).sum().toFloat();
         return weightedLoss.sum().div(numNonZeros);
       }
     }

--- a/src/ops/loss_ops.ts
+++ b/src/ops/loss_ops.ts
@@ -22,7 +22,6 @@ import * as util from '../util';
 
 import {BinaryOps} from './binary_ops';
 import {operation} from './operation';
-import {ones} from './ops';
 import {TensorOps} from './tensor_ops';
 
 export enum Reduction {
@@ -68,7 +67,7 @@ export class LossOps {
       if (weights == null) {
         return weightedLoss.sum().div(TensorOps.scalar(losses.size));
       } else {
-        const broadcastedWeights = weights.mul(ones(losses.shape));
+        const broadcastedWeights = weights.mul(TensorOps.ones(losses.shape));
 
         const numNonZeros =
             broadcastedWeights.notEqual(TensorOps.scalar(0)).sum().toFloat();

--- a/src/ops/loss_ops_test.ts
+++ b/src/ops/loss_ops_test.ts
@@ -70,6 +70,16 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     expectNumbersClose(y.get(), (1 * 0.1 + 2 * 0 + 3 * 0.3) / 2);
   });
 
+  it('2D - weights - broadcast', () => {
+    const losses = tf.tensor2d([[0, 0, 1], [1, 0, 0], [0, 1, 0]], [3, 3]);
+    const weights = tf.tensor2d([[0.1, 0.2, 0.3]]);
+
+    const y = tf.losses.computeWeightedLoss(losses, weights);
+
+    expect(y.shape).toEqual([]);
+    expectNumbersClose(y.get(), 0.06666667);
+  });
+
   it('1D - weights - Reduction.NONE', () => {
     const losses = tf.tensor1d([1, 2, 3]);
     const weights = tf.tensor1d([0.1, 0.2, 0.3]);


### PR DESCRIPTION
#### Description
This PR adds broadcasting to reduction `SUM_BY_NONZERO_WEIGHTS` before calculating non-zero values.

Fixes https://github.com/tensorflow/tfjs/issues/466

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1125)
<!-- Reviewable:end -->
