### PR TITLE
Allow `tf.loadModel(url)` in node.js if fetch exists

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -21,7 +21,6 @@
  * Uses [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
  */
 
-import {ENV} from '../environment';
 import {assert} from '../util';
 
 // tslint:disable:max-line-length
@@ -40,9 +39,10 @@ export class BrowserHTTPRequest implements IOHandler {
   static readonly URL_SCHEMES = ['http://', 'https://'];
 
   constructor(path: string, requestInit?: RequestInit) {
-    if (!ENV.get('IS_BROWSER')) {
+    if (typeof fetch === 'undefined') {
       throw new Error(
-          'browserHTTPRequest is not supported outside the web browser.');
+          // tslint:disable-next-line:max-line-length
+          'browserHTTPRequest is not supported outside the web browser without a fetch polyfill.');
     }
 
     assert(
@@ -157,9 +157,9 @@ export class BrowserHTTPRequest implements IOHandler {
 }
 
 export const httpRequestRouter: IORouter = (url: string) => {
-  if (!ENV.get('IS_BROWSER')) {
-    // browserHTTPRequest uses `fetch`, which differs from HTTP requests in
-    // node.js, which use `node-fetch`.
+  if (typeof fetch === 'undefined') {
+    // browserHTTPRequest uses `fetch`, if one wants to use it in node.js
+    // they have to setup a global fetch polyfill.
     return null;
   } else {
     for (const scheme of BrowserHTTPRequest.URL_SCHEMES) {

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -21,7 +21,8 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {BROWSER_ENVS, CHROME_ENVS} from '../test_util';
+import {BROWSER_ENVS, CHROME_ENVS, NODE_ENVS} from '../test_util';
+
 import {BrowserHTTPRequest, httpRequestRouter} from './browser_http';
 
 // Test data.
@@ -57,6 +58,95 @@ const modelTopology1: {} = {
   }],
   'backend': 'tensorflow'
 };
+
+describeWithFlags('browserHTTPRequest-load', NODE_ENVS, () => {
+  let requestInits: RequestInit[];
+
+  // simulate a fetch polyfill, this needs to be non-null for spyOn to work
+  beforeEach(() => {
+    (global as any).fetch = () => {};
+    requestInits = [];
+  });
+
+  afterAll(() => {
+    delete (global as any).fetch;
+  });
+  type TypedArrays = Float32Array|Int32Array|Uint8Array|Uint16Array;
+
+  const fakeResponse = (body: string|TypedArrays|ArrayBuffer) => ({
+    json() {
+      return Promise.resolve(JSON.parse(body as string));
+    },
+    arrayBuffer() {
+      const buf: ArrayBuffer = (body as TypedArrays).buffer ?
+          (body as TypedArrays).buffer :
+          body as ArrayBuffer;
+      return Promise.resolve(buf);
+    }
+  });
+
+  const setupFakeWeightFiles = (fileBufferMap: {
+    [filename: string]: string|Float32Array|Int32Array|ArrayBuffer|Uint8Array|
+    Uint16Array
+  }) => {
+    // tslint:disable-next-line:no-any
+    spyOn(global as any, 'fetch')
+        .and.callFake((path: string, init: RequestInit) => {
+          requestInits.push(init);
+          return fakeResponse(fileBufferMap[path]);
+        });
+  };
+
+  it('1 group, 2 weights, 1 path', done => {
+    const weightManifest1: tf.io.WeightsManifestConfig = [{
+      paths: ['weightfile0'],
+      weights: [
+        {
+          name: 'dense/kernel',
+          shape: [3, 1],
+          dtype: 'float32',
+        },
+        {
+          name: 'dense/bias',
+          shape: [2],
+          dtype: 'float32',
+        }
+      ]
+    }];
+    const floatData = new Float32Array([1, 3, 3, 7, 4]);
+    setupFakeWeightFiles({
+      './model.json': JSON.stringify(
+          {modelTopology: modelTopology1, weightsManifest: weightManifest1}),
+      './weightfile0': floatData,
+    });
+
+    const handler = tf.io.browserHTTPRequest('./model.json');
+    handler.load()
+        .then(modelArtifacts => {
+          expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
+          expect(modelArtifacts.weightSpecs)
+              .toEqual(weightManifest1[0].weights);
+          expect(new Float32Array(modelArtifacts.weightData))
+              .toEqual(floatData);
+          expect(requestInits).toEqual([{}, {}]);
+          done();
+        })
+        .catch(err => done.fail(err.stack));
+  });
+
+  it('throw exception if no fetch polyfill', () => {
+    // tslint:disable-next-line:no-any
+    delete (global as any).fetch;
+    try {
+      void tf.io.browserHTTPRequest('./model.json');
+    } catch (err) {
+      expect(err.message)
+          .toMatch(
+              // tslint:disable-next-line:max-line-length
+              /not supported outside the web browser without a fetch polyfill/);
+    }
+  });
+});
 
 // Turned off for other browsers due to:
 // https://github.com/tensorflow/tfjs/issues/426

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -59,7 +59,7 @@ const modelTopology1: {} = {
   'backend': 'tensorflow'
 };
 
-describeWithFlags('browserHTTPRequest-load', NODE_ENVS, () => {
+describeWithFlags('browserHTTPRequest-load fetch-polyfill', NODE_ENVS, () => {
   let requestInits: RequestInit[];
 
   // simulate a fetch polyfill, this needs to be non-null for spyOn to work
@@ -140,11 +140,10 @@ describeWithFlags('browserHTTPRequest-load', NODE_ENVS, () => {
     // tslint:disable-next-line:no-any
     delete (global as any).fetch;
     try {
-      void tf.io.browserHTTPRequest('./model.json');
+      tf.io.browserHTTPRequest('./model.json');
     } catch (err) {
       expect(err.message)
           .toMatch(
-              // tslint:disable-next-line:max-line-length
               /not supported outside the web browser without a fetch polyfill/);
     }
   });

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -64,11 +64,13 @@ describeWithFlags('browserHTTPRequest-load', NODE_ENVS, () => {
 
   // simulate a fetch polyfill, this needs to be non-null for spyOn to work
   beforeEach(() => {
+    // tslint:disable-next-line:no-any
     (global as any).fetch = () => {};
     requestInits = [];
   });
 
   afterAll(() => {
+    // tslint:disable-next-line:no-any
     delete (global as any).fetch;
   });
   type TypedArrays = Float32Array|Int32Array|Uint8Array|Uint16Array;


### PR DESCRIPTION
#### Description
Check for `fetch` instead of checking for `ENV.get('IS_BROWSER')`. This lets people use `tf.loadModel('http://....')` if they import a fetch polyfill, e.g:

```ts
import fetch from 'node-fetch'
global.fetch = fetch
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1184)
<!-- Reviewable:end -->
