### PR TITLE
Fix tf.fromPixels when using tfjs-core from node (cpu backend)

### DIFF
--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -16,7 +16,6 @@
  */
 
 import * as seedrandom from 'seedrandom';
-
 import {ENV} from '../environment';
 import * as axis_util from '../ops/axis_util';
 import * as broadcast_util from '../ops/broadcast_util';
@@ -32,7 +31,6 @@ import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor'
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
 import * as util from '../util';
-
 import {BackendTimingInfo, KernelBackend} from './backend';
 import * as backend_util from './backend_util';
 
@@ -83,12 +81,21 @@ export class MathBackendCPU implements KernelBackend {
       throw new Error('MathBackendCPU.writePixels(): pixels can not be null');
     }
     let vals: Uint8ClampedArray;
-    if (pixels instanceof ImageData) {
-      vals = pixels.data;
-    } else if (pixels instanceof HTMLCanvasElement) {
-      vals = pixels.getContext('2d')
+    // tslint:disable-next-line:no-any
+    if (ENV.get('IS_NODE') && (pixels as any).getContext == null) {
+      throw new Error(
+          'When running in node, pixels must be an HTMLCanvasElement ' +
+          'like the one returned by the `canvas` npm package');
+    }
+    // tslint:disable-next-line:no-any
+    if ((pixels as any).getContext != null) {
+      // tslint:disable-next-line:no-any
+      vals = (pixels as any)
+                 .getContext('2d')
                  .getImageData(0, 0, pixels.width, pixels.height)
                  .data;
+    } else if (pixels instanceof ImageData) {
+      vals = pixels.data;
     } else if (
         pixels instanceof HTMLImageElement ||
         pixels instanceof HTMLVideoElement) {

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -78,7 +78,7 @@ export class MathBackendCPU implements KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('MathBackendCPU.writePixels(): pixels can not be null');
+      throw new Error('pixels passed to tf.fromPixels() can not be null');
     }
     let vals: Uint8ClampedArray;
     // tslint:disable-next-line:no-any
@@ -113,7 +113,9 @@ export class MathBackendCPU implements KernelBackend {
                  .data;
     } else {
       throw new Error(
-          `pixels is of unknown type: ${(pixels as {}).constructor.name}`);
+          'pixels passed to tf.fromPixels() must be either an ' +
+          `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
+          `ImageData, but was ${(pixels as {}).constructor.name}`);
     }
     let values: Int32Array;
     if (numChannels === 4) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -157,7 +157,8 @@ export class MathBackendWebGL implements KernelBackend {
         !(pixels instanceof ImageData)) {
       throw new Error(
           'pixels passed to tf.fromPixels() must be either an ' +
-          'HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ImageData');
+          `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
+          `ImageData, but was ${(pixels as {}).constructor.name}`);
     }
     if (pixels instanceof HTMLVideoElement) {
       if (this.fromPixelsCanvas == null) {

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -18,7 +18,7 @@
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 // tslint:disable-next-line:max-line-length
-import {ALL_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, WEBGL_ENVS, BROWSER_ENVS, CPU_ENVS} from '../test_util';
+import {ALL_ENVS, BROWSER_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, WEBGL_ENVS} from '../test_util';
 import * as util from '../util';
 import {expectArrayInMeanStdRange, jarqueBeraNormalityTest} from './rand_util';
 
@@ -1352,13 +1352,13 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
   it('throws when passed a primitive number', () => {
     // tslint:disable-next-line:no-any
     expect(() => tf.fromPixels(3 as any))
-      .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
   });
 
   it('throws when passed a string', () => {
     // tslint:disable-next-line:no-any
     expect(() => tf.fromPixels('test' as any))
-      .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
   });
 });
 

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -18,7 +18,7 @@
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 // tslint:disable-next-line:max-line-length
-import {ALL_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, WEBGL_ENVS} from '../test_util';
+import {ALL_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, WEBGL_ENVS, BROWSER_ENVS, CPU_ENVS} from '../test_util';
 import * as util from '../util';
 import {expectArrayInMeanStdRange, jarqueBeraNormalityTest} from './rand_util';
 
@@ -1200,7 +1200,51 @@ describeWithFlags('randomUniform', ALL_ENVS, () => {
   });
 });
 
-describeWithFlags('fromPixels', WEBGL_ENVS, () => {
+class MockContext {
+  getImageData(x: number, y: number, width: number, height: number) {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < data.length; ++i) {
+      data[i] = i + 1;
+    }
+    return {data};
+  }
+}
+
+class MockCanvas {
+  constructor(public width: number, public height: number) {}
+  getContext(type: '2d'): MockContext {
+    return new MockContext();
+  }
+}
+
+describeWithFlags('fromPixels, mock canvas', CPU_ENVS, () => {
+  it('accepts a canvas-like element', () => {
+    const c = new MockCanvas(2, 2);
+    // tslint:disable-next-line:no-any
+    const t = tf.fromPixels(c as any);
+    expect(t.dtype).toBe('int32');
+    expect(t.shape).toEqual([2, 2, 3]);
+    tf.test_util.expectArraysEqual(
+        t, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
+  });
+
+  it('accepts a canvas-like element, numChannels=4', () => {
+    const c = new MockCanvas(2, 2);
+    // tslint:disable-next-line:no-any
+    const t = tf.fromPixels(c as any, 4);
+    expect(t.dtype).toBe('int32');
+    expect(t.shape).toEqual([2, 2, 4]);
+    tf.test_util.expectArraysEqual(
+        t, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  });
+
+  it('errors when passed a non-canvas object', () => {
+    // tslint:disable-next-line:no-any
+    expect(() => tf.fromPixels(5 as any)).toThrowError();
+  });
+});
+
+describeWithFlags('fromPixels', BROWSER_ENVS, () => {
   it('ImageData 1x1x3', () => {
     const pixels = new ImageData(1, 1);
     pixels.data[0] = 0;


### PR DESCRIPTION
Fixes tensorflow/tfjs#298.

This PR along with https://github.com/tensorflow/tfjs-node/pull/105 allow users to use `tf.fromPixels()` within node.

When in node, `tf.fromPixels(pixels)` now expects `pixels` to satisfy the `HTMLCanvasElement` interface, like the object returned by the `canvas` npm package.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1127)
<!-- Reviewable:end -->
