### PR TITLE
Move webgl typings to dependencies instead of devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@types/seedrandom": "~2.4.27",
     "@types/webgl2": "~0.0.4",
-    "@types/webgl-ext": "0.0.29",
+    "@types/webgl-ext": "~0.0.29",
     "seedrandom": "~2.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@types/jasmine": "~2.5.53",
     "@types/node": "~9.6.0",
     "@types/seedrandom": "~2.4.27",
-    "@types/webgl2": "~0.0.4",
-    "@types/webgl-ext": "0.0.29",
     "clang-format": "~1.2.2",
     "jasmine": "~3.1.0",
     "jasmine-core": "~3.1.0",
@@ -55,6 +53,8 @@
     "test-all": "./scripts/test-all.sh"
   },
   "dependencies": {
+    "@types/webgl2": "~0.0.4",
+    "@types/webgl-ext": "0.0.29",
     "seedrandom": "~2.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@types/jasmine": "~2.5.53",
     "@types/node": "~9.6.0",
-    "@types/seedrandom": "~2.4.27",
     "clang-format": "~1.2.2",
     "jasmine": "~3.1.0",
     "jasmine-core": "~3.1.0",
@@ -53,6 +52,7 @@
     "test-all": "./scripts/test-all.sh"
   },
   "dependencies": {
+    "@types/seedrandom": "~2.4.27",
     "@types/webgl2": "~0.0.4",
     "@types/webgl-ext": "0.0.29",
     "seedrandom": "~2.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@
   version "2.4.27"
   resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
 
-"@types/webgl-ext@0.0.29":
+"@types/webgl-ext@~0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/webgl-ext/-/webgl-ext-0.0.29.tgz#4d479baf1124795f53d54bdc85b386e0f194d90a"
 


### PR DESCRIPTION
Currently this is breaking any typescript users (as they wont be able to find these types).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1185)
<!-- Reviewable:end -->
