### PR TITLE
Allow tf.dispose(any), not just tf.dispose(TensorContainer)

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -164,7 +164,8 @@ export class Environment {
    *     `Promise`s are not supported.
    */
   @doc({heading: 'Performance', subheading: 'Memory'})
-  static dispose(container: TensorContainer) {
+  // tslint:disable-next-line:no-any
+  static dispose(container: any) {
     const tensors = getTensorsInContainer(container);
     tensors.forEach(tensor => tensor.dispose());
   }

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -17,7 +17,7 @@
 
 import {Tensor} from './tensor';
 // tslint:disable-next-line:max-line-length
-import {NamedTensorMap, TensorContainerArray} from './tensor_types';
+import {NamedTensorMap} from './tensor_types';
 import {ArrayData, DataType, TensorLike} from './types';
 import {assert, inferShape, isTypedArray, toTypedArray} from './util';
 

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -17,7 +17,7 @@
 
 import {Tensor} from './tensor';
 // tslint:disable-next-line:max-line-length
-import {NamedTensorMap, TensorContainer, TensorContainerArray} from './tensor_types';
+import {NamedTensorMap, TensorContainerArray} from './tensor_types';
 import {ArrayData, DataType, TensorLike} from './types';
 import {assert, inferShape, isTypedArray, toTypedArray} from './util';
 
@@ -110,7 +110,8 @@ export function unflattenToNameArrayMap(
  *   returned. If the object is not a `Tensor` or does not
  *   contain `Tensors`, an empty list is returned.
  */
-export function getTensorsInContainer(result: TensorContainer): Tensor[] {
+// tslint:disable-next-line:no-any
+export function getTensorsInContainer(result: any): Tensor[] {
   const list: Tensor[] = [];
   const seen = new Set<{}|void>();
   walkTensorContainer(result, list, seen);
@@ -118,7 +119,8 @@ export function getTensorsInContainer(result: TensorContainer): Tensor[] {
 }
 
 function walkTensorContainer(
-    container: TensorContainer, list: Tensor[], seen: Set<{}|void>): void {
+    // tslint:disable-next-line:no-any
+    container: any, list: Tensor[], seen: Set<{}|void>): void {
   if (container == null) {
     return;
   }

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -132,9 +132,8 @@ function walkTensorContainer(
     return;
   }
   // Iteration over keys works also for arrays.
-  const iterable = container as TensorContainerArray;
-  for (const k in iterable) {
-    const val = iterable[k];
+  for (const k in container) {
+    const val = container[k];
     if (!seen.has(val)) {
       seen.add(val);
       walkTensorContainer(val, list, seen);


### PR DESCRIPTION
The disposal code does not actually require the TensorContainer constraint.  It is useful to be able  tf.dispose(...) any object without type constraints (particularly in dependent libraries where TensorContainer is not a central concept).

This fixes a (perhaps inadvertent) breaking API change in #1083.

Happy to discuss, of course, whether the tighter API is actually what we want!

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1150)
<!-- Reviewable:end -->
