### PR TITLE
use setImmediate instead of requestAnimationFrame on Node.js

### DIFF
--- a/src/browser_util.ts
+++ b/src/browser_util.ts
@@ -16,15 +16,21 @@
  */
 import {doc} from './doc';
 
+const delayCallback = typeof requestAnimationFrame !== 'undefined'
+  ? requestAnimationFrame // Browsers
+  : setImmediate; // Node.js
+
 export class BrowserUtil {
   /**
    * Returns a promise that resolve when a requestAnimationFrame has completed.
+   *
+   * On Node.js this uses setImmediate instead of requestAnimationFrame.
    *
    * This is simply a sugar method so that users can do the following:
    * `await tf.nextFrame();`
    */
   @doc({heading: 'Performance', subheading: 'Timing'})
   static nextFrame(): Promise<void> {
-    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+    return new Promise<void>(resolve => delayCallback(() => resolve()));
   }
 }

--- a/src/browser_util_test.ts
+++ b/src/browser_util_test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from './index';
+import {describeWithFlags} from './jasmine_util';
+import {ALL_ENVS} from './test_util';
+
+describeWithFlags('nextFrame', ALL_ENVS, () => {
+  it('basic usage', async () => {
+    const t0 = tf.util.now();
+    await tf.nextFrame();
+    const t1 = tf.util.now();
+    // tf.util.now should give sufficient accuracy on all supported envs.
+    expect(t1 > t0);
+  });
+
+  it('does not block timers', async () => {
+    let flag = false;
+    setTimeout(() => {
+      flag = true;
+    }, 50);
+    const t0 = tf.util.now();
+    expect(flag).toBe(false);
+    while (tf.util.now() - t0 < 1000 && !flag) {
+      await tf.nextFrame();
+    }
+    expect(flag).toBe(true);
+  });
+});


### PR DESCRIPTION
#### Description

This makes `await tf.nextFrame();` work on Node.js for better code interoperability.

It also does the expected thing of unblocking the event loop and giving the engine time to perform other tasks, though the name is a bit confusing.

The order of the check is important: IE and Edge also implement `setImmediate`, but all versions that do that also have `requestAnimationFrame`, so `requestAnimationFrame` is used on those.

Refs: [setImmediate](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args), [Node.js Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/).

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1145)
<!-- Reviewable:end -->
