### PR TITLE
[io] Fix a bug in concatenateTypedArrays

### DIFF
--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -126,7 +126,7 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
   // this property, a new `TypedArray` that satisfy this property will be
   // constructed and pushed into `normalizedXs`.
   const normalizedXs: TypedArray[] = [];
-  xs.forEach(x => {
+  xs.forEach((x: TypedArray) => {
     totalByteLength += x.byteLength;
     // tslint:disable:no-any
     normalizedXs.push(
@@ -141,7 +141,7 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
 
   const y = new Uint8Array(totalByteLength);
   let offset = 0;
-  normalizedXs.forEach(x => {
+  normalizedXs.forEach((x: TypedArray) => {
     y.set(new Uint8Array(x.buffer), offset);
     offset += x.byteLength;
   });
@@ -210,13 +210,13 @@ export function base64StringToArrayBuffer(str: string): ArrayBuffer {
  */
 export function concatenateArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
   let totalByteLength = 0;
-  buffers.forEach(buffer => {
+  buffers.forEach((buffer: ArrayBuffer) => {
     totalByteLength += buffer.byteLength;
   });
 
   const temp = new Uint8Array(totalByteLength);
   let offset = 0;
-  buffers.forEach(buffer => {
+  buffers.forEach((buffer: ArrayBuffer) => {
     temp.set(new Uint8Array(buffer), offset);
     offset += buffer.byteLength;
   });

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -117,6 +117,14 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
   }
 
   let totalByteLength = 0;
+
+  // `normalized` is here for this reason: a `TypedArray`'s `buffer'
+  // can have a different byte length from that of the `TypedArray` itself,
+  // for example, when the `TypedArray` is created from an offset in an
+  // `ArrayBuffer`. `normliazedXs` holds `TypedArray`s whose `buffer`s match
+  // the `TypedArray` in byte length. If an element of `xs` does not show
+  // this property, a new `TypedArray` is constructed and pushed into
+  // `normalizedXs`.
   const normalizedXs: TypedArray[] = [];
   xs.forEach(x => {
     totalByteLength += x.byteLength;

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -118,13 +118,13 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
 
   let totalByteLength = 0;
 
-  // `normalized` is here for this reason: a `TypedArray`'s `buffer'
+  // `normalizedXs` is here for this reason: a `TypedArray`'s `buffer'
   // can have a different byte length from that of the `TypedArray` itself,
   // for example, when the `TypedArray` is created from an offset in an
   // `ArrayBuffer`. `normliazedXs` holds `TypedArray`s whose `buffer`s match
   // the `TypedArray` in byte length. If an element of `xs` does not show
-  // this property, a new `TypedArray` is constructed and pushed into
-  // `normalizedXs`.
+  // this property, a new `TypedArray` that satisfy this property will be
+  // constructed and pushed into `normalizedXs`.
   const normalizedXs: TypedArray[] = [];
   xs.forEach(x => {
     totalByteLength += x.byteLength;

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -117,23 +117,25 @@ export function concatenateTypedArrays(xs: TypedArray[]): ArrayBuffer {
   }
 
   let totalByteLength = 0;
+  const normalizedXs: TypedArray[] = [];
   xs.forEach(x => {
-    // tslint:disable-next-line:no-any
-    if (x as any instanceof Float32Array || x as any instanceof Int32Array) {
-      totalByteLength += x.buffer.byteLength;
-      // tslint:disable-next-line:no-any
-    } else if (x as any instanceof Uint8Array) {
-      totalByteLength += x.buffer.byteLength;
-    } else {
+    totalByteLength += x.byteLength;
+    // tslint:disable:no-any
+    normalizedXs.push(
+        x.byteLength === x.buffer.byteLength ? x :
+                                               new (x.constructor as any)(x));
+    if (!(x as any instanceof Float32Array || x as any instanceof Int32Array ||
+          x as any instanceof Uint8Array)) {
       throw new Error(`Unsupported TypedArray subtype: ${x.constructor.name}`);
     }
+    // tslint:enable:no-any
   });
 
   const y = new Uint8Array(totalByteLength);
   let offset = 0;
-  xs.forEach(x => {
+  normalizedXs.forEach(x => {
     y.set(new Uint8Array(x.buffer), offset);
-    offset += x.buffer.byteLength;
+    offset += x.byteLength;
   });
 
   return y.buffer;

--- a/src/io/io_utils_test.ts
+++ b/src/io/io_utils_test.ts
@@ -82,6 +82,82 @@ describe('concatenateTypedArrays', () => {
     expect(new Float32Array(buffer, 20, 4)).toEqual(z);
   });
 
+  it('Concatenate Float32Arrays from SubArrays', () => {
+    const x1 = new Float32Array([1.1, 2.2, 3.3]);
+    const x2 = new Float32Array([-1.1, -2.2, -3.3]);
+    const xConcatenated = concatenateTypedArrays([x1, x2]);
+    const y1 = new Float32Array(xConcatenated, 0, 3);
+    const y2 = new Float32Array(xConcatenated, 3 * 4, 3);
+    // At this point, the buffer of y1 is longer than than the actual byte
+    // length of y1, because of the way y1 is constructed. The same is true for
+    // y2.
+    expect(y1.buffer.byteLength).toEqual(6 * 4);
+    expect(y2.buffer.byteLength).toEqual(6 * 4);
+
+    const yConcatenated = concatenateTypedArrays([y1, y2]);
+
+    expect(new Float32Array(yConcatenated, 0, 3)).toEqual(x1);
+    expect(new Float32Array(yConcatenated, 3 * 4, 3)).toEqual(x2);
+  });
+
+  it('Concatenate Int32Array from SubArrays', () => {
+    const x1 = new Int32Array([11, 22, 33]);
+    const x2 = new Int32Array([-11, -22, -33]);
+    const xConcatenated = concatenateTypedArrays([x1, x2]);
+    const y1 = new Int32Array(xConcatenated, 0, 3);
+    const y2 = new Int32Array(xConcatenated, 3 * 4, 3);
+    // At this point, the buffer of y1 is longer than than the actual byte
+    // length of y1, because of the way y1 is constructed. The same is true for
+    // y2.
+    expect(y1.buffer.byteLength).toEqual(6 * 4);
+    expect(y2.buffer.byteLength).toEqual(6 * 4);
+
+    const yConcatenated = concatenateTypedArrays([y1, y2]);
+
+    expect(new Int32Array(yConcatenated, 0, 3)).toEqual(x1);
+    expect(new Int32Array(yConcatenated, 3 * 4, 3)).toEqual(x2);
+  });
+
+  it('Concatenate Uint8Array from SubArrays', () => {
+    const x1 = new Uint8Array([11, 22, 33]);
+    const x2 = new Uint8Array([44, 55, 66]);
+    const xConcatenated = concatenateTypedArrays([x1, x2]);
+    const y1 = new Uint8Array(xConcatenated, 0, 3);
+    const y2 = new Uint8Array(xConcatenated, 3, 3);
+    // At this point, the buffer of y1 is longer than than the actual byte
+    // length of y1, because of the way y1 is constructed. The same is true for
+    // y2.
+    expect(y1.buffer.byteLength).toEqual(6);
+    expect(y2.buffer.byteLength).toEqual(6);
+
+    const yConcatenated = concatenateTypedArrays([y1, y2]);
+
+    expect(new Uint8Array(yConcatenated, 0, 3)).toEqual(x1);
+    expect(new Uint8Array(yConcatenated, 3, 3)).toEqual(x2);
+  });
+
+  it('Concatenate mixed TypedArrays from SubArrays', () => {
+    const x1 = new Uint8Array([11, 22, 33, 44]);
+    const x2 = new Int32Array([-44, -55, -66]);
+    const x3 = new Float32Array([1.1, 2.2, 3.3]);
+    const xConcatenated = concatenateTypedArrays([x1, x2, x3]);
+    const y1 = new Uint8Array(xConcatenated, 0, 4);
+    const y2 = new Int32Array(xConcatenated, 4, 3);
+    const y3 = new Float32Array(xConcatenated, 4 + 3 * 4, 3);
+    // At this point, the buffer of y1 is longer than than the actual byte
+    // length of y1, because of the way y1 is constructed. The same is true for
+    // y2 and y3.
+    expect(y1.buffer.byteLength).toEqual(4 + 3 * 4 + 3 * 4);
+    expect(y2.buffer.byteLength).toEqual(4 + 3 * 4 + 3 * 4);
+    expect(y3.buffer.byteLength).toEqual(4 + 3 * 4 + 3 * 4);
+
+    const yConcatenated = concatenateTypedArrays([y1, y2, y3]);
+
+    expect(new Uint8Array(yConcatenated, 0, 4)).toEqual(x1);
+    expect(new Int32Array(yConcatenated, 4, 3)).toEqual(x2);
+    expect(new Float32Array(yConcatenated, 4 + 3 * 4, 3)).toEqual(x3);
+  });
+
   it('null and undefined inputs', () => {
     expect(() => concatenateTypedArrays(null)).toThrow();
     expect(() => concatenateTypedArrays(undefined)).toThrow();

--- a/src/io/io_utils_test.ts
+++ b/src/io/io_utils_test.ts
@@ -95,7 +95,7 @@ describe('concatenateTypedArrays', () => {
     expect(y2.buffer.byteLength).toEqual(6 * 4);
 
     const yConcatenated = concatenateTypedArrays([y1, y2]);
-
+    expect(yConcatenated.byteLength).toEqual(6 * 4);
     expect(new Float32Array(yConcatenated, 0, 3)).toEqual(x1);
     expect(new Float32Array(yConcatenated, 3 * 4, 3)).toEqual(x2);
   });
@@ -113,7 +113,7 @@ describe('concatenateTypedArrays', () => {
     expect(y2.buffer.byteLength).toEqual(6 * 4);
 
     const yConcatenated = concatenateTypedArrays([y1, y2]);
-
+    expect(yConcatenated.byteLength).toEqual(6 * 4);
     expect(new Int32Array(yConcatenated, 0, 3)).toEqual(x1);
     expect(new Int32Array(yConcatenated, 3 * 4, 3)).toEqual(x2);
   });
@@ -131,7 +131,7 @@ describe('concatenateTypedArrays', () => {
     expect(y2.buffer.byteLength).toEqual(6);
 
     const yConcatenated = concatenateTypedArrays([y1, y2]);
-
+    expect(yConcatenated.byteLength).toEqual(6);
     expect(new Uint8Array(yConcatenated, 0, 3)).toEqual(x1);
     expect(new Uint8Array(yConcatenated, 3, 3)).toEqual(x2);
   });
@@ -152,7 +152,7 @@ describe('concatenateTypedArrays', () => {
     expect(y3.buffer.byteLength).toEqual(4 + 3 * 4 + 3 * 4);
 
     const yConcatenated = concatenateTypedArrays([y1, y2, y3]);
-
+    expect(yConcatenated.byteLength).toEqual(4 + 3 * 4 + 3 * 4);
     expect(new Uint8Array(yConcatenated, 0, 4)).toEqual(x1);
     expect(new Int32Array(yConcatenated, 4, 3)).toEqual(x2);
     expect(new Float32Array(yConcatenated, 4 + 3 * 4, 3)).toEqual(x3);


### PR DESCRIPTION
Previously, it was incorrectly assumed that the `buffer` of a
`TypedArray` has the same `byteLength` as the `TypedArray` itself.
The two can actually be different if the `TypedArray` is created
from an offset and a length from an `ArrayBuffer`, e.g.,
`const x = new Float32Array(myBuffer, 32, 4)`.
This actually happens during the desrialization of a `tf.Model`.

This PR fixes it by checking whether the `byteLength` and
`buffer.byteLength` of a `TypedArray` are equal, and if not, creating
a new `TypedArray` with the buffer that matches the actual `byteLength`.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1181)
<!-- Reviewable:end -->
