### PR TITLE
Ignore bundle.js in benchmark tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 yalc.lock
 .rpt2_cache/
 package/
+integration_tests/benchmarks/bundle.js


### PR DESCRIPTION
#### Description

MISC

Benchmark tools generate `bundle.js` which includes whole dependencies to be runnable in a browser. Since it's generated from TypeScript source code, we can remove it from version control.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1162)
<!-- Reviewable:end -->
