### PR TITLE
Support stridedSlice in Tensor

### DIFF
--- a/src/ops/strided_slice_test.ts
+++ b/src/ops/strided_slice_test.ts
@@ -27,7 +27,7 @@ describeWithFlags('stridedSlice', ALL_ENVS, () => {
     expectArraysClose(output, [0, 2]);
   });
 
-  it('stridedSlice with 1d tensor should be executed by tensor directly', () => {
+  it('stridedSlice with 1d tensor should be used by tensor directly', () => {
     const t = tf.tensor1d([0, 1, 2, 3]);
     const output = t.stridedSlice([0], [3], [2]);
     expect(output.shape).toEqual([2]);
@@ -150,7 +150,7 @@ describeWithFlags('stridedSlice', ALL_ENVS, () => {
     expectArraysClose(output, [4, 5]);
   });
 
-  it('stridedSlice with 2d tensor should be executed by tensor directly', () => {
+  it('stridedSlice with 2d tensor should be used by tensor directly', () => {
     const t = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const output = t.stridedSlice([1, 0], [2, 2], [1, 1]);
     expect(output.shape).toEqual([1, 2]);

--- a/src/ops/strided_slice_test.ts
+++ b/src/ops/strided_slice_test.ts
@@ -27,6 +27,13 @@ describeWithFlags('stridedSlice', ALL_ENVS, () => {
     expectArraysClose(output, [0, 2]);
   });
 
+  it('stridedSlice with 1d tensor should be executed by tensor directly', () => {
+    const t = tf.tensor1d([0, 1, 2, 3]);
+    const output = t.stridedSlice([0], [3], [2]);
+    expect(output.shape).toEqual([2]);
+    expectArraysClose(output, [0, 2]);
+  });
+
   it('stridedSlice should suport 1d tensor empty result', () => {
     const tensor = tf.tensor1d([0, 1, 2, 3]);
     const output = tf.stridedSlice(tensor, [10], [3], [2]);
@@ -139,6 +146,13 @@ describeWithFlags('stridedSlice', ALL_ENVS, () => {
   it('stridedSlice should suport 2d tensor', () => {
     const tensor = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const output = tf.stridedSlice(tensor, [1, 0], [2, 2], [1, 1]);
+    expect(output.shape).toEqual([1, 2]);
+    expectArraysClose(output, [4, 5]);
+  });
+
+  it('stridedSlice with 2d tensor should be executed by tensor directly', () => {
+    const t = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const output = t.stridedSlice([1, 0], [2, 2], [1, 1]);
     expect(output.shape).toEqual([1, 2]);
     expectArraysClose(output, [4, 5]);
   });

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -306,6 +306,8 @@ export interface OpHandler {
       x: T, blockShape: number[], paddings: number[][]): T;
   topk<T extends Tensor>(x: T, k: number, sorted: boolean)
     : {values: T, indices: T};
+  stridedSlice<T extends Tensor>(x: T, begin: number[], end: number[],
+    strides: number[], beginMask: number, endMask: number): T;
 }
 
 // For tracking tensor creation and disposal.
@@ -1173,6 +1175,14 @@ export class Tensor<R extends Rank = Rank> {
     this: T, k = 1, sorted = true): {values: T, indices: T} {
       this.throwIfDisposed();
       return opHandler.topk(this, k, sorted);
+  }
+
+  stridedSlice<T extends Tensor>(
+    this: T, begin: number[], end: number[], strides: number[],
+    beginMask = 0 , endMask = 0) {
+      this.throwIfDisposed();
+      return opHandler.stridedSlice(this, begin, end, strides,
+        beginMask, endMask);
   }
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {


### PR DESCRIPTION
#### Description
FEATURE

Support `stridedSlice` op from tensor object directly because [sample code](https://github.com/tensorflow/tfjs-core/blob/80495941d89e72a14762f382498ccd6e2a6b0e39/src/ops/strided_slice.ts#L24-L39) does not work otherwise.


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1198)
<!-- Reviewable:end -->
