### PR TITLE
Unbind the pixel pack buffer after copying the texture into the buffer.

### DIFF
--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -311,6 +311,9 @@ export function maybeCreateBufferFromOutputTexture(
     webgl_util.callAndCheck(
         gl, () => gl2.readPixels(0, 0, columns, rows, gl.RGBA, gl.FLOAT, 0));
 
+    webgl_util.callAndCheck(
+        gl, () => gl.bindBuffer(gl2.PIXEL_PACK_BUFFER, null));
+
     bufferOrTexture = buffer;
   }
 

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -1168,6 +1168,19 @@ describeWithFlags('tensor grad', ALL_ENVS, () => {
 });
 
 describeWithFlags('tensor.data', ALL_ENVS, () => {
+  it('interleaving .data() and .dataSync()', async () => {
+    const a = tf.tensor1d([1, 2, 3]);
+    const b = tf.tensor1d([4, 5, 6]);
+
+    const ra = a.square().data();
+    const rb = b.square().dataSync();
+
+    expectArraysClose(a, [1, 2, 3]);
+    expectArraysClose(b, [4, 5, 6]);
+    expectArraysClose(Array.from(rb), [16, 25, 36]);
+    expectArraysClose(Array.from(await ra), [1, 4, 9]);
+  });
+
   it('.data() postpones disposal of tensor', done => {
     expect(tf.memory().numTensors).toBe(0);
     tf.tidy(() => {


### PR DESCRIPTION
Currently, if you interleave .data() and .dataSync() you get the following error:
```
WebGL: INVALID_OPERATION: readPixels: PIXEL_PACK buffer should not be bound
```

This is because the pixel pack buffer is bound at the same time the texture is bound to the framebuffer. WebGL does not like this.

To verify this fixes the layers tests, I used yalc to make sure the tests there pass. I also made sure the unit test I wrote failed before I made the fix.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1188)
<!-- Reviewable:end -->
