### PR TITLE
Fix benchmarks on browserstack

### DIFF
--- a/integration_tests/benchmarks/karma_test.ts
+++ b/integration_tests/benchmarks/karma_test.ts
@@ -14,12 +14,21 @@
  * limitations under the License.
  * =============================================================================
  */
+
 import {MatmulGPUBenchmark} from './matmul_benchmarks';
 
 const BENCHMARK_RUNS = 100;
 
+function nextTick(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
 describe('benchmarks', () => {
-  it('test', async () => {
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
+  });
+
+  it('test', async done => {
     const matmulGPU = new MatmulGPUBenchmark();
 
     const sizes = [1, 100, 400, 1000];
@@ -32,10 +41,12 @@ describe('benchmarks', () => {
       for (let j = 0; j < BENCHMARK_RUNS; j++) {
         const result = await matmulGPU.run(size);
         total += result / BENCHMARK_RUNS;
+        await nextTick();
       }
 
       console.log(`[${size}]: ${total}`);
     }
     console.log('-----------------------------------------');
+    done();
   });
 });

--- a/integration_tests/benchmarks/package.json
+++ b/integration_tests/benchmarks/package.json
@@ -77,7 +77,7 @@
     "tsc": "^1.20150623.0",
     "tsify": "^3.0.4",
     "tslint": "^5.10.0",
-    "typescript": "2.7.2",
+    "typescript": "2.9.2",
     "http-server": "^0.11.1"
   },
   "scripts": {

--- a/integration_tests/benchmarks/yarn.lock
+++ b/integration_tests/benchmarks/yarn.lock
@@ -190,8 +190,9 @@
   version "2.0.2"
   resolved "https://codeload.github.com/webcomponents/webcomponentsjs/tar.gz/aca216f6c7870f3ac9777bde7ebb9bed692b46c5"
 
-"@tensorflow/tfjs-core@file:../..":
+"@tensorflow/tfjs-core@0.12.4":
   version "0.12.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.4.tgz#39e6239617856fce82b41936f711f78190aa71bd"
   dependencies:
     seedrandom "~2.4.3"
 
@@ -4567,9 +4568,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 typical@^2.6.0:
   version "2.6.1"


### PR DESCRIPTION
Give some breathing room between benchmarks so the browser can send data back to karma server and overwrite the default jasmine timeout which is 10 sec.

Tested on browser stack to verify it works:
https://automate.browserstack.com/builds/0ad3ba06f034bf8fb4fca6f854ac91277decd3d9/sessions/172e06c823d3a4351dec87a6c5fd9ae8e9a93f7e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1194)
<!-- Reviewable:end -->
