### PR TITLE
Allow TensorLike objects for oneHot.

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -20,6 +20,7 @@ import {ENV} from '../environment';
 // tslint:disable-next-line:max-line-length
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
 import {convertToTensor, convertToTensorArray} from '../tensor_util';
+// tslint:disable-next-line:max-line-length
 import {DataType, Rank, ShapeMap, TensorLike, TensorLike1D, TypedArray} from '../types';
 import * as util from '../util';
 

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -20,7 +20,7 @@ import {ENV} from '../environment';
 // tslint:disable-next-line:max-line-length
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
 import {convertToTensor, convertToTensorArray} from '../tensor_util';
-import {DataType, Rank, ShapeMap, TensorLike, TypedArray} from '../types';
+import {DataType, Rank, ShapeMap, TensorLike, TensorLike1D, TypedArray} from '../types';
 import * as util from '../util';
 
 // tslint:disable-next-line:max-line-length
@@ -293,15 +293,18 @@ export class ArrayOps {
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
   @operation
-  static oneHot(indices: Tensor1D, depth: number, onValue = 1, offValue = 0):
+  static oneHot(
+      indices: Tensor1D|TensorLike1D, depth: number, onValue = 1, offValue = 0):
       Tensor2D {
-    util.assert(indices.dtype === 'int32', 'Indices must be of dtype `int32`');
+    const $indices = convertToTensor(indices, 'indices', 'oneHot', 'int32');
+    util.assert($indices.dtype === 'int32', 'Indices must be of dtype `int32`');
+
     if (depth < 2) {
       throw new Error(`Error in oneHot: depth must be >=2, but it is ${depth}`);
     }
     return ENV.engine.runKernel(
-        backend => backend.oneHot(indices, depth, onValue, offValue),
-        {indices});
+        backend => backend.oneHot($indices, depth, onValue, offValue),
+        {$indices});
   }
 
   /**

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2343,6 +2343,12 @@ describeWithFlags('oneHot', ALL_ENVS, () => {
 
     expect(res.dtype).toEqual(expectedType);
   });
+
+  it('oneHot accepts a tensor-like object', () => {
+    const res = tf.oneHot([0, 1], 2);
+    expect(res.shape).toEqual([2, 2]);
+    expectArraysClose(res, [1, 0, 0, 1]);
+  });
 });
 
 describeWithFlags('linspace', ALL_ENVS, () => {


### PR DESCRIPTION
Allows a TensorLike1D (an array) for tf.oneHot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1140)
<!-- Reviewable:end -->
