### PR TITLE
Makes zerosLike and onesLike operation chainable

### DIFF
--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -258,6 +258,14 @@ describeWithFlags('zerosLike', ALL_ENVS, () => {
     expectArraysClose(b, [0, 0, 0]);
   });
 
+  it('chainable 1D default dtype', () => {
+    const a = tf.tensor1d([1, 2, 3]);
+    const b = a.zerosLike();
+    expect(b.dtype).toBe('float32');
+    expect(b.shape).toEqual([3]);
+    expectArraysClose(b, [0, 0, 0]);
+  });
+
   it('1D float32 dtype', () => {
     const a = tf.tensor1d([1, 2, 3], 'float32');
     const b = tf.zerosLike(a);
@@ -466,6 +474,14 @@ describeWithFlags('onesLike', ALL_ENVS, () => {
   it('1D default dtype', () => {
     const a = tf.tensor1d([1, 2, 3]);
     const b = tf.onesLike(a);
+    expect(b.dtype).toBe('float32');
+    expect(b.shape).toEqual([3]);
+    expectArraysClose(b, [1, 1, 1]);
+  });
+
+  it('chainable 1D default dtype', () => {
+    const a = tf.tensor1d([1, 2, 3]);
+    const b = a.onesLike();
     expect(b.dtype).toBe('float32');
     expect(b.shape).toEqual([3]);
     expectArraysClose(b, [1, 1, 1]);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -243,6 +243,8 @@ export interface OpHandler {
   sigmoid<T extends Tensor>(x: T): T;
   logSigmoid<T extends Tensor>(x: T): T;
   softplus<T extends Tensor>(x: T): T;
+  zerosLike<T extends Tensor>(x: T): T;
+  onesLike<T extends Tensor>(x: T): T;
   sin<T extends Tensor>(x: T): T;
   cos<T extends Tensor>(x: T): T;
   tan<T extends Tensor>(x: T): T;
@@ -1011,6 +1013,14 @@ export class Tensor<R extends Rank = Rank> {
   softplus<T extends Tensor>(this: T): T {
     this.throwIfDisposed();
     return opHandler.softplus(this);
+  }
+  zerosLike<T extends Tensor>(this: T): T {
+    this.throwIfDisposed();
+    return opHandler.zerosLike(this);
+  }
+  onesLike<T extends Tensor>(this: T): T {
+    this.throwIfDisposed();
+    return opHandler.onesLike(this);
   }
   sin<T extends Tensor>(this: T): T {
     this.throwIfDisposed();


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
This PR makes `tf.zerosLike` and `tf.onesLike` chainable.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1229)
<!-- Reviewable:end -->
