### PR TITLE
When backend is already registered, reuse existing backend

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -21,7 +21,7 @@ import {Profiler} from './profiler';
 // tslint:disable-next-line:max-line-length
 import {backpropagateGradients, getFilteredNodesXToY, NamedGradientMap, TapeNode} from './tape';
 // tslint:disable-next-line:max-line-length
-import {DataId, setTensorTracker, Tensor, Tensor3D, Variable} from './tensor';
+import {DataId, Tensor, Tensor3D, Variable} from './tensor';
 // tslint:disable-next-line:max-line-length
 import {NamedTensorMap, NamedVariableMap, TensorContainer} from './tensor_types';
 import {getTensorsInContainer, isTensorInList} from './tensor_util';
@@ -94,7 +94,6 @@ export class Engine implements TensorManager {
     this.activeScope = {track: []};
     this.scopeStack = [this.activeScope];
     this.profiler = new Profiler(backend);
-    setTensorTracker(this);
   }
 
   tidy<T extends TensorContainer>(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -46,7 +46,6 @@ export class Environment {
           'be downloaded to CPU and checked for NaNs. ' +
           'This significantly impacts performance.');
     }
-    setTensorTracker(() => this.engine);
   }
 
   /**
@@ -355,7 +354,9 @@ export class Environment {
     if (name in this.registry) {
       console.warn(
           `${name} backend was already registered. Reusing existing backend`);
-      setTensorTrackerFn(() => this.engine);
+      if (setTensorTrackerFn != null) {
+        setTensorTrackerFn(() => this.engine);
+      }
       return false;
     }
     try {
@@ -404,7 +405,10 @@ function getGlobalNamespace(): {ENV: Environment} {
 
 function getOrMakeEnvironment(): Environment {
   const ns = getGlobalNamespace();
-  ns.ENV = ns.ENV || new Environment(getFeaturesFromURL());
+  if (ns.ENV == null) {
+    ns.ENV = new Environment(getFeaturesFromURL());
+    setTensorTracker(() => ns.ENV.engine);
+  }
   return ns.ENV;
 }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -21,7 +21,7 @@ import {Engine, MemoryInfo, ScopeFn, TimingInfo} from './engine';
 // tslint:disable-next-line:max-line-length
 import {Features, getFeaturesFromURL, getWebGLDisjointQueryTimerVersion, isChrome, isDownloadFloatTextureEnabled, isRenderToFloatTextureEnabled, isWebGLGetBufferSubDataAsyncExtensionEnabled, isWebGLVersionEnabled} from './environment_util';
 import {KernelBackend} from './kernels/backend';
-import {Tensor} from './tensor';
+import {setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
@@ -46,6 +46,7 @@ export class Environment {
           'be downloaded to CPU and checked for NaNs. ' +
           'This significantly impacts performance.');
     }
+    setTensorTracker(() => this.engine);
   }
 
   /**
@@ -348,11 +349,13 @@ export class Environment {
    *     priority to find the best backend. Defaults to 1.
    * @return False if the creation/registration failed. True otherwise.
    */
-  registerBackend(name: string, factory: () => KernelBackend, priority = 1):
-      boolean {
+  registerBackend(
+      name: string, factory: () => KernelBackend, priority = 1,
+      setTensorTrackerFn?: (f: () => TensorTracker) => void): boolean {
     if (name in this.registry) {
       console.warn(
           `${name} backend was already registered. Reusing existing backend`);
+      setTensorTrackerFn(() => this.engine);
       return false;
     }
     try {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -351,7 +351,9 @@ export class Environment {
   registerBackend(name: string, factory: () => KernelBackend, priority = 1):
       boolean {
     if (name in this.registry) {
-      console.warn(`${name} backend was already registered`);
+      console.warn(
+          `${name} backend was already registered. Reusing existing backend`);
+      return false;
     }
     try {
       const backend = factory();

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -27,7 +27,7 @@ import {buffer, tensor3d, tensor4d} from '../ops/ops';
 import * as selu_util from '../ops/selu_util';
 import {getStridedSlicedInfo} from '../ops/slice_util';
 // tslint:disable-next-line:max-line-length
-import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
+import {DataId, setTensorTracker, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
 import * as util from '../util';
@@ -2073,4 +2073,5 @@ export class MathBackendCPU implements KernelBackend {
   dispose() {}
 }
 
-ENV.registerBackend('cpu', () => new MathBackendCPU(), 1 /* priority */);
+ENV.registerBackend(
+    'cpu', () => new MathBackendCPU(), 1 /* priority */, setTensorTracker);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -24,7 +24,7 @@ import * as reduce_util from '../ops/reduce_util';
 import * as segment_util from '../ops/segment_util';
 import {getStridedSlicedInfo} from '../ops/slice_util';
 // tslint:disable-next-line:max-line-length
-import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
+import {DataId, setTensorTracker, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import * as types from '../types';
 import {DataType, DataTypeMap, RecursiveArray, TypedArray} from '../types';
 import * as util from '../util';
@@ -1309,7 +1309,9 @@ export class MathBackendWebGL implements KernelBackend {
 }
 
 if (ENV.get('IS_BROWSER')) {
-  ENV.registerBackend('webgl', () => new MathBackendWebGL(), 2 /* priority */);
+  ENV.registerBackend(
+      'webgl', () => new MathBackendWebGL(), 2 /* priority */,
+      setTensorTracker);
 }
 
 function float32ToTypedArray<D extends DataType>(


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/109.

When the backend is already registered, re-use the existing backend. Also tested that double imports in the browser works:

```html
<script src="tf-core.min.js"></script>
<script src="tf-core.min.js"></script>
<script>tf.square(3).print()</script>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1130)
<!-- Reviewable:end -->
