### PR TITLE
Add tf.topk

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -32,7 +32,7 @@ import {makeOnesTypedArray, now, sizeFromShape} from './util';
  * A function that computes an output. The save function is for saving tensors
  * computed in the forward pass, that we need in the backwards pass.
  */
-export type ForwardFunc<T extends Tensor> =
+export type ForwardFunc<T> =
     (backend: KernelBackend, save?: <S extends Tensor>(tensor: S) => S) => T;
 
 /**
@@ -148,7 +148,7 @@ export class Engine implements TensorManager {
     }
   }
 
-  runKernel<T extends Tensor, I extends NamedTensorMap>(
+  runKernel<T extends Tensor|Tensor[], I extends NamedTensorMap>(
       forwardFunc: ForwardFunc<T>,
       inputs: I,
       backwardsFunc?: (dy: T, saved: Tensor[]) => {[P in keyof I]: () => I[P]},
@@ -178,11 +178,13 @@ export class Engine implements TensorManager {
         id: this.nextTapeNodeId++,
         name: scopeName,
         inputs,
-        output: result,
-
+        // Keep gradient records only for the first output.
+        output: Array.isArray(result) ? result[0] : result
       };
       if (backwardsFunc != null) {
-        tapeNode.gradient = (dy: T) => backwardsFunc(dy, saved);
+        tapeNode.gradient =
+            ((dy: T) => backwardsFunc(dy, saved)) as (dy: Tensor) =>
+                NamedGradientMap;
       }
       this.activeTape.push(tapeNode);
     }

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -100,8 +100,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
 
   where(condition: Tensor, a: Tensor, b: Tensor, dtype: DataType): Tensor;
 
-  topKValues<T extends Tensor>(x: T, k: number): Tensor1D;
-  topKIndices(x: Tensor, k: number): Tensor1D;
+  topk<T extends Tensor>(x: T, k: number, sorted: boolean): [T, T];
 
   min(x: Tensor, axes: number[]): Tensor;
   minimum(a: Tensor, b: Tensor): Tensor;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -32,6 +32,7 @@ import * as util from '../util';
 
 import {KernelBackend} from './backend';
 import * as backend_util from './backend_util';
+import {topkImpl} from './topk_impl';
 import {ArgMinMaxProgram} from './webgl/argminmax_gpu';
 import {AvgPool2DBackpropProgram} from './webgl/avg_pool_backprop_gpu';
 import {BatchNormProgram} from './webgl/batchnorm_gpu';
@@ -747,12 +748,8 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [condition, a, b], output);
   }
 
-  topKValues<T extends Tensor>(x: T, k: number): Tensor1D {
-    throw new Error('topKValues GPU not yet implemented!');
-  }
-
-  topKIndices(x: Tensor, k: number): Tensor1D {
-    throw new Error('topKIndices GPU not yet implemented!');
+  topk<T extends Tensor>(x: T, k: number, sorted: boolean): [T, T] {
+    return topkImpl(x, k, sorted);
   }
 
   min(x: Tensor, axes: number[]): Tensor {

--- a/src/kernels/topk_impl.ts
+++ b/src/kernels/topk_impl.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/** An implementation of topk shared between webgl and cpu backend. */
+
+import {tensor} from '../ops/tensor_ops';
+import {Tensor} from '../tensor';
+import {getTypedArrayFromDType} from '../util';
+
+export function topkImpl<T extends Tensor>(
+    x: T, k: number, sorted: boolean): [T, T] {
+  // Reshape into a 2d tensor [batch, lastDim] and compute topk along lastDim.
+  const lastDim = x.shape[x.shape.length - 1];
+  const x2d = x.reshape([-1, lastDim]);
+  const [batch, size] = x2d.shape;
+  const allVals = x.dataSync();
+  const allTopKVals = getTypedArrayFromDType(x.dtype, batch * k);
+  const allTopKIndices = getTypedArrayFromDType('int32', batch * k);
+
+  for (let b = 0; b < batch; b++) {
+    const offset = b * size;
+    const vals = allVals.subarray(offset, offset + size);
+    const valAndInd: Array<{value: number, index: number}> = [];
+    for (let i = 0; i < vals.length; i++) {
+      valAndInd.push({value: vals[i], index: i});
+    }
+    valAndInd.sort((a, b) => b.value - a.value);
+
+    const outOffset = b * k;
+    const topKVals = allTopKVals.subarray(outOffset, outOffset + k);
+    const topKIndices = allTopKIndices.subarray(outOffset, outOffset + k);
+    for (let i = 0; i < k; i++) {
+      topKVals[i] = valAndInd[i].value;
+      topKIndices[i] = valAndInd[i].index;
+    }
+  }
+  // Reshape back to the original input shape, except that the last
+  // dimension is k.
+  const outputShape = x.shape.slice();
+  outputShape[outputShape.length - 1] = k;
+  return [
+    tensor(allTopKVals, outputShape, x.dtype) as T,
+    tensor(allTopKIndices, outputShape, 'int32') as T
+  ];
+}

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -38,6 +38,7 @@ export * from './segment_ops';
 export * from './lstm';
 export * from './moving_average';
 export * from './strided_slice';
+export * from './topk';
 
 export {op} from './operation';
 

--- a/src/ops/topk.ts
+++ b/src/ops/topk.ts
@@ -54,7 +54,8 @@ function topk_<T extends Tensor>(
   const lastDim = $x.shape[$x.shape.length - 1];
   if (k > lastDim) {
     throw new Error(
-        `'k' passed to topk() must be <= the last dimension (${lastDim})`);
+        `'k' passed to topk() must be <= the last dimension (${lastDim}) ` +
+        `but got ${k}`);
   }
 
   const [values, indices] =

--- a/src/ops/topk.ts
+++ b/src/ops/topk.ts
@@ -21,6 +21,29 @@ import {convertToTensor} from '../tensor_util';
 import {TensorLike} from '../types';
 import {op} from './operation';
 
+/**
+ * Finds the values and indices of the `k` largest entries along the last
+ * dimension.
+ *
+ * If the input is a vector (rank=1), finds the k largest entries in the vector
+ * and outputs their values and indices as vectors. Thus values[j] is the j-th
+ * largest entry in input, and its index is indices[j].
+ * For higher rank inputs, computes the top k entries along the last dimension.
+ *
+ * If two elements are equal, the lower-index element appears first.
+ *
+ * ```js
+ * const a = tensor2d([[1, 5], [4, 3]]);
+ * const {values, indices} = tf.topk(a);
+ * values.print();
+ * indices.print();
+ * ```
+ * @param x 1-D or higher `Tensor` with last dimension being at least `k`.
+ * @param k Number of top elements to look for along the last dimension.
+ * @param sorted If true, the resulting `k` elements will be sorted by the
+ *     values in descending order.
+ */
+/** @doc {heading: 'Operations', subheading: 'Evaluation'} */
 function topk_<T extends Tensor>(
     x: T|TensorLike, k = 1, sorted = true): {values: T, indices: T} {
   const $x = convertToTensor(x, 'x', 'topk');

--- a/src/ops/topk.ts
+++ b/src/ops/topk.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../environment';
+import {Tensor} from '../tensor';
+import {convertToTensor} from '../tensor_util';
+import {TensorLike} from '../types';
+import {op} from './operation';
+
+function topk_<T extends Tensor>(x: T|TensorLike, k: number, sorted = true): T {
+  const $x = convertToTensor(x, 'x', 'topk');
+
+  if ($x.rank === 0) {
+    throw new Error('Topk expects the input to be of rank-1 or higher');
+  }
+  return ENV.engine.runKernel(b => b.topk(x, k, sorted), {x});
+}
+
+export const topk = op({topk_});

--- a/src/ops/topk_test.ts
+++ b/src/ops/topk_test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+import {describeWithFlags} from '../jasmine_util';
+import {ALL_ENVS, expectArraysClose} from '../test_util';
+
+import {scalar, tensor1d, tensor2d, tensor3d} from './tensor_ops';
+
+describeWithFlags('topk', ALL_ENVS, () => {
+  it('1d array with default k', () => {
+    const a = tensor1d([20, 10, 40, 30]);
+    const {values, indices} = tf.topk(a);
+
+    expect(values.shape).toEqual([1]);
+    expect(indices.shape).toEqual([1]);
+    expect(values.dtype).toBe('float32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [40]);
+    expectArraysClose(indices, [2]);
+  });
+
+  it('2d array with default k', () => {
+    const a = tensor2d([[10, 50], [40, 30]]);
+    const {values, indices} = tf.topk(a);
+
+    expect(values.shape).toEqual([2, 1]);
+    expect(indices.shape).toEqual([2, 1]);
+    expect(values.dtype).toBe('float32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [50, 40]);
+    expectArraysClose(indices, [1, 0]);
+  });
+
+  it('2d array with k=2', () => {
+    const a = tensor2d([
+      [1, 5, 2],
+      [4, 3, 6],
+      [3, 2, 1],
+      [1, 2, 3],
+    ]);
+    const k = 2;
+    const {values, indices} = tf.topk(a, k);
+
+    expect(values.shape).toEqual([4, 2]);
+    expect(indices.shape).toEqual([4, 2]);
+    expect(values.dtype).toBe('float32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [5, 2, 6, 4, 3, 2, 3, 2]);
+    expectArraysClose(indices, [1, 2, 2, 0, 0, 1, 2, 1]);
+  });
+
+  it('3d array with k=3', () => {
+    const a = tensor3d([
+      [[1, 5, 2], [4, 3, 6]],
+      [[3, 2, 1], [1, 2, 3]],
+    ]);  // 2x2x3.
+    const k = 3;
+    const {values, indices} = tf.topk(a, k);
+
+    expect(values.shape).toEqual([2, 2, 3]);
+    expect(indices.shape).toEqual([2, 2, 3]);
+    expect(values.dtype).toBe('float32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [5, 2, 1, 6, 4, 3, 3, 2, 1, 3, 2, 1]);
+    expectArraysClose(indices, [1, 2, 0, 2, 0, 1, 0, 1, 2, 2, 1, 0]);
+  });
+
+  it('topk(int32) propagates int32 dtype', () => {
+    const a = tensor1d([2, 3, 1, 4], 'int32');
+    const {values, indices} = tf.topk(a);
+
+    expect(values.shape).toEqual([1]);
+    expect(indices.shape).toEqual([1]);
+    expect(values.dtype).toBe('int32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [4]);
+    expectArraysClose(indices, [3]);
+  });
+
+  it('throws when k > size of array', () => {
+    const a = tensor2d([[10, 50], [40, 30]]);
+    expect(() => tf.topk(a, 3))
+        .toThrowError(/'k' passed to topk\(\) must be <= the last dimension/);
+  });
+
+  it('throws when passed a scalar', () => {
+    const a = scalar(2);
+    expect(() => tf.topk(a))
+        .toThrowError(/topk\(\) expects the input to be of rank 1 or higher/);
+  });
+});

--- a/src/ops/topk_test.ts
+++ b/src/ops/topk_test.ts
@@ -92,6 +92,19 @@ describeWithFlags('topk', ALL_ENVS, () => {
     expectArraysClose(indices, [3]);
   });
 
+  it('lower-index element appears first, k=4', () => {
+    const a = tensor1d([1, 2, 2, 1], 'int32');
+    const k = 4;
+    const {values, indices} = tf.topk(a, k);
+
+    expect(values.shape).toEqual([4]);
+    expect(indices.shape).toEqual([4]);
+    expect(values.dtype).toBe('int32');
+    expect(indices.dtype).toBe('int32');
+    expectArraysClose(values, [2, 2, 1, 1]);
+    expectArraysClose(indices, [1, 2, 0, 3]);
+  });
+
   it('throws when k > size of array', () => {
     const a = tensor2d([[10, 50], [40, 30]]);
     expect(() => tf.topk(a, 3))


### PR DESCRIPTION
Add tf.topk.

This is required in ssd_mobilenet_v2: https://github.com/tensorflow/tfjs/issues/188. Uses a shared implementation across webgl and cpu where the values are downloaded and sorted on the cpu. There is already an issue that tracks topk on the gpu, which we can revisit later: https://github.com/tensorflow/tfjs/issues/94

FEATURE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1172)
<!-- Reviewable:end -->
