### PR TITLE
Add `declare` to interfaces that describe JSON types

### DIFF
--- a/src/io/types.ts
+++ b/src/io/types.ts
@@ -36,7 +36,7 @@ export const DTYPE_VALUE_SIZE_MAP: {[dtype: string]: number} = {
  * number of weight values stored in a number of paths.
  * See the documentation of `WeightManifestGroupConfig` below for more details.
  */
-export type WeightsManifestConfig = WeightsManifestGroupConfig[];
+export declare type WeightsManifestConfig = WeightsManifestGroupConfig[];
 
 /**
  * A weight-manifest group.
@@ -44,7 +44,7 @@ export type WeightsManifestConfig = WeightsManifestGroupConfig[];
  * Consists of an ordered list of weight values encoded in binary format,
  * stored in an ordered list of paths.
  */
-export interface WeightsManifestGroupConfig {
+export declare interface WeightsManifestGroupConfig {
   /**
    * An ordered list of paths.
    *
@@ -64,7 +64,7 @@ export interface WeightsManifestGroupConfig {
  *
  * The entry contains specification of a weight.
  */
-export interface WeightsManifestEntry {
+export declare interface WeightsManifestEntry {
   /**
    * Name of the weight, e.g., 'Dense_1/bias'
    */
@@ -122,7 +122,7 @@ export interface SaveResult {
   errors?: Array<{}|string>;
 }
 
-export interface ModelArtifactsInfo {
+export declare interface ModelArtifactsInfo {
   /**
    * Timestamp for when the model is saved.
    */
@@ -162,7 +162,7 @@ export interface ModelArtifactsInfo {
  * are optional, in order to support topology- or weights-only saving and
  * loading.
  */
-export interface ModelArtifacts {
+export declare interface ModelArtifacts {
   /**
    * Model topology.
    *

--- a/src/ops/multinomial_test.ts
+++ b/src/ops/multinomial_test.ts
@@ -21,14 +21,14 @@ import {Tensor1D} from '../tensor';
 import {ALL_ENVS, expectArraysClose} from '../test_util';
 
 describeWithFlags('multinomial', ALL_ENVS, () => {
-  const NUM_SAMPLES = 10000;
+  const NUM_SAMPLES = 1000;
   // Allowed Variance in probability (in %).
   const EPSILON = 0.05;
+  const SEED = 3.14;
 
   it('Flip a fair coin and check bounds', () => {
     const probs = tf.tensor1d([1, 1]);
-    const seed: number = null;
-    const result = tf.multinomial(probs, NUM_SAMPLES, seed);
+    const result = tf.multinomial(probs, NUM_SAMPLES, SEED);
     expect(result.dtype).toBe('int32');
     expect(result.shape).toEqual([NUM_SAMPLES]);
     const outcomeProbs = computeProbs(result.dataSync(), 2);
@@ -37,8 +37,7 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
 
   it('Flip a two-sided coin with 100% of heads', () => {
     const logits = tf.tensor1d([1, -100]);
-    const seed: number = null;
-    const result = tf.multinomial(logits, NUM_SAMPLES, seed);
+    const result = tf.multinomial(logits, NUM_SAMPLES, SEED);
     expect(result.dtype).toBe('int32');
     expect(result.shape).toEqual([NUM_SAMPLES]);
     const outcomeProbs = computeProbs(result.dataSync(), 2);
@@ -47,8 +46,7 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
 
   it('Flip a two-sided coin with 100% of tails', () => {
     const logits = tf.tensor1d([-100, 1]);
-    const seed: number = null;
-    const result = tf.multinomial(logits, NUM_SAMPLES, seed);
+    const result = tf.multinomial(logits, NUM_SAMPLES, SEED);
     expect(result.dtype).toBe('int32');
     expect(result.shape).toEqual([NUM_SAMPLES]);
     const outcomeProbs = computeProbs(result.dataSync(), 2);
@@ -57,15 +55,13 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
 
   it('Flip a single-sided coin throws error', () => {
     const probs = tf.tensor1d([1]);
-    const seed: number = null;
-    expect(() => tf.multinomial(probs, NUM_SAMPLES, seed)).toThrowError();
+    expect(() => tf.multinomial(probs, NUM_SAMPLES, SEED)).toThrowError();
   });
 
   it('Flip a ten-sided coin and check bounds', () => {
     const numOutcomes = 10;
     const logits = tf.fill([numOutcomes], 1).as1D();
-    const seed: number = null;
-    const result = tf.multinomial(logits, NUM_SAMPLES, seed);
+    const result = tf.multinomial(logits, NUM_SAMPLES, SEED);
     expect(result.dtype).toBe('int32');
     expect(result.shape).toEqual([NUM_SAMPLES]);
     const outcomeProbs = computeProbs(result.dataSync(), numOutcomes);
@@ -76,8 +72,7 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
     const numOutcomes = 3;
     const logits = tf.tensor2d(
         [[-100, -100, 1], [-100, 1, -100], [1, -100, -100]], [3, numOutcomes]);
-    const seed: number = null;
-    const result = tf.multinomial(logits, NUM_SAMPLES, seed);
+    const result = tf.multinomial(logits, NUM_SAMPLES, SEED);
     expect(result.dtype).toBe('int32');
     expect(result.shape).toEqual([3, NUM_SAMPLES]);
 
@@ -99,26 +94,22 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
 
   it('passing Tensor3D throws error', () => {
     const probs = tf.zeros([3, 2, 2]);
-    const seed: number = null;
     const normalized = true;
-    expect(() => tf.multinomial(probs as Tensor1D, 3, seed, normalized))
+    expect(() => tf.multinomial(probs as Tensor1D, 3, SEED, normalized))
         .toThrowError();
   });
 
   it('throws when passed a non-tensor', () => {
-    const seed: number = null;
     // tslint:disable-next-line:no-any
-    expect(() => tf.multinomial({} as any, NUM_SAMPLES, seed))
+    expect(() => tf.multinomial({} as any, NUM_SAMPLES, SEED))
         .toThrowError(
             /Argument 'logits' passed to 'multinomial' must be a Tensor/);
   });
 
   it('accepts a tensor-like object for logits (biased coin)', () => {
-    const numSamples = 10;
-    const seed: number = null;
-    const res = tf.multinomial([-10, 1], numSamples, seed);
+    const res = tf.multinomial([-100, 1], NUM_SAMPLES, SEED);
     expect(res.dtype).toBe('int32');
-    expect(res.shape).toEqual([numSamples]);
+    expect(res.shape).toEqual([NUM_SAMPLES]);
     const outcomeProbs = computeProbs(res.dataSync(), 2);
     expectArraysClose(outcomeProbs, [0, 1], EPSILON);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,27 +64,27 @@ export interface RecursiveArray<T extends any> {
 }
 
 enum UpcastInt32AndMap {
-  float32 = 'float32',
-  int32 = 'int32',
-  bool = 'int32'
+  'float32' = 'float32',
+  'int32' = 'int32',
+  'bool' = 'int32'
 }
 
 enum UpcastBoolAndMap {
-  float32 = 'float32',
-  int32 = 'int32',
-  bool = 'bool'
+  'float32' = 'float32',
+  'int32' = 'int32',
+  'bool' = 'bool'
 }
 
 enum UpcastFloat32AndMap {
-  float32 = 'float32',
-  int32 = 'float32',
-  bool = 'float32'
+  'float32' = 'float32',
+  'int32' = 'float32',
+  'bool' = 'float32'
 }
 
 const upcastTypeMap = {
-  float32: UpcastFloat32AndMap,
-  int32: UpcastInt32AndMap,
-  bool: UpcastBoolAndMap
+  'float32': UpcastFloat32AndMap,
+  'int32': UpcastInt32AndMap,
+  'bool': UpcastBoolAndMap
 };
 
 export function upcastType(typeA: DataType, typeB: DataType): DataType {


### PR DESCRIPTION
Adding `declare` to interfaces that describe JSON types tells the closure compiler to not rewrite the code that accessed those fields. Also use strings for lookup in dictionaries.

And fix flaky multinomial unit tests.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1161)
<!-- Reviewable:end -->
