### PR TITLE
Initial coverage generation support (also: do not instrument normal tests)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,27 @@
  * =============================================================================
  */
 
+const karmaTypescriptConfig = {
+  tsconfig: 'tsconfig.json',
+  // Disable coverage reports and instrumentation by default for tests
+  coverageOptions: {
+    instrumentation: false
+  },
+  reports: {
+  }
+};
+
+// Enable coverage reports and instrumentation under KARMA_COVERAGE=1 env
+const coverageEnabled = !!process.env.KARMA_COVERAGE;
+if (coverageEnabled) {
+  karmaTypescriptConfig.coverageOptions.instrumentation = true;
+  karmaTypescriptConfig.coverageOptions.exclude = /_test\.ts$/;
+  karmaTypescriptConfig.reports = {
+    html: 'coverage',
+    'text-summary': ''
+  };
+}
+
 module.exports = function(config) {
   config.set({
     frameworks: ['jasmine', 'karma-typescript'],
@@ -22,10 +43,7 @@ module.exports = function(config) {
     preprocessors: {
       '**/*.ts': ['karma-typescript'],  // *.tsx for React Jsx
     },
-    karmaTypescriptConfig: {
-      tsconfig: 'tsconfig.json',
-      reports: {} // Do not produce coverage html.
-    },
+    karmaTypescriptConfig,
     reporters: ['progress', 'karma-typescript'],
     browsers: ['Chrome'],
     browserStack: {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
     "lint": "tslint -p . -t verbose",
+    "coverage": "KARMA_COVERAGE=1 karma start --browsers='Chrome' --singleRun",
     "test": "karma start",
     "test-travis": "./scripts/test-travis.sh"
   },


### PR DESCRIPTION
This adds `npm run coverage` script, which produces coverage output in two formats: `text-summary` (to console) and `html` (detailed output written to `./coverage/` dir).

It does not introduce Travis + coveralls.io/codecov.io integration yet, this is just the first step aimed at getting coverage reports locally.

This also disables Istanbul instrumentation for all files during normal non-coverage tests, which were previously enabled for all tests.

To demonstrate the last clause:
  1. Check out `master`, run `npm it` (or `npm install && npm run test`), while the tests are running, open these two locations (adjust karma port if needed): http://localhost:9876/base/src/common.js and http://localhost:9876/base/src/common_test.js.
  Observe that the code is instrumented.
  Imo, that doesn't make much sense — coverage reporting seems to be disabled, coverage tests are also not used, and there seem to be performance warnings enabled.
  2. Check out this PR, run `npm t`, open those two urls again while the tests are running.
      Observe that the code of those two files is *not* instrumented.
  3. Check out this PR, run `npm run coverage`, open those two urls again while the tests are running.
      Observe that the code of `common.js` is instrumented while the code of `common_test.js` is not — instrumentation of test files was explicitly disabled.
  4. Observe the coverage summary and `./coverage` dir with HTML output being created at the previous step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1132)
<!-- Reviewable:end -->
