### PR TITLE
Remove @operation decorator

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -16,7 +16,6 @@
  */
 
 import {BackendTimingInfo, KernelBackend} from './kernels/backend';
-import {TensorOps} from './ops/tensor_ops';
 import {Profiler} from './profiler';
 // tslint:disable-next-line:max-line-length
 import {backpropagateGradients, getFilteredNodesXToY, NamedGradientMap, TapeNode} from './tape';
@@ -27,7 +26,7 @@ import {NamedTensorMap, NamedVariableMap, TensorContainer} from './tensor_types'
 import {getTensorsInContainer, isTensorInList} from './tensor_util';
 import {TypedArray} from './types';
 import * as util from './util';
-import {now} from './util';
+import {makeOnesTypedArray, now, sizeFromShape} from './util';
 
 /**
  * A function that computes an output. The save function is for saving tensors
@@ -388,8 +387,7 @@ export class Engine implements TensorManager {
       }
 
       const accumulatedGradientMap: {[tensorId: number]: Tensor} = {};
-      accumulatedGradientMap[y.id] =
-          (dy == null) ? TensorOps.ones(y.shape) : dy;
+      accumulatedGradientMap[y.id] = (dy == null) ? ones(y.shape) : dy;
 
       // Backprop gradients through the filtered nodes.
       backpropagateGradients(accumulatedGradientMap, filteredTape);
@@ -489,4 +487,9 @@ export class Engine implements TensorManager {
     this.activeScope.track.push(result);
     return result;
   }
+}
+
+function ones(shape: number[]): Tensor {
+  const values = makeOnesTypedArray(sizeFromShape(shape), 'float32');
+  return Tensor.make(shape, {values});
 }

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {TensorOps} from '../ops/tensor_ops';
+import {tensor} from '../ops/tensor_ops';
 import {Tensor} from '../tensor';
 import {NamedTensorMap} from '../tensor_types';
 import {TypedArray} from '../types';
@@ -92,14 +92,11 @@ export function decodeWeights(
     const size = sizeFromShape(shape);
     let value: Tensor;
     if (dtype === 'float32') {
-      value = TensorOps.tensor(
-          new Float32Array(buffer, offset, size), shape, 'float32');
+      value = tensor(new Float32Array(buffer, offset, size), shape, 'float32');
     } else if (dtype === 'int32') {
-      value = TensorOps.tensor(
-          new Int32Array(buffer, offset, size), shape, 'int32');
+      value = tensor(new Int32Array(buffer, offset, size), shape, 'int32');
     } else if (dtype === 'bool') {
-      value =
-          TensorOps.tensor(new Uint8Array(buffer, offset, size), shape, 'bool');
+      value = tensor(new Uint8Array(buffer, offset, size), shape, 'bool');
     } else {
       throw new Error(`Unsupported dtype in weight '${name}': ${dtype}`);
     }
@@ -143,11 +140,9 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
 }
 
 // Use Buffer on Node.js instead of Blob/atob/btoa
-const useNodeBuffer = typeof Buffer !== 'undefined' && (
-  typeof Blob === 'undefined' ||
-  typeof atob === 'undefined' ||
-  typeof btoa === 'undefined'
-);
+const useNodeBuffer = typeof Buffer !== 'undefined' &&
+    (typeof Blob === 'undefined' || typeof atob === 'undefined' ||
+     typeof btoa === 'undefined');
 
 /**
  * Calculate the byte length of a JavaScript string.

--- a/src/kernels/backend_util.ts
+++ b/src/kernels/backend_util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {TensorOps} from '../ops/tensor_ops';
+import {scalar} from '../ops/tensor_ops';
 import {Tensor} from '../tensor';
 import {Rank} from '../types';
 import {DataType, ShapeMap} from '../types';
@@ -32,7 +32,7 @@ export function castTensor<T extends Tensor>(
   if (dtype === 'int32') {
     return backend.int(x);
   } else if (dtype === 'bool') {
-    return backend.notEqual(x, TensorOps.scalar(0, x.dtype)) as T;
+    return backend.notEqual(x, scalar(0, x.dtype)) as T;
   } else {
     throw new Error(`Error in Cast: unknown dtype argument (${dtype})`);
   }

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -23,10 +23,9 @@ import {convertToTensor, convertToTensorArray} from '../tensor_util';
 // tslint:disable-next-line:max-line-length
 import {DataType, Rank, ShapeMap, TensorLike, TensorLike1D, TypedArray} from '../types';
 import * as util from '../util';
-
 // tslint:disable-next-line:max-line-length
 import {getAxesPermutation, getInnerMostAxes, parseAxisParam} from './axis_util';
-import {ConcatOps} from './concat';
+import {concat} from './concat';
 import {operation} from './operation';
 import {MPRandGauss} from './rand';
 import {TensorOps} from './tensor_ops';
@@ -749,7 +748,7 @@ export class ArrayOps {
           'All tensors passed to stack must have matching dtypes');
     });
     const expandedTensors = $tensors.map(t => t.expandDims(axis));
-    return ConcatOps.concat(expandedTensors, axis);
+    return concat(expandedTensors, axis);
   }
 
   /**

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -26,11 +26,11 @@ import * as util from '../util';
 // tslint:disable-next-line:max-line-length
 import {getAxesPermutation, getInnerMostAxes, parseAxisParam} from './axis_util';
 import {concat} from './concat';
-import {operation} from './operation';
+import {op} from './operation';
 import {MPRandGauss} from './rand';
-import {TensorOps} from './tensor_ops';
+import {zerosLike} from './tensor_ops';
 
-export class ArrayOps {
+class ArrayOps {
   /**
    * Creates a new tensor with the same values and shape as the specified
    * tensor.
@@ -44,7 +44,6 @@ export class ArrayOps {
    * @param x The tensor to clone.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
-  @operation
   static clone<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'clone');
     const der = (dy: T) => {
@@ -70,7 +69,6 @@ export class ArrayOps {
    *   with batch repetition if `batchShape` is specified.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
-  @operation
   static eye(
       numRows: number, numColumns?: number,
       batchShape?: [number]|[number, number],
@@ -118,7 +116,6 @@ export class ArrayOps {
    * @param seed The seed for the random number generator.
    */
   @doc({heading: 'Tensors', subheading: 'Random'})
-  @operation
   static randomNormal<R extends Rank>(
       shape: ShapeMap[R], mean = 0, stdDev = 1, dtype?: 'float32'|'int32',
       seed?: number): Tensor<R> {
@@ -153,7 +150,6 @@ export class ArrayOps {
    * @param seed The seed for the random number generator.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
-  @operation
   static truncatedNormal<R extends Rank>(
       shape: ShapeMap[R], mean = 0, stdDev = 1, dtype?: 'float32'|'int32',
       seed?: number): Tensor<R> {
@@ -188,7 +184,6 @@ export class ArrayOps {
    * @param dtype The data type of the output tensor. Defaults to 'float32'.
    */
   @doc({heading: 'Tensors', subheading: 'Random'})
-  @operation
   static randomUniform<R extends Rank>(
       shape: ShapeMap[R], minval = 0, maxval = 1, dtype: DataType = 'float32'):
       Tensor<R> {
@@ -208,10 +203,9 @@ export class ArrayOps {
    * for each element in the output tensor.
    * @param dtype The data type of the output tensor. Defaults to 'float32'.
    */
-  @operation
   static rand<R extends Rank>(
-      shape: ShapeMap[R], randFunction: () => number, dtype?: DataType):
-      Tensor<R> {
+      shape: ShapeMap[R], randFunction: () => number,
+      dtype?: DataType): Tensor<R> {
     const size = util.sizeFromShape(shape);
 
     let values = null;
@@ -250,7 +244,6 @@ export class ArrayOps {
    *     `[batchSize, numSamples]`, depending on the rank of the input.
    */
   @doc({heading: 'Tensors', subheading: 'Random'})
-  @operation
   static multinomial(
       logits: Tensor1D|Tensor2D|TensorLike, numSamples: number, seed?: number,
       normalized = false): Tensor1D|Tensor2D {
@@ -292,7 +285,6 @@ export class ArrayOps {
    *     not match the location.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
-  @operation
   static oneHot(
       indices: Tensor1D|TensorLike1D, depth: number, onValue = 1, offValue = 0):
       Tensor2D {
@@ -327,7 +319,6 @@ export class ArrayOps {
    * 3 (ignores alpha channel of input image).
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
-  @operation
   static fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels = 3): Tensor3D {
@@ -463,7 +454,6 @@ export class ArrayOps {
    * @param shape An array of integers defining the output tensor shape.
    */
   @doc({heading: 'Tensors', subheading: 'Transformations'})
-  @operation
   static reshape<R2 extends Rank>(x: Tensor|TensorLike, shape: ShapeMap[R2]):
       Tensor<R2> {
     const $x = convertToTensor(x, 'x', 'reshape');
@@ -510,7 +500,6 @@ export class ArrayOps {
    * @param dtype The dtype to cast the input tensor to.
    */
   @doc({heading: 'Tensors', subheading: 'Transformations'})
-  @operation
   static cast<T extends Tensor>(x: T|TensorLike, dtype: DataType): T {
     const $x = convertToTensor(x, 'x', 'cast');
 
@@ -545,7 +534,6 @@ export class ArrayOps {
    * @param reps Determines the number of replications per dimension.
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static tile<T extends Tensor>(x: T|TensorLike, reps: number[]): T {
     const $x = convertToTensor(x, 'x', 'tile');
 
@@ -555,7 +543,7 @@ export class ArrayOps {
             `must match length of reps ${reps}.`);
     const grad = (dy: T) => {
       const derX = () => {
-        let xGrad = TensorOps.zerosLike($x);
+        let xGrad = zerosLike($x);
         // TODO(cais): Maybe reduce memory footprint by avoiding repeated
         // slicing.
         if ($x.rank === 1) {
@@ -688,7 +676,6 @@ export class ArrayOps {
    * @param constantValue The pad value to use. Defaults to 0.
    */
   @doc({heading: 'Tensors', subheading: 'Transformations'})
-  @operation
   static pad<T extends Tensor>(
       x: T|TensorLike, paddings: Array<[number, number]>, constantValue = 0):
       T {
@@ -722,7 +709,6 @@ export class ArrayOps {
    * @param axis The axis to stack along. Defaults to 0 (the first dim).
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static stack<T extends Tensor>(tensors: T[]|TensorLike[], axis = 0): Tensor {
     const $tensors = convertToTensorArray(tensors, 'tensors', 'stack');
 
@@ -764,7 +750,6 @@ export class ArrayOps {
    * @param axis The axis to unstack along. Defaults to 0 (the first dim).
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static unstack<T extends Tensor>(x: T|TensorLike, axis = 0): Tensor[] {
     const $x = convertToTensor(x, 'x', 'unstack');
     const num = $x.shape[axis];
@@ -822,7 +807,6 @@ export class ArrayOps {
    * dim).
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static split<T extends Tensor>(
       x: T|TensorLike, numOrSizeSplits: number[]|number, axis = 0): T[] {
     const $x = convertToTensor(x, 'x', 'split');
@@ -914,7 +898,6 @@ export class ArrayOps {
    *     to 0 (the first dimension).
    */
   @doc({heading: 'Tensors', subheading: 'Transformations'})
-  @operation
   static expandDims<R2 extends Rank>(x: Tensor|TensorLike, axis = 0):
       Tensor<R2> {
     const $x = convertToTensor(x, 'x', 'expandDims');
@@ -972,3 +955,32 @@ export class ArrayOps {
     console.log(x.toString(verbose));
   }
 }
+
+// No need to wrap.
+export const fromPixels = ArrayOps.fromPixels;
+export const buffer = ArrayOps.buffer;
+export const print = ArrayOps.print;
+export const toPixels = ArrayOps.toPixels;
+
+export const cast = op(ArrayOps.cast);
+export const clone = op(ArrayOps.clone);
+export const cumsum = op(ArrayOps.cumsum);
+export const expandDims = op(ArrayOps.expandDims);
+export const eye = op(ArrayOps.eye);
+export const multinomial = op(ArrayOps.multinomial);
+export const oneHot = op(ArrayOps.oneHot);
+export const pad = op(ArrayOps.pad);
+export const pad1d = op(ArrayOps.pad1d);
+export const pad2d = op(ArrayOps.pad2d);
+export const pad3d = op(ArrayOps.pad3d);
+export const pad4d = op(ArrayOps.pad4d);
+export const rand = op(ArrayOps.rand);
+export const randomNormal = op(ArrayOps.randomNormal);
+export const randomUniform = op(ArrayOps.randomUniform);
+export const reshape = op(ArrayOps.reshape);
+export const split = op(ArrayOps.split);
+export const squeeze = op(ArrayOps.squeeze);
+export const stack = op(ArrayOps.stack);
+export const tile = op(ArrayOps.tile);
+export const truncatedNormal = op(ArrayOps.truncatedNormal);
+export const unstack = op(ArrayOps.unstack);

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -21,12 +21,14 @@ import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {Rank, TensorLike} from '../types';
 import * as util from '../util';
-import {ArrayOps} from './array_ops';
-import {getReductionAxes} from './broadcast_util';
-import {TensorOps} from './tensor_ops';
-import {UnaryOps} from './unary_ops';
 
-export class BatchNormOps {
+import {tile} from './array_ops';
+import {getReductionAxes} from './broadcast_util';
+import {op} from './operation';
+import {scalar} from './tensor_ops';
+import {rsqrt} from './unary_ops';
+
+class BatchNormOps {
   /**
    * Batch normalization, strictly for 2D. For the more relaxed version, see
    * `batchNormalization`.
@@ -266,7 +268,7 @@ export class BatchNormOps {
     }
 
     const der = (dy: Tensor) => {
-      const scaleValue = $scale == null ? TensorOps.scalar(1) : $scale;
+      const scaleValue = $scale == null ? scalar(1) : $scale;
       const reductionAxes = getReductionAxes($mean.shape, x4D.shape);
       const tileShape: number[] = [];
       if ($mean.rank === 1) {
@@ -278,15 +280,14 @@ export class BatchNormOps {
 
       const xMinusMean = $x.sub($mean);
       const dyTimesScaleValue = dy.mul(scaleValue);
-      const oneOverSqrtVariance =
-          UnaryOps.rsqrt($variance.add(TensorOps.scalar(varianceEpsilon)));
+      const oneOverSqrtVariance = rsqrt($variance.add(scalar(varianceEpsilon)));
       const minusHalfRCube = oneOverSqrtVariance.mul(oneOverSqrtVariance)
                                  .mul(oneOverSqrtVariance)
-                                 .mul(TensorOps.scalar(-0.5));
+                                 .mul(scalar(-0.5));
       const derX = () => {
         if ($mean.rank === 1) {
           return dy
-              .mul(ArrayOps.tile(
+              .mul(tile(
                   oneOverSqrtVariance.as4D(1, 1, 1, $mean.shape[0]), tileShape))
               .mul(scaleValue)
               .reshape($x.shape);
@@ -295,8 +296,8 @@ export class BatchNormOps {
         }
       };
       const derMean = () => {
-        let meanDer = oneOverSqrtVariance.mul(TensorOps.scalar(-1))
-                          .mul(dyTimesScaleValue);
+        let meanDer =
+            oneOverSqrtVariance.mul(scalar(-1)).mul(dyTimesScaleValue);
         if ($mean.rank === 1) {
           meanDer = meanDer.sum(reductionAxes);
         }
@@ -358,3 +359,8 @@ function batchnormReshape4D(x: Tensor): Tensor4D|Tensor1D {
   }
   return x as Tensor4D;
 }
+
+export const batchNormalization2d = op(BatchNormOps.batchNormalization2d);
+export const batchNormalization3d = op(BatchNormOps.batchNormalization3d);
+export const batchNormalization4d = op(BatchNormOps.batchNormalization4d);
+export const batchNormalization = op(BatchNormOps.batchNormalization);

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -23,7 +23,6 @@ import {Rank, TensorLike} from '../types';
 import * as util from '../util';
 import {ArrayOps} from './array_ops';
 import {getReductionAxes} from './broadcast_util';
-import {operation} from './operation';
 import {TensorOps} from './tensor_ops';
 import {UnaryOps} from './unary_ops';
 
@@ -39,7 +38,6 @@ export class BatchNormOps {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @operation
   static batchNormalization2d(
       x: Tensor2D|TensorLike, mean: Tensor2D|Tensor1D|TensorLike,
       variance: Tensor2D|Tensor1D|TensorLike, varianceEpsilon = .001,
@@ -97,7 +95,6 @@ export class BatchNormOps {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @operation
   static batchNormalization3d(
       x: Tensor3D|TensorLike, mean: Tensor3D|Tensor1D|TensorLike,
       variance: Tensor3D|Tensor1D|TensorLike, varianceEpsilon = .001,
@@ -155,7 +152,6 @@ export class BatchNormOps {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @operation
   static batchNormalization4d(
       x: Tensor4D|TensorLike, mean: Tensor4D|Tensor1D|TensorLike,
       variance: Tensor4D|Tensor1D|TensorLike, varianceEpsilon = .001,

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -22,12 +22,13 @@ import {Tensor} from '../tensor';
 import {assertTypesMatch, convertToTensor} from '../tensor_util';
 import {TensorLike, upcastType} from '../types';
 import * as util from '../util';
-import * as broadcast_util from './broadcast_util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
-import {UnaryOps} from './unary_ops';
 
-export class BinaryOps {
+import * as broadcast_util from './broadcast_util';
+import {op} from './operation';
+import {scalar} from './tensor_ops';
+import {neg} from './unary_ops';
+
+class BinaryOps {
   /**
    * Adds two `Tensor`s element-wise, A + B. Supports broadcasting.
    *
@@ -52,7 +53,6 @@ export class BinaryOps {
    * @param b The second `Tensor` to add. Must have the same type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static add<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'add');
     const $b = convertToTensor(b, 'b', 'add');
@@ -92,7 +92,6 @@ export class BinaryOps {
    * @param a The first Tensor to add element-wise.
    * @param b The second Tensor to add element-wise.
    */
-  @operation
   static addStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in addStrict: ');
     return a.add(b);
@@ -123,7 +122,6 @@ export class BinaryOps {
    * `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static sub<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'sub');
     const $b = convertToTensor(b, 'b', 'sub');
@@ -164,7 +162,6 @@ export class BinaryOps {
    * @param a The first Tensor to subtract element-wise.
    * @param b The second Tensor to subtract element-wise.
    */
-  @operation
   static subStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in subStrict: ');
     return a.sub(b);
@@ -197,7 +194,6 @@ export class BinaryOps {
    * @param exp The exponent `Tensor` to pow element-wise.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static pow<T extends Tensor>(base: T|TensorLike, exp: Tensor|TensorLike): T {
     const $base = convertToTensor(base, 'base', 'pow');
     const $exp = convertToTensor(exp, 'exp', 'pow');
@@ -242,7 +238,6 @@ export class BinaryOps {
    * @param base The base tensor to pow element-wise.
    * @param exp The exponent tensor to pow element-wise.
    */
-  @operation
   static powStrict<T extends Tensor>(base: T, exp: Tensor): T {
     util.assertShapesMatch(base.shape, exp.shape, 'Error in powStrict: ');
     return base.pow(exp);
@@ -272,7 +267,6 @@ export class BinaryOps {
    * @param b The second tensor to multiply. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static mul<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'mul');
     const $b = convertToTensor(b, 'b', 'mul');
@@ -313,7 +307,6 @@ export class BinaryOps {
    * @param b The first tensor to multiply. Must have the same
    *    dtype as `a`.
    */
-  @operation
   static mulStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in multiplyStrict: ');
     return a.mul(b) as T;
@@ -345,7 +338,6 @@ export class BinaryOps {
    * `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static div<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'div');
     const $b = convertToTensor(b, 'b', 'div');
@@ -408,7 +400,6 @@ export class BinaryOps {
    * `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static floorDiv<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'floorDiv');
@@ -448,7 +439,6 @@ export class BinaryOps {
    * @param a The first tensor as the numerator for element-wise division.
    * @param b The second tensor as the denominator for element-wise division.
    */
-  @operation
   static divStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in divideStrict: ');
     return a.div(b) as T;
@@ -481,7 +471,6 @@ export class BinaryOps {
    * @param b The second tensor. Must have the same type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static mod<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'mod');
     const $b = convertToTensor(b, 'b', 'mod');
@@ -518,7 +507,6 @@ export class BinaryOps {
    * @param a The first tensor.
    * @param b The second tensor. Must have the same dtype as `a`.
    */
-  @operation
   static modStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in modStrict: ');
     return a.mod(b);
@@ -550,7 +538,6 @@ export class BinaryOps {
    * @param b The second tensor. Must have the same type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static minimum<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     let $a = convertToTensor(a, 'a', 'minimum');
@@ -580,7 +567,6 @@ export class BinaryOps {
    * @param a The first tensor.
    * @param b The second tensor. Must have the same dtype as `a`.
    */
-  @operation
   static minimumStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
     return a.minimum(b);
@@ -612,7 +598,6 @@ export class BinaryOps {
    * @param b The second tensor. Must have the same type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static maximum<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     let $a = convertToTensor(a, 'a', 'maximum');
@@ -642,7 +627,6 @@ export class BinaryOps {
    * @param a The first tensor.
    * @param b The second tensor. Must have the same dtype as `a`.
    */
-  @operation
   static maximumStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
     return a.maximum(b);
@@ -675,7 +659,6 @@ export class BinaryOps {
    * @param b The second tensor. Must have the same type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
-  @operation
   static squaredDifference<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'squaredDifference');
@@ -684,7 +667,7 @@ export class BinaryOps {
 
     broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
     const der = (dy: Tensor) => {
-      const two = TensorOps.scalar(2);
+      const two = scalar(2);
       const derA = () => dy.mul($a.sub($b).mul(two));
       const derB = () => dy.mul($b.sub($a).mul(two));
       return {$a: derA, $b: derB};
@@ -703,7 +686,6 @@ export class BinaryOps {
    * @param a The first tensor.
    * @param b The second tensor. Must have the same type as `a`.
    */
-  @operation
   static squaredDifferenceStrict<T extends Tensor>(a: T, b: T): T {
     util.assertShapesMatch(
         a.shape, b.shape, 'Error in squaredDifferenceStrict: ');
@@ -726,7 +708,6 @@ export class BinaryOps {
    *
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static atan2<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'atan2');
@@ -748,7 +729,7 @@ export class BinaryOps {
       };
       const derB = () => {
         const d = BinaryOps.add($a.square(), $b.square()) as T;
-        let res = UnaryOps.neg(dy.mul($a.div(d)));
+        let res = neg(dy.mul($a.div(d)));
         const reduceAxes = broadcast_util.getReductionAxes($b.shape, outShape);
         if (reduceAxes.length > 0) {
           res = res.sum(reduceAxes);
@@ -761,3 +742,24 @@ export class BinaryOps {
                backend => backend.atan2($a, $b), {$a, $b}, der) as T;
   }
 }
+
+export const add = op(BinaryOps.add);
+export const addStrict = op(BinaryOps.addStrict);
+export const atan2 = op(BinaryOps.atan2);
+export const div = op(BinaryOps.div);
+export const divStrict = op(BinaryOps.divStrict);
+export const floorDiv = op(BinaryOps.floorDiv);
+export const maximum = op(BinaryOps.maximum);
+export const maximumStrict = op(BinaryOps.maximumStrict);
+export const minimum = op(BinaryOps.minimum);
+export const minimumStrict = op(BinaryOps.minimumStrict);
+export const mod = op(BinaryOps.mod);
+export const modStrict = op(BinaryOps.modStrict);
+export const mul = op(BinaryOps.mul);
+export const mulStrict = op(BinaryOps.mulStrict);
+export const pow = op(BinaryOps.pow);
+export const powStrict = op(BinaryOps.powStrict);
+export const squaredDifference = op(BinaryOps.squaredDifference);
+export const squaredDifferenceStrict = op(BinaryOps.squaredDifferenceStrict);
+export const sub = op(BinaryOps.sub);
+export const subStrict = op(BinaryOps.subStrict);

--- a/src/ops/compare.ts
+++ b/src/ops/compare.ts
@@ -22,9 +22,9 @@ import {assertTypesMatch, convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import {assertShapesMatch} from '../util';
 import {assertAndGetBroadcastShape} from './broadcast_util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class CompareOps {
+class CompareOps {
   /**
    * Returns the truth value of (a != b) element-wise. Supports broadcasting.
    *
@@ -41,7 +41,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static notEqual<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'notEqual');
@@ -60,7 +59,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same shape and dtype as
    *     `a`.
    */
-  @operation
   static notEqualStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'notEqualStrict');
     const $b = convertToTensor(b, 'b', 'notEqualStrict');
@@ -84,7 +82,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static less<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'less');
     const $b = convertToTensor(b, 'b', 'less');
@@ -102,7 +99,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same shape and dtype as
    *     `a`.
    */
-  @operation
   static lessStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'lessStrict');
     const $b = convertToTensor(b, 'b', 'lessStrict');
@@ -127,7 +123,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static equal<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'equal');
@@ -139,7 +134,6 @@ export class CompareOps {
         T;
   }
 
-  @operation
   static equalStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'equalStrict');
     const $b = convertToTensor(b, 'b', 'equalStrict');
@@ -164,7 +158,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static lessEqual<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'lessEqual');
@@ -176,7 +169,6 @@ export class CompareOps {
                backend => backend.lessEqual($a, $b), {$a, $b}) as T;
   }
 
-  @operation
   static lessEqualStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'lessEqualStrict');
@@ -202,7 +194,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static greater<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'greater');
@@ -214,7 +205,6 @@ export class CompareOps {
         T;
   }
 
-  @operation
   static greaterStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'greaterStrict');
     const $b = convertToTensor(b, 'b', 'greaterStrict');
@@ -239,7 +229,6 @@ export class CompareOps {
    * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static greaterEqual<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'greaterEqual');
@@ -251,7 +240,6 @@ export class CompareOps {
                backend => backend.greaterEqual($a, $b), {$a, $b}) as T;
   }
 
-  @operation
   static greaterEqualStrict<T extends Tensor>(a: T|TensorLike, b: T|TensorLike):
       T {
     const $a = convertToTensor(a, 'a', 'greaterEqualStrict');
@@ -260,3 +248,16 @@ export class CompareOps {
     return $a.greaterEqual($b);
   }
 }
+
+export const equal = op(CompareOps.equal);
+export const equalStrict = op(CompareOps.equalStrict);
+export const greater = op(CompareOps.greater);
+export const greaterEqual = op(CompareOps.greaterEqual);
+export const greaterEqualStrict = op(CompareOps.greaterEqualStrict);
+export const greaterStrict = op(CompareOps.greaterStrict);
+export const less = op(CompareOps.less);
+export const lessEqual = op(CompareOps.lessEqual);
+export const lessEqualStrict = op(CompareOps.lessEqualStrict);
+export const lessStrict = op(CompareOps.lessStrict);
+export const notEqual = op(CompareOps.notEqual);
+export const notEqualStrict = op(CompareOps.notEqualStrict);

--- a/src/ops/concat.ts
+++ b/src/ops/concat.ts
@@ -23,7 +23,7 @@ import {TensorLike} from '../types';
 import {assert, sizeFromShape} from '../util';
 import {parseAxisParam} from './axis_util';
 import * as concat_util from './concat_util';
-import {oper} from './operation';
+import {op} from './operation';
 
 class ConcatOps {
   /**
@@ -173,12 +173,6 @@ class ConcatOps {
   }
 }
 
-export const concat = oper(ConcatOps.concat);
-export const concat1d = oper(ConcatOps.concat1d);
-export const concat2d = oper(ConcatOps.concat2d);
-export const concat3d = oper(ConcatOps.concat3d);
-export const concat4d = oper(ConcatOps.concat4d);
-
 function concat2Tensors<T extends Tensor>(a: T, b: T, axis: number): T {
   concat_util.assertParams(a.shape, b.shape, axis);
   const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
@@ -196,3 +190,9 @@ function concat2Tensors<T extends Tensor>(a: T, b: T, axis: number): T {
       backend => backend.concat(a2D, b2D), {a: a2D, b: b2D}, der);
   return res.reshape(outShape) as T;
 }
+
+export const concat = op(ConcatOps.concat);
+export const concat1d = op(ConcatOps.concat1d);
+export const concat2d = op(ConcatOps.concat2d);
+export const concat3d = op(ConcatOps.concat3d);
+export const concat4d = op(ConcatOps.concat4d);

--- a/src/ops/concat.ts
+++ b/src/ops/concat.ts
@@ -23,9 +23,9 @@ import {TensorLike} from '../types';
 import {assert, sizeFromShape} from '../util';
 import {parseAxisParam} from './axis_util';
 import * as concat_util from './concat_util';
-import {operation} from './operation';
+import {oper} from './operation';
 
-export class ConcatOps {
+class ConcatOps {
   /**
    * Concatenates a list of `Tensor1D`s along an axis. See `concat` for details.
    *
@@ -156,7 +156,6 @@ export class ConcatOps {
    * @param axis The axis to concate along. Defaults to 0 (the first dim).
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static concat<T extends Tensor>(tensors: T[]|TensorLike[], axis = 0): T {
     assert(tensors.length >= 1, 'Pass at least one tensor to concat');
     const $tensors = convertToTensorArray(tensors, 'tensors', 'concat');
@@ -173,6 +172,12 @@ export class ConcatOps {
     return result;
   }
 }
+
+export const concat = oper(ConcatOps.concat);
+export const concat1d = oper(ConcatOps.concat1d);
+export const concat2d = oper(ConcatOps.concat2d);
+export const concat3d = oper(ConcatOps.concat3d);
+export const concat4d = oper(ConcatOps.concat4d);
 
 function concat2Tensors<T extends Tensor>(a: T, b: T, axis: number): T {
   concat_util.assertParams(a.shape, b.shape, axis);

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -22,9 +22,9 @@ import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
 import * as conv_util from './conv_util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class ConvOps {
+class ConvOps {
   /**
    * Computes a 1D convolution over the input x.
    *
@@ -53,7 +53,6 @@ export class ConvOps {
    *     and error if the output is of fractional size.
    */
   @doc({heading: 'Operations', subheading: 'Convolution'})
-  @operation
   static conv1d<T extends Tensor2D|Tensor3D>(
       x: T|TensorLike, filter: Tensor3D|TensorLike, stride: number,
       pad: 'valid'|'same'|number, dataFormat: 'NWC'|'NCW' = 'NWC', dilation = 1,
@@ -145,7 +144,6 @@ export class ConvOps {
    *     and error if the output is of fractional size.
    */
   @doc({heading: 'Operations', subheading: 'Convolution'})
-  @operation
   static conv2d<T extends Tensor3D|Tensor4D>(
       x: T|TensorLike, filter: Tensor4D|TensorLike,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
@@ -235,7 +233,6 @@ export class ConvOps {
    *     dimensions if pad is a number. If none is provided, it will not round
    *     and error if the output is of fractional size.
    */
-  @operation
   static conv2dDerInput<T extends Tensor3D|Tensor4D>(
       xShape: [number, number, number, number]|[number, number, number], dy: T,
       filter: Tensor4D, strides: [number, number]|number,
@@ -313,7 +310,6 @@ export class ConvOps {
    *     number. If none is provided, it will not round and error if the output
    *     is of fractional size.
    */
-  @operation
   static conv2dDerFilter<T extends Tensor3D|Tensor4D>(
       x: T, dy: T, filterShape: [number, number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
@@ -381,7 +377,6 @@ export class ConvOps {
    *    and error if the output is of fractional size.
    */
   @doc({heading: 'Operations', subheading: 'Convolution'})
-  @operation
   static conv2dTranspose<T extends Tensor3D|Tensor4D>(
       x: T|TensorLike, filter: Tensor4D|TensorLike,
       outputShape: [number, number, number, number]|[number, number, number],
@@ -439,7 +434,6 @@ export class ConvOps {
    *     and error if the output is of fractional size.
    */
   @doc({heading: 'Operations', subheading: 'Convolution'})
-  @operation
   static depthwiseConv2d<T extends Tensor3D|Tensor4D>(
       x: T|TensorLike, filter: Tensor4D|TensorLike,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
@@ -552,7 +546,6 @@ export class ConvOps {
    *     height, width, channels]. Only "NHWC" is currently supported.
    */
   @doc({heading: 'Operations', subheading: 'Convolution'})
-  @operation
   static separableConv2d<T extends Tensor3D|Tensor4D>(
       x: T|TensorLike, depthwiseFilter: Tensor4D|TensorLike,
       pointwiseFilter: Tensor4D|TensorLike, strides: [number, number]|number,
@@ -666,3 +659,9 @@ function depthwiseConv2dDerFilter<T extends Tensor3D|Tensor4D>(
       backend => backend.depthwiseConv2DDerFilter(x4D, dy4D, convInfo),
       {x4D, dy4D});
 }
+
+export const conv1d = op(ConvOps.conv1d);
+export const conv2d = op(ConvOps.conv2d);
+export const depthwiseConv2d = op(ConvOps.depthwiseConv2d);
+export const separableConv2d = op(ConvOps.separableConv2d);
+export const conv2dTranspose = op(ConvOps.conv2dTranspose);

--- a/src/ops/image_ops.ts
+++ b/src/ops/image_ops.ts
@@ -22,9 +22,9 @@ import {Tensor, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class ImageOps {
+class ImageOps {
   /**
    * Bilinear resize a batch of 3D images to a new shape.
    *
@@ -38,7 +38,6 @@ export class ImageOps {
    *     `new_height / height`. Treat similarly the width dimension.
    */
   @doc({heading: 'Operations', subheading: 'Images', namespace: 'image'})
-  @operation
   static resizeBilinear<T extends Tensor3D|Tensor4D>(
       images: T|TensorLike, size: [number, number], alignCorners = false): T {
     const $images = convertToTensor(images, 'images', 'resizeBilinear');
@@ -92,7 +91,6 @@ export class ImageOps {
    *     `new_height / height`. Treat similarly the width dimension.
    */
   @doc({heading: 'Operations', subheading: 'Images', namespace: 'image'})
-  @operation
   static resizeNearestNeighbor<T extends Tensor3D|Tensor4D>(
       images: T|TensorLike, size: [number, number], alignCorners = false): T {
     const $images = convertToTensor(images, 'images', 'resizeNearestNeighbor');
@@ -138,3 +136,6 @@ export class ImageOps {
     return res as T;
   }
 }
+
+export const resizeBilinear = op(ImageOps.resizeBilinear);
+export const resizeNearestNeighbor = op(ImageOps.resizeNearestNeighbor);

--- a/src/ops/logical_ops.ts
+++ b/src/ops/logical_ops.ts
@@ -23,10 +23,10 @@ import * as types from '../types';
 import {TensorLike} from '../types';
 import {assert, assertShapesMatch} from '../util';
 import {assertAndGetBroadcastShape} from './broadcast_util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
+import {op} from './operation';
+import {zerosLike} from './tensor_ops';
 
-export class LogicalOps {
+class LogicalOps {
   /**
    * Returns the truth value of `NOT x` element-wise.
    *
@@ -39,7 +39,6 @@ export class LogicalOps {
    * @param x The input tensor. Must be of dtype 'bool'.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static logicalNot<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'logicalNot', 'bool');
     assert($x.dtype === 'bool', 'Error Array must be of type bool.');
@@ -61,7 +60,6 @@ export class LogicalOps {
    * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static logicalAnd<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'logicalAnd', 'bool');
@@ -88,7 +86,6 @@ export class LogicalOps {
    * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static logicalOr<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'logicalOr', 'bool');
@@ -116,7 +113,6 @@ export class LogicalOps {
    * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static logicalXor<T extends Tensor>(
       a: Tensor|TensorLike, b: Tensor|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'logicalXor', 'bool');
@@ -150,7 +146,6 @@ export class LogicalOps {
    * @param b A tensor with the same shape and type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
-  @operation
   static where<T extends Tensor>(
       condition: Tensor|TensorLike, a: T|TensorLike, b: T|TensorLike): T {
     const $a = convertToTensor(a, 'a', 'where');
@@ -178,7 +173,7 @@ export class LogicalOps {
     // TODO(julianoks): Return null for condition gradient
     // when backprop supports it.
     const grad = (dy: T) => ({
-      $condition: () => TensorOps.zerosLike($condition),
+      $condition: () => zerosLike($condition),
       $a: () => dy.mul($condition.cast($a.dtype)) as T,
       $b: () => dy.mul($condition.logicalNot().cast($b.dtype)) as T
     });
@@ -188,3 +183,9 @@ export class LogicalOps {
                {$condition, $a, $b}, grad) as T;
   }
 }
+
+export const logicalAnd = op(LogicalOps.logicalAnd);
+export const logicalNot = op(LogicalOps.logicalNot);
+export const logicalOr = op(LogicalOps.logicalOr);
+export const logicalXor = op(LogicalOps.logicalXor);
+export const where = op(LogicalOps.where);

--- a/src/ops/loss_ops.ts
+++ b/src/ops/loss_ops.ts
@@ -16,13 +16,15 @@
  */
 
 import {doc} from '../doc';
+import {customGrad} from '../globals';
 import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import {assertShapesMatch} from '../util';
-import {BinaryOps} from './binary_ops';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
+import {expandShapeToKeepDim} from './axis_util';
+import {minimum} from './binary_ops';
+import {op} from './operation';
+import {ones, scalar} from './tensor_ops';
 
 export enum Reduction {
   NONE,
@@ -31,7 +33,7 @@ export enum Reduction {
   SUM_BY_NONZERO_WEIGHTS
 }
 
-export class LossOps {
+class LossOps {
   /**
    * Computes the weighted loss between two tensors.
    *
@@ -42,7 +44,6 @@ export class LossOps {
    *    `losses` dimension).
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static computeWeightedLoss<T extends Tensor, O extends Tensor>(
       losses: T|TensorLike, weights?: Tensor|TensorLike,
       reduction = Reduction.SUM_BY_NONZERO_WEIGHTS): O {
@@ -66,12 +67,12 @@ export class LossOps {
     }
     if (reduction === Reduction.SUM_BY_NONZERO_WEIGHTS) {
       if ($weights == null) {
-        return weightedLoss.sum().div(TensorOps.scalar($losses.size));
+        return weightedLoss.sum().div(scalar($losses.size));
       } else {
-        const broadcastedWeights = $weights.mul(TensorOps.ones($losses.shape));
+        const broadcastedWeights = $weights.mul(ones($losses.shape));
 
         const numNonZeros =
-            broadcastedWeights.notEqual(TensorOps.scalar(0)).sum().toFloat();
+            broadcastedWeights.notEqual(scalar(0)).sum().toFloat();
         return weightedLoss.sum().div(numNonZeros);
       }
     }
@@ -93,7 +94,6 @@ export class LossOps {
    *    `Reduction`
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static absoluteDifference<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike,
       weights?: Tensor|TensorLike,
@@ -126,7 +126,6 @@ export class LossOps {
    *    `Reduction`
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static meanSquaredError<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike,
       weights?: Tensor|TensorLike,
@@ -160,7 +159,6 @@ export class LossOps {
    *    `Reduction`
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static cosineDistance<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike, axis: number,
       weights?: Tensor|TensorLike,
@@ -175,7 +173,7 @@ export class LossOps {
     assertShapesMatch(
         $labels.shape, $predictions.shape, 'Error in cosineDistance: ');
 
-    const one = TensorOps.scalar(1);
+    const one = scalar(1);
     const losses = one.sub($labels.mul($predictions).sum(axis, true));
     return LossOps.computeWeightedLoss(losses, $weights, reduction);
   }
@@ -194,7 +192,6 @@ export class LossOps {
    *    `Reduction`
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static hingeLoss<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike,
       weights?: Tensor|TensorLike,
@@ -209,9 +206,9 @@ export class LossOps {
     assertShapesMatch(
         $labels.shape, $predictions.shape, 'Error in hingeLoss: ');
 
-    const one = TensorOps.scalar(1);
+    const one = scalar(1);
     // Convert binary labels to (-1, 1)
-    $labels = TensorOps.scalar(2).mul($labels).sub(one);
+    $labels = scalar(2).mul($labels).sub(one);
     const losses = one.sub($labels.mul($predictions)).relu();
     return LossOps.computeWeightedLoss(losses, $weights, reduction);
   }
@@ -231,7 +228,6 @@ export class LossOps {
    *    `Reduction`
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static logLoss<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike,
       weights?: Tensor|TensorLike, epsilon = 1e-7,
@@ -244,8 +240,8 @@ export class LossOps {
     }
     assertShapesMatch($labels.shape, $predictions.shape, 'Error in logLoss: ');
 
-    const one = TensorOps.scalar(1);
-    const epsilonScalar = TensorOps.scalar(epsilon);
+    const one = scalar(1);
+    const epsilonScalar = scalar(epsilon);
     const losses = $labels.mul($predictions.add(epsilonScalar).log())
                        .neg()
                        .sub(one.sub($labels).mul(
@@ -268,7 +264,6 @@ export class LossOps {
    *    `Reduction`.
    */
   @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
   static huberLoss<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, predictions: T|TensorLike,
       weights?: Tensor|TensorLike, delta = 1.0,
@@ -283,14 +278,83 @@ export class LossOps {
     assertShapesMatch(
         $labels.shape, $predictions.shape, 'Error in huberLoss: ');
 
-    const deltaScalar = TensorOps.scalar(delta);
+    const deltaScalar = scalar(delta);
     const error = $predictions.sub($labels).abs();
-    const quadratic = BinaryOps.minimum(error, deltaScalar);
+    const quadratic = minimum(error, deltaScalar);
     const linear = error.sub(quadratic);
 
-    const losses = TensorOps.scalar(0.5)
-                       .mul(quadratic.square())
-                       .add(deltaScalar.mul(linear));
+    const losses =
+        scalar(0.5).mul(quadratic.square()).add(deltaScalar.mul(linear));
     return LossOps.computeWeightedLoss(losses, $weights, reduction);
   }
+
+  /**
+   * Computes softmax cross entropy between logits and labels.
+   *
+   * Measures the probability error in discrete classification tasks in which
+   * the classes are mutually exclusive (each entry is in exactly one class).
+   * For example, each CIFAR-10 image is labeled with one and only one label: an
+   * image can be a dog or a truck, but not both.
+   *
+   * `NOTE`: While the classes are mutually exclusive, their probabilities need
+   * not be. All that is required is that each row of labels is a valid
+   * probability distribution. If they are not, the computation of the gradient
+   * will be incorrect.
+   *
+   * `WARNING`: This op expects unscaled logits, since it performs a softmax on
+   * logits internally for efficiency. Do not call this op with the output of
+   * softmax, as it will produce incorrect results.
+   *
+   * logits and labels must have the same shape, e.g. [batch_size, num_classes]
+   * and the same dtype.
+   * @param labels The labels array.
+   * @param logits The logits array.
+   * @param dim The dimension softmax would be performed on. Defaults to `-1`
+   *     which indicates the last dimension.
+   */
+  @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
+  static softmaxCrossEntropy<T extends Tensor, O extends Tensor>(
+      labels: T|TensorLike, logits: T|TensorLike, dim = -1): O {
+    const $labels = convertToTensor(labels, 'labels', 'softmaxCrossEntropy');
+    const $logits = convertToTensor(logits, 'logits', 'softmaxCrossEntropy');
+    assertShapesMatch(
+        $labels.shape, $logits.shape, 'Error in softmaxCrossEntropy: ');
+
+    if (dim === -1) {
+      dim = $logits.rank - 1;
+    }
+    if (dim !== $logits.rank - 1) {
+      throw Error(
+          `Softmax cross entropy along a non-last dimension is not yet ` +
+          `supported. Labels / logits was rank ${$logits.rank} ` +
+          `and dim was ${dim}`);
+    }
+    // Use a custom gradient for numerical stability.
+    const customOp = customGrad((labels, logits) => {
+      const predictedProbs = logits.softmax(dim);
+      const costVector =
+          scalar(1e-5).add(predictedProbs).log().mul(labels).neg();
+      const value = costVector.sum([dim]) as O;
+
+      const gradFunc = (dy: O) => {
+        const dyShape = expandShapeToKeepDim(dy.shape, [dim]);
+        return [
+          dy.reshape(dyShape).mul(labels.toFloat().sub(predictedProbs)),
+          dy.reshape(dyShape).mul(predictedProbs.sub(labels.toFloat())),
+        ];
+      };
+      return {value, gradFunc};
+    });
+
+    return customOp($labels, $logits);
+  }
 }
+
+export const absoluteDifference = op(LossOps.absoluteDifference);
+export const computeWeightedLoss = op(LossOps.computeWeightedLoss);
+export const cosineDistance = op(LossOps.cosineDistance);
+export const hingeLoss = op(LossOps.hingeLoss);
+export const huberLoss = op(LossOps.huberLoss);
+export const logLoss = op(LossOps.logLoss);
+export const meanSquaredError = op(LossOps.meanSquaredError);
+export const softmaxCrossEntropy = op(LossOps.softmaxCrossEntropy);

--- a/src/ops/lrn.ts
+++ b/src/ops/lrn.ts
@@ -21,9 +21,9 @@ import {Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class LRNOps {
+class LRNOps {
   /**
    * Normalizes the activation of a local neighborhood across or within
    * channels.
@@ -38,7 +38,6 @@ export class LRNOps {
    * @param beta An exponent.
    */
   @doc({heading: 'Operations', subheading: 'Normalization'})
-  @operation
   static localResponseNormalization<T extends Tensor3D|Tensor4D>(
       x: T|TensorLike, depthRadius = 5, bias = 1, alpha = 1, beta = 0.5): T {
     const $x = convertToTensor(x, 'x', 'localResponseNormalization');
@@ -68,3 +67,5 @@ export class LRNOps {
     }
   }
 }
+
+export const localResponseNormalization = op(LRNOps.localResponseNormalization);

--- a/src/ops/lstm.ts
+++ b/src/ops/lstm.ts
@@ -19,7 +19,7 @@ import {doc} from '../doc';
 import {Scalar, Tensor1D, Tensor2D} from '../tensor';
 import {convertToTensor, convertToTensorArray} from '../tensor_util';
 import {TensorLike} from '../types';
-import {operation} from './operation';
+import {op} from './operation';
 
 /**
  * @docalias (data: Tensor2D, c: Tensor2D, h: Tensor2D): [Tensor2D, Tensor2D]
@@ -28,7 +28,7 @@ export type LSTMCellFunc = {
   (data: Tensor2D, c: Tensor2D, h: Tensor2D): [Tensor2D, Tensor2D];
 };
 
-export class LSTMOps {
+class LSTMOps {
   /**
    * Computes the next states and outputs of a stack of LSTMCells.
    *
@@ -44,7 +44,6 @@ export class LSTMOps {
    * @param h Array of previous cell outputs.
    */
   @doc({heading: 'Operations', subheading: 'RNN'})
-  @operation
   static multiRNNCell(
       lstmCells: LSTMCellFunc[], data: Tensor2D|TensorLike,
       c: Tensor2D[]|TensorLike[],
@@ -85,7 +84,6 @@ export class LSTMOps {
    * @param h Previous cell output.
    */
   @doc({heading: 'Operations', subheading: 'RNN'})
-  @operation
   static basicLSTMCell(
       forgetBias: Scalar|TensorLike, lstmKernel: Tensor2D|TensorLike,
       lstmBias: Tensor1D|TensorLike, data: Tensor2D|TensorLike,
@@ -118,3 +116,6 @@ export class LSTMOps {
     return [newC, newH];
   }
 }
+
+export const basicLSTMCell = op(LSTMOps.basicLSTMCell);
+export const multiRNNCell = op(LSTMOps.multiRNNCell);

--- a/src/ops/matmul.ts
+++ b/src/ops/matmul.ts
@@ -17,13 +17,13 @@
 
 import {doc} from '../doc';
 import {ENV} from '../environment';
-import {Scalar, Tensor, Tensor1D, Tensor2D} from '../tensor';
+import {Tensor, Tensor1D, Tensor2D} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class MatmulOps {
+class MatmulOps {
   /**
    * Computes the dot product of two matrices, A * B. These must be matrices.
    *
@@ -39,7 +39,6 @@ export class MatmulOps {
    * @param transposeB If true, `b` is transposed before multiplication.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
-  @operation
   static matMul(
       a: Tensor2D|TensorLike, b: Tensor2D|TensorLike, transposeA = false,
       transposeB = false): Tensor2D {
@@ -90,73 +89,6 @@ export class MatmulOps {
   }
 
   /**
-   * Computes the dot product of a vector and a matrix, v * B.
-   *
-   * @param v The vector in dot product operation.
-   * @param matrix The matrix in dot product operation.
-   */
-  @operation
-  static vectorTimesMatrix(v: Tensor1D, matrix: Tensor2D): Tensor1D {
-    util.assert(
-        v.rank === 1,
-        `Error in vectorTimesMatrix: first input must be rank 1, but got ` +
-            `rank ${v.rank}.`);
-    util.assert(
-        matrix.rank === 2,
-        `Error in vectorTimesMatrix: second input must be rank 2, but got ` +
-            `rank ${matrix.rank}.`);
-    util.assert(
-        v.size === matrix.shape[0],
-        `Error in vectorTimesMatrix: size of vector (${v.size}) ` +
-            `must match first dimension of matrix (${matrix.shape[0]})`);
-    return v.as2D(1, -1).matMul(matrix).as1D();
-  }
-
-  /**
-   * Computes the dot product of a matrix and vector, A * v.
-   *
-   * @param matrix The matrix in dot product operation.
-   * @param v The vector in dot product operation.
-   */
-  @operation
-  static matrixTimesVector(matrix: Tensor2D, v: Tensor1D): Tensor1D {
-    util.assert(
-        v.rank === 1,
-        `Error in matrixTimesVector: second input must rank 1, but got ` +
-            `rank ${v.rank}.`);
-    util.assert(
-        matrix.rank === 2,
-        `Error in matrixTimesVector: first input must be a rank 2, but got ` +
-            `rank ${matrix.rank}.`);
-    util.assert(
-        v.size === matrix.shape[1],
-        `Error in matrixTimesVector: size of first rank 1 input ${v.size} ` +
-            `must match inner dimension of second rank 2 input, but got ` +
-            `shape ${matrix.shape}.`);
-
-    return matrix.matMul(v.as2D(-1, 1)).as1D();
-  }
-
-  /**
-   * Computes the dot product of two vectors, v1 * v2.
-   *
-   * @param v1 The first vector in the dot product operation.
-   * @param v2 The second vector in the dot product operation.
-   */
-  @operation
-  static dotProduct(v1: Tensor1D, v2: Tensor1D): Scalar {
-    util.assert(
-        v1.rank === 1 && v2.rank === 1,
-        `Error in dotProduct: inputs must be rank 1, but got ranks ` +
-            `${v1.rank} and ${v2.rank}.`);
-    util.assert(
-        v1.size === v2.size,
-        `Error in dotProduct: size of inputs (${v1.size}) and (` +
-            `${v2.size}) must match.`);
-    return v1.as2D(1, -1).matMul(v2.as2D(-1, 1)).asScalar();
-  }
-
-  /**
    * Computes the outer product of two vectors, v1 and v2.
    *
    * ```js
@@ -169,7 +101,6 @@ export class MatmulOps {
    * @param v2 The second vector in the dot product operation.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
-  @operation
   static outerProduct(v1: Tensor1D|TensorLike, v2: Tensor1D|TensorLike):
       Tensor2D {
     const $v1 = convertToTensor(v1, 'v1', 'outerProduct');
@@ -199,7 +130,6 @@ export class MatmulOps {
    * @param t2 The second tensor in the dot operation.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
-  @operation
   static dot(t1: Tensor|TensorLike, t2: Tensor|TensorLike): Tensor {
     const $t1 = convertToTensor(t1, 't1', 'dot');
     const $t2 = convertToTensor(t2, 't2', 'dot');
@@ -230,3 +160,7 @@ export class MatmulOps {
     }
   }
 }
+
+export const matMul = op(MatmulOps.matMul);
+export const dot = op(MatmulOps.dot);
+export const outerProduct = op(MatmulOps.outerProduct);

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -20,7 +20,6 @@ import {describeWithFlags} from '../jasmine_util';
 // tslint:disable-next-line:max-line-length
 import {ALL_ENVS, expectArraysClose, expectNumbersClose, WEBGL_ENVS} from '../test_util';
 import {Rank} from '../types';
-import {MatmulOps} from './matmul';
 
 describeWithFlags('matmul', ALL_ENVS, () => {
   it('A x B', () => {
@@ -125,7 +124,7 @@ describeWithFlags('matmul', ALL_ENVS, () => {
   it('Vector times matrix', () => {
     const v = tf.tensor1d([2, 3]);
     const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-    const result = tf.vectorTimesMatrix(v, matrix);
+    const result = tf.dot(v, matrix);
 
     const expected = [11, 16];
     expectArraysClose(result, expected);
@@ -135,32 +134,16 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     const v = tf.tensor1d([2, 3]);
 
     const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-    const result = tf.vectorTimesMatrix(v, matrix);
+    const result = tf.dot(v, matrix);
 
     const expected = [11, 16];
     expectArraysClose(result, expected);
   });
 
-  it('Vector times matrix throws when not passed a vector', () => {
-    // tslint:disable-next-line:no-any
-    const v: any = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-    const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-
-    expect(() => tf.vectorTimesMatrix(v, matrix)).toThrowError();
-  });
-
-  it('Vector times matrix throws when not passed a matrix', () => {
-    const v = tf.tensor1d([2, 3]);
-    // tslint:disable-next-line:no-any
-    const matrix: any = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
-
-    expect(() => tf.vectorTimesMatrix(v, matrix)).toThrowError();
-  });
-
   it('Matrix times vector', () => {
     const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
     const v = tf.tensor1d([2, 3]);
-    const result = tf.matrixTimesVector(matrix, v);
+    const result = tf.dot(matrix, v);
 
     const expected = [8, 18];
     expectArraysClose(result, expected);
@@ -169,18 +152,10 @@ describeWithFlags('matmul', ALL_ENVS, () => {
   it('Matrix * vector propagates NaNs', () => {
     const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
     const v = tf.tensor1d([2, NaN]);
-    const result = tf.matrixTimesVector(matrix, v);
+    const result = tf.dot(matrix, v);
 
     const expected = [NaN, NaN];
     expectArraysClose(result, expected);
-  });
-
-  it('matrix times vector throws when not passed a vector', () => {
-    // tslint:disable-next-line:no-any
-    const v: any = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-    const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
-
-    expect(() => tf.matrixTimesVector(matrix, v)).toThrowError();
   });
 
   it('matrix times vector throws when not passed a matrix', () => {
@@ -189,13 +164,13 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     // tslint:disable-next-line:no-any
     const matrix: any = tf.tensor3d([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
 
-    expect(() => tf.matrixTimesVector(matrix, v)).toThrowError();
+    expect(() => tf.dot(matrix, v)).toThrowError();
   });
 
   it('Dot product', () => {
     const v1 = tf.tensor1d([2, 3]);
     const v2 = tf.tensor1d([2, 1]);
-    const result = MatmulOps.dotProduct(v1, v2);
+    const result = tf.dot(v1, v2);
 
     expectNumbersClose(result.get(), 7);
   });
@@ -203,7 +178,7 @@ describeWithFlags('matmul', ALL_ENVS, () => {
   it('Dot product propagates NaNs', () => {
     const v1 = tf.tensor1d([2, NaN]);
     const v2 = tf.tensor1d([2, 1]);
-    const result = MatmulOps.dotProduct(v1, v2);
+    const result = tf.dot(v1, v2);
     expect(result.get()).toEqual(NaN);
   });
 
@@ -211,17 +186,8 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     const v1 = tf.tensor1d([2, 3, 3]);
     const v2 = tf.tensor1d([2, 1]);
 
-    expect(() => MatmulOps.dotProduct(v1, v2)).toThrowError();
-    expect(() => MatmulOps.dotProduct(v2, v1)).toThrowError();
-  });
-
-  it('Dot product throws when passed non vectors', () => {
-    // tslint:disable-next-line:no-any
-    const v1: any = tf.tensor2d([1, 2, 3, 3], [2, 2]);
-    const v2 = tf.tensor1d([2, 1]);
-
-    expect(() => MatmulOps.dotProduct(v1, v2)).toThrowError();
-    expect(() => MatmulOps.dotProduct(v2, v1)).toThrowError();
+    expect(() => tf.dot(v1, v2)).toThrowError();
+    expect(() => tf.dot(v2, v1)).toThrowError();
   });
 
   it('Outer product', () => {
@@ -433,7 +399,7 @@ describeWithFlags('matmul webgl-only', WEBGL_ENVS, () => {
     v.set(1, sharedDim - 3);
     v.set(1, sharedDim - 2);
 
-    const result = tf.matrixTimesVector(matrix.toTensor(), v.toTensor());
+    const result = tf.dot(matrix.toTensor(), v.toTensor());
     const expected = [2, 0];
     expectArraysClose(result, expected);
   });

--- a/src/ops/moving_average.ts
+++ b/src/ops/moving_average.ts
@@ -20,12 +20,11 @@ import {Scalar, Tensor} from '../tensor';
 import {assertTypesMatch, convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
+import {pow} from './binary_ops';
+import {op} from './operation';
+import {scalar} from './tensor_ops';
 
-import {BinaryOps} from './binary_ops';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
-
-export class MovingAverageOps {
+class MovingAverageOps {
   /**
    * Compute the moving average of a variable.
    *
@@ -53,7 +52,6 @@ export class MovingAverageOps {
    * @returns The new moving average value.
    */
   @doc({heading: 'Operations', subheading: 'Moving Average'})
-  @operation
   static movingAverage<T extends Tensor>(
       v: T|TensorLike, x: T|TensorLike, decay: number|Scalar,
       step?: number|Scalar, zeroDebias = true): T {
@@ -65,7 +63,7 @@ export class MovingAverageOps {
     util.assert(
         util.arraysEqual($v.shape, $x.shape), 'Shape mismatch in v and x');
 
-    const one = TensorOps.scalar(1);
+    const one = scalar(1);
     const oneMinusDecay = one.sub($decay);
 
     let update = $x.sub($v).mul(oneMinusDecay);
@@ -73,8 +71,10 @@ export class MovingAverageOps {
       util.assert(
           step != null, 'When using zeroDebias: true, step is required.');
       const $step = convertToTensor(step, 'step', 'movingAverage');
-      update = update.div(one.sub(BinaryOps.pow($decay, $step)));
+      update = update.div(one.sub(pow($decay, $step)));
     }
     return $v.add(update);
   }
 }
+
+export const movingAverage = op(MovingAverageOps.movingAverage);

--- a/src/ops/norm.ts
+++ b/src/ops/norm.ts
@@ -20,10 +20,10 @@ import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as axis_util from './axis_util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
+import {op} from './operation';
+import {scalar} from './tensor_ops';
 
-export class NormOps {
+class NormOps {
   /**
    * Computes the norm of scalar, vectors, and matrices.
    * This function can compute several different vector norms (the 1-norm, the
@@ -61,7 +61,6 @@ export class NormOps {
    * as the input.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
-  @operation
   static norm(
       x: Tensor|TensorLike, ord: number|'euclidean'|'fro' = 'euclidean',
       axis: number|number[] = null, keepDims = false): Tensor {
@@ -102,8 +101,7 @@ function normImpl(
     }
     if (p === 'euclidean' || p === 2) {
       // norm(x, 2) = sum(abs(xi) ^ 2) ^ 1/2
-      return x.abs().pow(TensorOps.scalar(2, 'int32')).sum(axis).sqrt() as
-          Tensor;
+      return x.abs().pow(scalar(2, 'int32')).sum(axis).sqrt() as Tensor;
     }
 
     throw new Error(`Error in norm: invalid ord value: ${p}`);
@@ -130,3 +128,5 @@ function normImpl(
 
   throw new Error(`Error in norm: invalid axis: ${axis}`);
 }
+
+export const norm = op(NormOps.norm);

--- a/src/ops/operation.ts
+++ b/src/ops/operation.ts
@@ -17,24 +17,14 @@
 
 import {Environment} from '../environment';
 
-export function oper<T extends Function>(f: T): T {
+/**
+ * Used for wrapping functions that perform math operations on
+ * Tensors. The function will be wrapped in a named scope that cleans all
+ * memory usage after the function is done.
+ */
+export function op<T extends Function>(f: T): T {
   // tslint:disable-next-line:no-any
   const f2 = (...args: any[]) => Environment.tidy(f.name, () => f(...args));
   // tslint:disable-next-line:no-any
   return f2 as any as T;
-}
-
-/**
- * Decorator for wrapping functions that perform math operations on
- * Tensors. The function will be wrapped in a named scope that cleans all
- * memory usage after the function is done.
- */
-export function operation(
-    target: {}, name: string, descriptor: PropertyDescriptor) {
-  const fn = descriptor.value;
-  // tslint:disable-next-line:no-any
-  descriptor.value = (...args: any[]) => {
-    return Environment.tidy(name, () => fn(...args));
-  };
-  return descriptor;
 }

--- a/src/ops/operation.ts
+++ b/src/ops/operation.ts
@@ -17,6 +17,13 @@
 
 import {Environment} from '../environment';
 
+export function oper<T extends Function>(f: T): T {
+  // tslint:disable-next-line:no-any
+  const f2 = (...args: any[]) => Environment.tidy(f.name, () => f(...args));
+  // tslint:disable-next-line:no-any
+  return f2 as any as T;
+}
+
 /**
  * Decorator for wrapping functions that perform math operations on
  * Tensors. The function will be wrapped in a named scope that cleans all

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -21,7 +21,6 @@ import {ArrayOps} from './array_ops';
 import {BatchNormOps} from './batchnorm';
 import {BinaryOps} from './binary_ops';
 import {CompareOps} from './compare';
-import {ConcatOps} from './concat';
 import {ConvOps} from './conv';
 import {ImageOps} from './image_ops';
 import {LinalgOps} from './linalg_ops';
@@ -50,11 +49,7 @@ export const batchNormalization2d = BatchNormOps.batchNormalization2d;
 export const batchNormalization3d = BatchNormOps.batchNormalization3d;
 export const batchNormalization4d = BatchNormOps.batchNormalization4d;
 
-export const concat = ConcatOps.concat;
-export const concat1d = ConcatOps.concat1d;
-export const concat2d = ConcatOps.concat2d;
-export const concat3d = ConcatOps.concat3d;
-export const concat4d = ConcatOps.concat4d;
+export * from './concat';
 
 export const conv1d = ConvOps.conv1d;
 export const conv2d = ConvOps.conv2d;

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -15,245 +15,36 @@
  * =============================================================================
  */
 
-import {Tensor} from '../tensor';
-import {Rank} from '../types';
-import {ArrayOps} from './array_ops';
-import {BatchNormOps} from './batchnorm';
-import {BinaryOps} from './binary_ops';
-import {CompareOps} from './compare';
-import {ConvOps} from './conv';
-import {ImageOps} from './image_ops';
-import {LinalgOps} from './linalg_ops';
-import {LogicalOps} from './logical_ops';
-import {LossOps, Reduction} from './loss_ops';
-import {LRNOps} from './lrn';
-import {LSTMOps} from './lstm';
-import {MatmulOps} from './matmul';
-import {MovingAverageOps} from './moving_average';
-import {NormOps} from './norm';
-import {PoolOps} from './pool';
-import {ReductionOps} from './reduction_ops';
-import {ReluOps} from './relu_ops';
-import {ReverseOps} from './reverse';
-import {SegmentOps} from './segment_ops';
-import {SigmoidCrossEntropyOps} from './sigmoid_cross_entropy';
-import {SliceOps} from './slice';
-import {SoftmaxOps} from './softmax';
-import {StridedSliceOps} from './strided_slice';
-import {TensorOps} from './tensor_ops';
-import {TransposeOps} from './transpose';
-import {UnaryOps} from './unary_ops';
-
-export const batchNormalization = BatchNormOps.batchNormalization;
-export const batchNormalization2d = BatchNormOps.batchNormalization2d;
-export const batchNormalization3d = BatchNormOps.batchNormalization3d;
-export const batchNormalization4d = BatchNormOps.batchNormalization4d;
-
+export * from './batchnorm';
 export * from './concat';
+export * from './conv';
+export * from './matmul';
+export * from './reverse';
+export * from './pool';
+export * from './slice';
+export * from './unary_ops';
+export * from './reduction_ops';
+export * from './compare';
+export * from './binary_ops';
+export * from './sigmoid_cross_entropy';
+export * from './relu_ops';
+export * from './logical_ops';
+export * from './array_ops';
+export * from './tensor_ops';
+export * from './transpose';
+export * from './softmax';
+export * from './lrn';
+export * from './norm';
+export * from './segment_ops';
+export * from './lstm';
+export * from './moving_average';
+export * from './strided_slice';
 
-export const conv1d = ConvOps.conv1d;
-export const conv2d = ConvOps.conv2d;
-export const conv2dTranspose = ConvOps.conv2dTranspose;
-export const depthwiseConv2d = ConvOps.depthwiseConv2d;
-export const separableConv2d = ConvOps.separableConv2d;
+export {op} from './operation';
 
-export const matMul = MatmulOps.matMul;
-export const matrixTimesVector = MatmulOps.matrixTimesVector;
-export const outerProduct = MatmulOps.outerProduct;
-export const vectorTimesMatrix = MatmulOps.vectorTimesMatrix;
-export const dot = MatmulOps.dot;
+import * as losses from './loss_ops';
+import * as linalg from './linalg_ops';
+import * as image from './image_ops';
 
-export const avgPool = PoolOps.avgPool;
-export const maxPool = PoolOps.maxPool;
-
-export const transpose = TransposeOps.transpose;
-
-export const reverse = ReverseOps.reverse;
-export const reverse1d = ReverseOps.reverse1d;
-export const reverse2d = ReverseOps.reverse2d;
-export const reverse3d = ReverseOps.reverse3d;
-export const reverse4d = ReverseOps.reverse4d;
-
-export const slice = SliceOps.slice;
-export const slice1d = SliceOps.slice1d;
-export const slice2d = SliceOps.slice2d;
-export const slice3d = SliceOps.slice3d;
-export const slice4d = SliceOps.slice4d;
-
-export const stridedSlice = StridedSliceOps.stridedSlice;
-
-export const argMax = ReductionOps.argMax;
-export const argMin = ReductionOps.argMin;
-export const logSumExp = ReductionOps.logSumExp;
-export const max = ReductionOps.max;
-export const mean = ReductionOps.mean;
-export const min = ReductionOps.min;
-export const all = ReductionOps.all;
-// tslint:disable-next-line:variable-name
-export const any = ReductionOps.any;
-export const moments = ReductionOps.moments;
-export const sum = ReductionOps.sum;
-
-export const equal = CompareOps.equal;
-export const equalStrict = CompareOps.equalStrict;
-export const greater = CompareOps.greater;
-export const greaterStrict = CompareOps.greaterStrict;
-export const greaterEqual = CompareOps.greaterEqual;
-export const greaterEqualStrict = CompareOps.greaterEqualStrict;
-export const less = CompareOps.less;
-export const lessStrict = CompareOps.lessStrict;
-export const lessEqual = CompareOps.lessEqual;
-export const lessEqualStrict = CompareOps.lessEqualStrict;
-export const notEqual = CompareOps.notEqual;
-export const notEqualStrict = CompareOps.notEqualStrict;
-
-export const logicalNot = LogicalOps.logicalNot;
-export const logicalAnd = LogicalOps.logicalAnd;
-export const logicalOr = LogicalOps.logicalOr;
-export const logicalXor = LogicalOps.logicalXor;
-export const where = LogicalOps.where;
-
-export const abs = UnaryOps.abs;
-export const acos = UnaryOps.acos;
-export const acosh = UnaryOps.acosh;
-export const asin = UnaryOps.asin;
-export const asinh = UnaryOps.asinh;
-export const atan = UnaryOps.atan;
-export const atanh = UnaryOps.atanh;
-export const ceil = UnaryOps.ceil;
-export const clipByValue = UnaryOps.clipByValue;
-export const cos = UnaryOps.cos;
-export const cosh = UnaryOps.cosh;
-export const elu = ReluOps.elu;
-export const exp = UnaryOps.exp;
-export const expm1 = UnaryOps.expm1;
-export const floor = UnaryOps.floor;
-export const sign = UnaryOps.sign;
-export const leakyRelu = ReluOps.leakyRelu;
-export const log = UnaryOps.log;
-export const log1p = UnaryOps.log1p;
-export const logSigmoid = UnaryOps.logSigmoid;
-export const neg = UnaryOps.neg;
-export const prelu = ReluOps.prelu;
-export const relu = ReluOps.relu;
-export const reciprocal = UnaryOps.reciprocal;
-export const round = UnaryOps.round;
-export const selu = ReluOps.selu;
-export const sigmoid = UnaryOps.sigmoid;
-export const sin = UnaryOps.sin;
-export const sinh = UnaryOps.sinh;
-export const softplus = UnaryOps.softplus;
-export const sqrt = UnaryOps.sqrt;
-export const rsqrt = UnaryOps.rsqrt;
-export const square = UnaryOps.square;
-export const step = UnaryOps.step;
-export const tan = UnaryOps.tan;
-export const tanh = UnaryOps.tanh;
-export const erf = UnaryOps.erf;
-
-export const add = BinaryOps.add;
-export const addStrict = BinaryOps.addStrict;
-export const atan2 = BinaryOps.atan2;
-export const div = BinaryOps.div;
-export const floorDiv = BinaryOps.floorDiv;
-export const divStrict = BinaryOps.divStrict;
-export const maximum = BinaryOps.maximum;
-export const maximumStrict = BinaryOps.maximumStrict;
-export const minimum = BinaryOps.minimum;
-export const minimumStrict = BinaryOps.minimumStrict;
-export const mod = BinaryOps.mod;
-export const modStrict = BinaryOps.modStrict;
-export const mul = BinaryOps.mul;
-export const mulStrict = BinaryOps.mulStrict;
-export const pow = BinaryOps.pow;
-export const powStrict = BinaryOps.powStrict;
-export const sub = BinaryOps.sub;
-export const subStrict = BinaryOps.subStrict;
-
-export const squaredDifference = BinaryOps.squaredDifference;
-export const squaredDifferenceStrict = BinaryOps.squaredDifferenceStrict;
-
-export const norm = NormOps.norm;
-
-export const cast = ArrayOps.cast;
-export const clone = ArrayOps.clone;
-export const fromPixels = ArrayOps.fromPixels;
-export const toPixels = ArrayOps.toPixels;
-export const ones = TensorOps.ones;
-export const onesLike = TensorOps.onesLike;
-export const zeros = TensorOps.zeros;
-export const zerosLike = TensorOps.zerosLike;
-export const eye = ArrayOps.eye;
-export const rand = ArrayOps.rand;
-export const randomNormal = ArrayOps.randomNormal;
-export const truncatedNormal = ArrayOps.truncatedNormal;
-export const randomUniform = ArrayOps.randomUniform;
-export const multinomial = ArrayOps.multinomial;
-export const reshape = ArrayOps.reshape;
-export const squeeze = ArrayOps.squeeze;
-export const tile = ArrayOps.tile;
-export const gather = SegmentOps.gather;
-export const oneHot = ArrayOps.oneHot;
-export const linspace = TensorOps.linspace;
-export const range = TensorOps.range;
-export const buffer = ArrayOps.buffer;
-export const fill = TensorOps.fill;
-export const tensor = TensorOps.tensor;
-export const scalar = TensorOps.scalar;
-export const tensor1d = TensorOps.tensor1d;
-export const tensor2d = TensorOps.tensor2d;
-export const tensor3d = TensorOps.tensor3d;
-export const tensor4d = TensorOps.tensor4d;
-export const tensor5d = TensorOps.tensor5d;
-export const tensor6d = TensorOps.tensor6d;
-export const print = ArrayOps.print;
-export const expandDims = ArrayOps.expandDims;
-export const stack = ArrayOps.stack;
-export const unstack = ArrayOps.unstack;
-export const split = ArrayOps.split;
-export const cumsum = ArrayOps.cumsum;
-
-export const pad = ArrayOps.pad;
-export const pad1d = ArrayOps.pad1d;
-export const pad2d = ArrayOps.pad2d;
-export const pad3d = ArrayOps.pad3d;
-export const pad4d = ArrayOps.pad4d;
-export const unsortedSegmentSum = SegmentOps.unsortedSegmentSum;
-
-export const movingAverage = MovingAverageOps.movingAverage;
-
-export const basicLSTMCell = LSTMOps.basicLSTMCell;
-export const multiRNNCell = LSTMOps.multiRNNCell;
-
-export const softmax = SoftmaxOps.softmax;
-export const sigmoidCrossEntropyWithLogits =
-    SigmoidCrossEntropyOps.sigmoidCrossEntropyWithLogits;
-
-export const localResponseNormalization = LRNOps.localResponseNormalization;
-
-export const linalg = LinalgOps;
-
-export {operation} from './operation';
-
-// So typings can propagate.
-// tslint:disable-next-line:no-unused-expression
-[Tensor, Rank];
-
-// tslint:disable-next-line:no-unused-expression
-[Reduction];
-
-export const losses = {
-  absoluteDifference: LossOps.absoluteDifference,
-  computeWeightedLoss: LossOps.computeWeightedLoss,
-  cosineDistance: LossOps.cosineDistance,
-  hingeLoss: LossOps.hingeLoss,
-  huberLoss: LossOps.huberLoss,
-  logLoss: LossOps.logLoss,
-  meanSquaredError: LossOps.meanSquaredError,
-  softmaxCrossEntropy: SoftmaxOps.softmaxCrossEntropy
-};
-
-export const image = {
-  resizeBilinear: ImageOps.resizeBilinear,
-  resizeNearestNeighbor: ImageOps.resizeNearestNeighbor,
-};
+// Second level exports.
+export {image, linalg, losses};

--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -23,10 +23,10 @@ import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
 import * as axis_util from './axis_util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
+import {op} from './operation';
+import {ones, scalar} from './tensor_ops';
 
-export class ReductionOps {
+class ReductionOps {
   /**
    * Computes the log(sum(exp(elements across the reduction dimensions)).
    *
@@ -55,7 +55,6 @@ export class ReductionOps {
    *     of 1. Defaults to false.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static logSumExp<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     const $x = convertToTensor(x, 'x', 'logSumExp');
@@ -104,7 +103,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static sum<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     let $x = convertToTensor(x, 'x', 'sum');
@@ -138,7 +136,7 @@ export class ReductionOps {
           expandedDyShape[axis] = 1;
         });
         const expandedDy = dy.reshape(expandedDyShape);
-        const derX = expandedDy.mul(TensorOps.ones(x.shape, 'float32'));
+        const derX = expandedDy.mul(ones(x.shape, 'float32'));
         return derX;
       };
       return {value, gradFunc};
@@ -175,7 +173,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static mean<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     const $x = convertToTensor(x, 'x', 'mean');
@@ -188,7 +185,7 @@ export class ReductionOps {
     // Use a custom gradient to bypass 2 gradient backprops since mean is used
     // extremely often.
     const customOp = customGrad(x => {
-      const reduceSizeScalar = TensorOps.scalar(reduceSize);
+      const reduceSizeScalar = scalar(reduceSize);
       // Cast if needed.
       const xReduce = reduceSizeScalar.dtype === x.dtype ?
           x :
@@ -202,8 +199,8 @@ export class ReductionOps {
           expandedDyShape[axis] = 1;
         });
         const expandedDy = dy.reshape(expandedDyShape);
-        const derX = expandedDy.mul(TensorOps.ones(x.shape, 'float32'))
-                         .div(reduceSizeScalar);
+        const derX =
+            expandedDy.mul(ones(x.shape, 'float32')).div(reduceSizeScalar);
         return derX;
       };
       return {value, gradFunc};
@@ -240,7 +237,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static min<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     let $x = convertToTensor(x, 'x', 'min');
@@ -288,7 +284,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static max<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     let $x = convertToTensor(x, 'x', 'max');
@@ -332,7 +327,6 @@ export class ReductionOps {
    *
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static argMin<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     let $x = convertToTensor(x, 'x', 'argMin');
 
@@ -372,7 +366,6 @@ export class ReductionOps {
    * @param axis The dimension to reduce. Defaults to 0 (outer-most dimension).
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static argMax<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     let $x = convertToTensor(x, 'x', 'argMax');
 
@@ -417,7 +410,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static all<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     let $x = convertToTensor(x, 'x', 'all', 'bool');
@@ -468,7 +460,6 @@ export class ReductionOps {
    * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
-  @operation
   static any<T extends Tensor>(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false): T {
     let $x = convertToTensor(x, 'x', 'any', 'bool');
@@ -504,7 +495,6 @@ export class ReductionOps {
    * @return An object with two keys: `mean` and `variance`.
    */
   @doc({heading: 'Operations', subheading: 'Normalization'})
-  @operation
   static moments(
       x: Tensor|TensorLike, axis: number|number[] = null, keepDims = false):
       {mean: Tensor, variance: Tensor} {
@@ -520,3 +510,15 @@ export class ReductionOps {
     return {mean, variance};
   }
 }
+
+export const all = op(ReductionOps.all);
+// tslint:disable-next-line:variable-name
+export const any = op(ReductionOps.any);
+export const argMax = op(ReductionOps.argMax);
+export const argMin = op(ReductionOps.argMin);
+export const logSumExp = op(ReductionOps.logSumExp);
+export const max = op(ReductionOps.max);
+export const mean = op(ReductionOps.mean);
+export const min = op(ReductionOps.min);
+export const moments = op(ReductionOps.moments);
+export const sum = op(ReductionOps.sum);

--- a/src/ops/reverse.ts
+++ b/src/ops/reverse.ts
@@ -22,9 +22,9 @@ import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
 import {parseAxisParam} from './axis_util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class ReverseOps {
+class ReverseOps {
   /**
    * Reverses a `Tensor1D`.
    *
@@ -109,7 +109,6 @@ export class ReverseOps {
    *     range [-rank(x), rank(x)). Defaults to all axes.
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static reverse<T extends Tensor>(x: T|TensorLike, axis?: number|number[]): T {
     const $x = convertToTensor(x, 'x', 'reverse');
 
@@ -125,3 +124,9 @@ export class ReverseOps {
     return res.reshapeAs($x);
   }
 }
+
+export const reverse = op(ReverseOps.reverse);
+export const reverse1d = op(ReverseOps.reverse1d);
+export const reverse2d = op(ReverseOps.reverse2d);
+export const reverse3d = op(ReverseOps.reverse3d);
+export const reverse4d = op(ReverseOps.reverse4d);

--- a/src/ops/sigmoid_cross_entropy.ts
+++ b/src/ops/sigmoid_cross_entropy.ts
@@ -20,9 +20,9 @@ import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class SigmoidCrossEntropyOps {
+class SigmoidCrossEntropyOps {
   /**
    * Computes sigmoid cross entropy given logits.
    *
@@ -30,7 +30,6 @@ export class SigmoidCrossEntropyOps {
    * @param logits A Tensor of type float32 or float64.
    */
   @doc({heading: 'Operations', subheading: 'Cross Entropy'})
-  @operation
   static sigmoidCrossEntropyWithLogits<T extends Tensor, O extends Tensor>(
       labels: T|TensorLike, logits: T|TensorLike): O {
     const $labels =
@@ -68,3 +67,6 @@ export class SigmoidCrossEntropyOps {
     return maxOutput.sub(outputXTarget).add(sigmoidOutput);
   }
 }
+
+export const sigmoidCrossEntropyWithLogits =
+    op(SigmoidCrossEntropyOps.sigmoidCrossEntropyWithLogits);

--- a/src/ops/slice.ts
+++ b/src/ops/slice.ts
@@ -21,10 +21,10 @@ import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {Rank, TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
+import {op} from './operation';
 import * as slice_util from './slice_util';
 
-export class SliceOps {
+class SliceOps {
   /**
    * Extracts a 1D slice from 1D array starting at coordinates `begin` and is
    * of length `size`. See `slice` for details.
@@ -113,7 +113,6 @@ export class SliceOps {
    *     in which case it specifies the size of the first axis.
    */
   @doc({heading: 'Tensors', subheading: 'Slicing and Joining'})
-  @operation
   static slice<R extends Rank, T extends Tensor<R>>(
       x: T|TensorLike, begin: number|number[], size?: number|number[]): T {
     const $x = convertToTensor(x, 'x', 'slice');
@@ -167,3 +166,9 @@ export class SliceOps {
                backend => backend.slice($x, begin_, size_), {$x}, grad) as T;
   }
 }
+
+export const slice = op(SliceOps.slice);
+export const slice1d = op(SliceOps.slice1d);
+export const slice2d = op(SliceOps.slice2d);
+export const slice3d = op(SliceOps.slice3d);
+export const slice4d = op(SliceOps.slice4d);

--- a/src/ops/softmax.ts
+++ b/src/ops/softmax.ts
@@ -16,17 +16,13 @@
  */
 
 import {doc} from '../doc';
-import {customGrad} from '../globals';
+import {Gradients} from '../gradients';
 import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
-import * as util from '../util';
+import {op} from './operation';
 
-import * as axis_util from './axis_util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
-
-export class SoftmaxOps {
+class SoftmaxOps {
   /**
    * Computes the softmax normalized vector given the logits.
    *
@@ -47,7 +43,6 @@ export class SoftmaxOps {
    *     which indicates the last dimension.
    */
   @doc({heading: 'Operations', subheading: 'Normalization'})
-  @operation
   static softmax<T extends Tensor>(logits: T|TensorLike, dim = -1): T {
     const $logits = convertToTensor(logits, 'logits', 'softmax');
 
@@ -60,7 +55,7 @@ export class SoftmaxOps {
           `Logits was rank ${$logits.rank} and dim was ${dim}`);
     }
 
-    const customOp = customGrad(logits => {
+    const customOp = Gradients.customGrad(logits => {
       // Do it in log space for numerical stability.
       // exp(X - logSumExp(X))
       const keepDims = true;
@@ -79,66 +74,6 @@ export class SoftmaxOps {
 
     return customOp($logits);
   }
-
-  /**
-   * Computes softmax cross entropy between logits and labels.
-   *
-   * Measures the probability error in discrete classification tasks in which
-   * the classes are mutually exclusive (each entry is in exactly one class).
-   * For example, each CIFAR-10 image is labeled with one and only one label: an
-   * image can be a dog or a truck, but not both.
-   *
-   * `NOTE`: While the classes are mutually exclusive, their probabilities need
-   * not be. All that is required is that each row of labels is a valid
-   * probability distribution. If they are not, the computation of the gradient
-   * will be incorrect.
-   *
-   * `WARNING`: This op expects unscaled logits, since it performs a softmax on
-   * logits internally for efficiency. Do not call this op with the output of
-   * softmax, as it will produce incorrect results.
-   *
-   * logits and labels must have the same shape, e.g. [batch_size, num_classes]
-   * and the same dtype.
-   * @param labels The labels array.
-   * @param logits The logits array.
-   * @param dim The dimension softmax would be performed on. Defaults to `-1`
-   *     which indicates the last dimension.
-   */
-  @doc({heading: 'Training', subheading: 'Losses', namespace: 'losses'})
-  @operation
-  static softmaxCrossEntropy<T extends Tensor, O extends Tensor>(
-      labels: T|TensorLike, logits: T|TensorLike, dim = -1): O {
-    const $labels = convertToTensor(labels, 'labels', 'softmaxCrossEntropy');
-    const $logits = convertToTensor(logits, 'logits', 'softmaxCrossEntropy');
-    util.assertShapesMatch(
-        $labels.shape, $logits.shape, 'Error in softmaxCrossEntropy: ');
-
-    if (dim === -1) {
-      dim = $logits.rank - 1;
-    }
-    if (dim !== $logits.rank - 1) {
-      throw Error(
-          `Softmax cross entropy along a non-last dimension is not yet ` +
-          `supported. Labels / logits was rank ${$logits.rank} ` +
-          `and dim was ${dim}`);
-    }
-    // Use a custom gradient for numerical stability.
-    const customOp = customGrad((labels, logits) => {
-      const predictedProbs = logits.softmax(dim);
-      const costVector =
-          TensorOps.scalar(1e-5).add(predictedProbs).log().mul(labels).neg();
-      const value = costVector.sum([dim]) as O;
-
-      const gradFunc = (dy: O) => {
-        const dyShape = axis_util.expandShapeToKeepDim(dy.shape, [dim]);
-        return [
-          dy.reshape(dyShape).mul(labels.toFloat().sub(predictedProbs)),
-          dy.reshape(dyShape).mul(predictedProbs.sub(labels.toFloat())),
-        ];
-      };
-      return {value, gradFunc};
-    });
-
-    return customOp($labels, $logits);
-  }
 }
+
+export const softmax = op(SoftmaxOps.softmax);

--- a/src/ops/strided_slice.ts
+++ b/src/ops/strided_slice.ts
@@ -20,9 +20,9 @@ import {ENV} from '../environment';
 import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class StridedSliceOps {
+class StridedSliceOps {
   /**
    * Extracts a strided slice of a tensor.
    *
@@ -52,7 +52,6 @@ export class StridedSliceOps {
    *      and the fullest possible range in that dimension is used instead.
    */
   @doc({heading: 'Operations', subheading: 'Slicing and Joining'})
-  @operation
   static stridedSlice<T extends Tensor>(
       x: T|TensorLike, begin: number[], end: number[], strides: number[],
       beginMask = 0, endMask = 0): T {
@@ -63,3 +62,5 @@ export class StridedSliceOps {
                {$x}) as T;
   }
 }
+
+export const stridedSlice = op(StridedSliceOps.stridedSlice);

--- a/src/ops/tensor_ops.ts
+++ b/src/ops/tensor_ops.ts
@@ -24,8 +24,9 @@ import {TensorLike, TensorLike1D, TensorLike2D, TensorLike3D, TensorLike4D, Tens
 import {ArrayData, DataType, Rank, ShapeMap} from '../types';
 // tslint:disable-next-line:max-line-length
 import {assertNonNull, assertShapesMatch, getTypedArrayFromDType, inferShape, isTypedArray, makeOnesTypedArray, makeZerosTypedArray, sizeFromShape, toTypedArray} from '../util';
+import {op} from './operation';
 
-export class TensorOps {
+class TensorOps {
   /**
    * Creates a `Tensor` with the provided values, shape and dtype.
    *
@@ -510,3 +511,20 @@ export class TensorOps {
     return TensorOps.tensor1d(values, dtype);
   }
 }
+
+export const fill = TensorOps.fill;
+export const linspace = TensorOps.linspace;
+export const ones = TensorOps.ones;
+export const range = TensorOps.range;
+export const scalar = TensorOps.scalar;
+export const tensor = TensorOps.tensor;
+export const tensor1d = TensorOps.tensor1d;
+export const tensor2d = TensorOps.tensor2d;
+export const tensor3d = TensorOps.tensor3d;
+export const tensor4d = TensorOps.tensor4d;
+export const tensor5d = TensorOps.tensor5d;
+export const tensor6d = TensorOps.tensor6d;
+export const zeros = TensorOps.zeros;
+
+export const onesLike = op(TensorOps.onesLike);
+export const zerosLike = op(TensorOps.zerosLike);

--- a/src/ops/transpose.ts
+++ b/src/ops/transpose.ts
@@ -22,9 +22,9 @@ import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
 import * as axis_util from './axis_util';
-import {operation} from './operation';
+import {op} from './operation';
 
-export class TransposeOps {
+class TransposeOps {
   /**
    * Transposes the `Tensor`. Permutes the dimensions according to `perm`.
    *
@@ -43,7 +43,6 @@ export class TransposeOps {
    * @param perm The permutation of the dimensions of a.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
-  @operation
   static transpose<T extends Tensor>(x: T|TensorLike, perm?: number[]): T {
     const $x = convertToTensor(x, 'x', 'transpose');
 
@@ -73,3 +72,5 @@ export class TransposeOps {
         backend => backend.transpose($x, perm), {$x}, der);
   }
 }
+
+export const transpose = op(TransposeOps.transpose);

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -21,10 +21,11 @@ import {Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import * as util from '../util';
-import {operation} from './operation';
-import {TensorOps} from './tensor_ops';
 
-export class UnaryOps {
+import {op} from './operation';
+import {scalar, zerosLike} from './tensor_ops';
+
+class UnaryOps {
   /**
    * Computes `-1 * x` element-wise.
    *
@@ -37,7 +38,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static neg<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'neg');
 
@@ -58,13 +58,12 @@ export class UnaryOps {
    * @param x The input Tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static ceil<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'ceil');
 
     // TODO(manrajgrover): Return null for gradients when backprop supports it.
     const grad = (dy: T) => {
-      return {$x: () => TensorOps.zerosLike(dy)};
+      return {$x: () => zerosLike(dy)};
     };
     return ENV.engine.runKernel(backend => backend.ceil($x), {$x}, grad);
   }
@@ -80,14 +79,13 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static floor<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'floor');
 
     // TODO(nsthorat): Let gradients be null for cases where we want to stop
     // backpropgation.
     const grad = (dy: T) => {
-      return {$x: () => TensorOps.zerosLike(dy)};
+      return {$x: () => zerosLike(dy)};
     };
     return ENV.engine.runKernel(backend => backend.floor($x), {$x}, grad);
   }
@@ -103,12 +101,11 @@ export class UnaryOps {
    * @param x The input Tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static sign<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'sign');
 
     const grad = (dy: T) => {
-      return {$x: () => TensorOps.zerosLike(dy)};
+      return {$x: () => zerosLike(dy)};
     };
     return ENV.engine.runKernel(backend => backend.sign($x), {$x}, grad);
   }
@@ -125,14 +122,13 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static round<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'round');
 
     // TODO(nsthorat): Let gradients be null for cases where we want to stop
     // backpropgation.
     const grad = (dy: T) => {
-      return {$x: () => TensorOps.zerosLike(dy)};
+      return {$x: () => zerosLike(dy)};
     };
     return ENV.engine.runKernel(backend => backend.round($x), {$x}, grad);
   }
@@ -148,7 +144,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static exp<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'exp');
 
@@ -172,7 +167,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static expm1<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'expm1');
 
@@ -193,7 +187,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static log<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'log');
 
@@ -215,12 +208,11 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static log1p<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'log1p');
 
     const grad = (dy: T) => {
-      return {$x: () => dy.divStrict($x.add(TensorOps.scalar(1)))};
+      return {$x: () => dy.divStrict($x.add(scalar(1)))};
     };
     return ENV.engine.runKernel(backend => backend.log1p($x), {$x}, grad);
   }
@@ -236,14 +228,11 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static sqrt<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'sqrt');
 
     const grad = (dy: T) => {
-      return {
-        $x: () => dy.divStrict($x.toFloat().sqrt().mul(TensorOps.scalar(2)))
-      };
+      return {$x: () => dy.divStrict($x.toFloat().sqrt().mul(scalar(2)))};
     };
     return ENV.engine.runKernel(backend => backend.sqrt($x), {$x}, grad);
   }
@@ -260,16 +249,11 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static rsqrt<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'rsqrt');
 
     const grad = (dy: T) => {
-      return {
-        $x: () =>
-            dy.divStrict($x.pow(TensorOps.scalar(1.5)).mul(TensorOps.scalar(2)))
-                .neg()
-      };
+      return {$x: () => dy.divStrict($x.pow(scalar(1.5)).mul(scalar(2))).neg()};
     };
     return ENV.engine.runKernel(backend => backend.rsqrt($x), {$x}, grad);
   }
@@ -285,12 +269,11 @@ export class UnaryOps {
    * @param x The input Tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static square<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'square');
 
     const grad = (dy: T) => {
-      return {$x: () => dy.mulStrict($x.toFloat().mul(TensorOps.scalar(2)))};
+      return {$x: () => dy.mulStrict($x.toFloat().mul(scalar(2)))};
     };
     return ENV.engine.runKernel(backend => backend.square($x), {$x}, grad);
   }
@@ -306,7 +289,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static reciprocal<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'reciprocal');
 
@@ -327,7 +309,6 @@ export class UnaryOps {
    * @param x The input `Tensor`.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static abs<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'abs');
 
@@ -350,7 +331,6 @@ export class UnaryOps {
    * @param clipValueMax Upper-bound of range to be clipped to.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static clipByValue<T extends Tensor>(
       x: T|TensorLike, clipValueMin: number, clipValueMax: number): T {
     const $x = convertToTensor(x, 'x', 'clipByValue');
@@ -361,11 +341,10 @@ export class UnaryOps {
 
     const grad = (dy: T) => {
       return {
-        $x: () =>
-            dy.where(
-                $x.greaterEqual(TensorOps.scalar(clipValueMin))
-                    .logicalAnd($x.lessEqual(TensorOps.scalar(clipValueMax))),
-                TensorOps.zerosLike(dy)) as T,
+        $x: () => dy.where(
+                      $x.greaterEqual(scalar(clipValueMin))
+                          .logicalAnd($x.lessEqual(scalar(clipValueMax))),
+                      zerosLike(dy)) as T,
       };
     };
     return ENV.engine.runKernel(
@@ -383,13 +362,12 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static sigmoid<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'sigmoid');
 
     const grad = (dy: T, saved: Tensor[]) => {
       const [y] = saved;
-      return {$x: () => dy.mulStrict(y.mul(TensorOps.scalar(1).sub(y)))};
+      return {$x: () => dy.mulStrict(y.mul(scalar(1).sub(y)))};
     };
     return ENV.engine.runKernel(
         (backend, save) => save(backend.sigmoid($x)), {$x}, grad);
@@ -407,7 +385,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static logSigmoid<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'logSigmoid');
 
@@ -429,7 +406,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static softplus<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'softplus');
 
@@ -450,7 +426,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static sin<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'sin');
 
@@ -471,7 +446,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static cos<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'cos');
 
@@ -492,7 +466,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static tan<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'tan');
 
@@ -513,14 +486,12 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static asin<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'asin');
 
     const grad = (dy: T) => {
       return {
-        $x: () => dy.divStrict(
-            TensorOps.scalar(1).sub($x.toFloat().square()).sqrt() as T)
+        $x: () => dy.divStrict(scalar(1).sub($x.toFloat().square()).sqrt() as T)
       };
     };
     return ENV.engine.runKernel(backend => backend.asin($x), {$x}, grad);
@@ -537,16 +508,13 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static acos<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'acos');
 
     const grad = (dy: T) => {
       return {
         $x: () =>
-            dy.divStrict(
-                  TensorOps.scalar(1).sub($x.toFloat().square()).sqrt() as T)
-                .neg()
+            dy.divStrict(scalar(1).sub($x.toFloat().square()).sqrt() as T).neg()
       };
     };
     return ENV.engine.runKernel(backend => backend.acos($x), {$x}, grad);
@@ -563,14 +531,11 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static atan<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'atan');
 
     const grad = (dy: T) => {
-      return {
-        $x: () => dy.divStrict(TensorOps.scalar(1).add($x.toFloat().square()))
-      };
+      return {$x: () => dy.divStrict(scalar(1).add($x.toFloat().square()))};
     };
     return ENV.engine.runKernel(backend => backend.atan($x), {$x}, grad);
   }
@@ -586,7 +551,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static sinh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'sinh');
 
@@ -607,7 +571,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static cosh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'cosh');
 
@@ -628,13 +591,12 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static tanh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'tanh');
 
     const grad = (dy: T, saved: Tensor[]) => {
       const [y] = saved;
-      return {$x: () => TensorOps.scalar(1).sub(y.square()).mulStrict(dy) as T};
+      return {$x: () => scalar(1).sub(y.square()).mulStrict(dy) as T};
     };
     return ENV.engine.runKernel(
         (backend, save) => save(backend.tanh($x)), {$x}, grad);
@@ -652,14 +614,12 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static asinh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'asinh');
 
     const grad = (dy: T) => {
       return {
-        $x: () => dy.divStrict(
-            TensorOps.scalar(1).add($x.toFloat().square()).sqrt() as T)
+        $x: () => dy.divStrict(scalar(1).add($x.toFloat().square()).sqrt() as T)
       };
     };
     return ENV.engine.runKernel(backend => backend.asinh($x), {$x}, grad);
@@ -677,14 +637,12 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static acosh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'acosh');
 
     const grad = (dy: T) => {
       return {
-        $x: () => dy.divStrict(
-            $x.toFloat().square().sub(TensorOps.scalar(1)).sqrt() as T)
+        $x: () => dy.divStrict($x.toFloat().square().sub(scalar(1)).sqrt() as T)
       };
     };
     return ENV.engine.runKernel(backend => backend.acosh($x), {$x}, grad);
@@ -702,14 +660,11 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static atanh<T extends Tensor>(x: T|TensorLike): T {
     const $x = convertToTensor(x, 'x', 'atanh');
 
     const grad = (dy: T) => {
-      return {
-        $x: () => dy.divStrict(TensorOps.scalar(1).sub($x.toFloat().square()))
-      };
+      return {$x: () => dy.divStrict(scalar(1).sub($x.toFloat().square()))};
     };
     return ENV.engine.runKernel(backend => backend.atanh($x), {$x}, grad);
   }
@@ -726,7 +681,6 @@ export class UnaryOps {
    * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static erf<T extends Tensor>(x: T|TensorLike): T {
     let $x = convertToTensor(x, 'x', 'erf');
     util.assert(
@@ -739,8 +693,8 @@ export class UnaryOps {
 
     const grad = (dy: T) => {
       return {
-        $x: () => dy.mulStrict(TensorOps.scalar(2 / Math.sqrt(Math.PI))
-                                   .mul($x.square().neg().exp()))
+        $x: () => dy.mulStrict(
+            scalar(2 / Math.sqrt(Math.PI)).mul($x.square().neg().exp()))
       };
     };
     return ENV.engine.runKernel(backend => backend.erf($x), {$x}, grad);
@@ -758,15 +712,47 @@ export class UnaryOps {
    * @param alpha The gradient when input is negative.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
-  @operation
   static step<T extends Tensor>(x: T|TensorLike, alpha = 0.0): T {
     const $x = convertToTensor(x, 'x', 'step');
 
     // TODO(manrajgrover): Return null for gradients when backprop supports
     // it.
     const grad = (dy: T) => {
-      return {$x: () => TensorOps.zerosLike(dy)};
+      return {$x: () => zerosLike(dy)};
     };
     return ENV.engine.runKernel(backend => backend.step($x, alpha), {$x}, grad);
   }
 }
+
+export const abs = op(UnaryOps.abs);
+export const acos = op(UnaryOps.acos);
+export const acosh = op(UnaryOps.acosh);
+export const asin = op(UnaryOps.asin);
+export const asinh = op(UnaryOps.asinh);
+export const atan = op(UnaryOps.atan);
+export const atanh = op(UnaryOps.atanh);
+export const ceil = op(UnaryOps.ceil);
+export const clipByValue = op(UnaryOps.clipByValue);
+export const cos = op(UnaryOps.cos);
+export const cosh = op(UnaryOps.cosh);
+export const erf = op(UnaryOps.erf);
+export const exp = op(UnaryOps.exp);
+export const expm1 = op(UnaryOps.expm1);
+export const floor = op(UnaryOps.floor);
+export const log = op(UnaryOps.log);
+export const log1p = op(UnaryOps.log1p);
+export const logSigmoid = op(UnaryOps.logSigmoid);
+export const neg = op(UnaryOps.neg);
+export const reciprocal = op(UnaryOps.reciprocal);
+export const round = op(UnaryOps.round);
+export const rsqrt = op(UnaryOps.rsqrt);
+export const sigmoid = op(UnaryOps.sigmoid);
+export const sign = op(UnaryOps.sign);
+export const sin = op(UnaryOps.sin);
+export const sinh = op(UnaryOps.sinh);
+export const softplus = op(UnaryOps.softplus);
+export const sqrt = op(UnaryOps.sqrt);
+export const square = op(UnaryOps.square);
+export const step = op(UnaryOps.step);
+export const tan = op(UnaryOps.tan);
+export const tanh = op(UnaryOps.tanh);


### PR DESCRIPTION
The `@operation` decorator is causing problems when syncing the library inside Google. Instead, we introduce an `op` function that wraps existing function.

DEV