### PR TITLE
Export tf.io.browserDownloads()

### DIFF
--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -21,7 +21,7 @@
 import './indexed_db';
 import './local_storage';
 
-import {browserFiles} from './browser_files';
+import {browserDownloads, browserFiles} from './browser_files';
 import {browserHTTPRequest} from './browser_http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, withSaveHandler} from './passthrough';
@@ -39,6 +39,7 @@ export {copyModel, listModels, moveModel, removeModel} from './model_management'
 // tslint:enable:max-line-length
 
 export {
+  browserDownloads,
   browserFiles,
   browserHTTPRequest,
   concatenateArrayBuffers,


### PR DESCRIPTION
#### Description

The browserDownloads symbol was not exported in io/io.ts; this corrects the oversight and so makes `tf.io.browserDownloads()` work as already documented.

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
