### PR TITLE
Fix unary benchmark error

### DIFF
--- a/integration_tests/benchmarks/unary_ops_benchmark.ts
+++ b/integration_tests/benchmarks/unary_ops_benchmark.ts
@@ -88,7 +88,7 @@ export class UnaryOpsCPUBenchmark implements BenchmarkTest {
     const start = performance.now();
 
     tf.tidy(() => {
-      op(input).get();
+      op(input).dataSync();
     });
 
     const end = performance.now();


### PR DESCRIPTION
#### Description

BUG

Since the location parameter in the `get` method of a tensor is required, it is necessary to change the way to get the data from each ops. `dataSync` in this case is sufficient.

<img width="562" alt="screen shot 2018-07-10 at 22 59 34" src="https://user-images.githubusercontent.com/1713047/42514898-6ffa0a8c-8495-11e8-9d1c-7d66e7683a17.png">


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1153)
<!-- Reviewable:end -->
