### PR TITLE
Ensure that tf.exp() uses non-int32 tensors.

### DIFF
--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -151,6 +151,7 @@ export class UnaryOps {
   @operation
   static exp<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'exp');
+    util.assert($x.dtype !== 'int32', 'Input dtype must not be `int32`.');
 
     const bck = (dy: T, saved: Tensor[]) => {
       const [y] = saved;

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -1254,6 +1254,12 @@ describeWithFlags('exp', ALL_ENVS, () => {
     expectNumbersClose(r.get(2), 1);
   });
 
+  it('exp does not support int32 KREEGER', () => {
+    expect(() => {
+      tf.exp(tf.scalar(2, 'int32'));
+    }).toThrowError();
+  });
+
   it('exp propagates NaNs', () => {
     const a = tf.tensor1d([1, NaN, 0]);
     const r = tf.exp(a);


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/445#event-1687297929

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1129)
<!-- Reviewable:end -->
