### PR TITLE
add support for binary model loading through browser http handler

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -191,12 +191,11 @@ export class BrowserHTTPRequest implements IOHandler {
 
   private async loadWeightData(weightsManifest: WeightsManifestConfig):
       Promise<ArrayBuffer> {
-    let pathPrefix =
-        (this.path as string).substring(0, this.path.lastIndexOf('/'));
+    const weightPath = Array.isArray(this.path) ? this.path[1] : this.path;
+    let pathPrefix = weightPath.substring(0, weightPath.lastIndexOf('/'));
     if (!pathPrefix.endsWith('/')) {
       pathPrefix = pathPrefix + '/';
     }
-
     const fetchURLs: string[] = [];
     weightsManifest.forEach(weightsGroup => {
       weightsGroup.paths.forEach(path => {


### PR DESCRIPTION
#### Description
this would allow frozen model to be load through http io handler, which checks fetch polyfill.


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1207)
<!-- Reviewable:end -->
