### PR TITLE
Add gradients to `oneHot` and `argMax`

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -293,9 +293,12 @@ function oneHot_(
   if (depth < 2) {
     throw new Error(`Error in oneHot: depth must be >=2, but it is ${depth}`);
   }
+  const grad = (dy: Tensor2D) => {
+    return {$indices: () => zerosLike($indices)};
+  };
   return ENV.engine.runKernel(
       backend => backend.oneHot($indices, depth, onValue, offValue),
-      {$indices});
+      {$indices}, grad);
 }
 
 /**

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2361,6 +2361,16 @@ describeWithFlags('oneHot', ALL_ENVS, () => {
     expect(res.shape).toEqual([2, 2]);
     expectArraysClose(res, [1, 0, 0, 1]);
   });
+
+  it('has gradient', () => {
+    const a = tf.tensor1d([0, 1, 2], 'int32');
+    const dy = tf.ones([3, 3], 'float32') as tf.Tensor2D;
+    const da = tf.grad((x: tf.Tensor1D) => tf.oneHot(x, 3))(a, dy);
+
+    expect(da.dtype).toBe('int32');
+    expect(da.shape).toEqual([3]);
+    expectArraysClose(da, [0, 0, 0]);
+  });
 });
 
 describeWithFlags('linspace', ALL_ENVS, () => {

--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -23,7 +23,7 @@ import {TensorLike} from '../types';
 import * as util from '../util';
 import * as axis_util from './axis_util';
 import {op} from './operation';
-import {ones, scalar} from './tensor_ops';
+import {ones, scalar, zerosLike} from './tensor_ops';
 
 /**
  * Computes the log(sum(exp(elements across the reduction dimensions)).
@@ -374,8 +374,11 @@ function argMax_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     $x = $x.transpose(permutedAxes);
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
-  return ENV.engine.runKernel(backend => backend.argMax($x, axes[0]), {$x}) as
-      T;
+  const grad = (dy: T) => {
+    return {$x: () => zerosLike($x)};
+  };
+  return ENV.engine.runKernel(backend => backend.argMax($x, axes[0]), {$x},
+    grad) as T;
 }
 
 /**

--- a/src/ops/reduction_ops_test.ts
+++ b/src/ops/reduction_ops_test.ts
@@ -240,6 +240,16 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
     expect(result.dtype).toBe('int32');
     expect(result.get()).toBe(2);
   });
+
+  it('has gradient', () => {
+    const a = tf.tensor2d([3, 2, 5, 100, -7, 2], [2, 3]);
+    const dy = tf.ones([3], 'float32') as tf.Tensor1D;
+    const da = tf.grad((x: tf.Tensor2D) => tf.argMax(x))(a, dy);
+
+    expect(da.dtype).toBe('float32');
+    expect(da.shape).toEqual([2, 3]);
+    expectArraysClose(da, [0, 0, 0, 0, 0, 0]);
+  });
 });
 
 describeWithFlags('Reduction: argmin', ALL_ENVS, () => {


### PR DESCRIPTION
#### Description

Add gradients to `oneHot` and `argMax`. Both are not differentiable, and thus their gradients must be zero.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
