### PR TITLE
add missing tf. in topk example

### DIFF
--- a/src/ops/topk.ts
+++ b/src/ops/topk.ts
@@ -33,7 +33,7 @@ import {op} from './operation';
  * If two elements are equal, the lower-index element appears first.
  *
  * ```js
- * const a = tensor2d([[1, 5], [4, 3]]);
+ * const a = tf.tensor2d([[1, 5], [4, 3]]);
  * const {values, indices} = tf.topk(a);
  * values.print();
  * indices.print();


### PR DESCRIPTION
#### Description

DOC
`const a = tensor2d([[1, 5], [4, 3]]);` -> `const a = tf.tensor2d([[1, 5], [4, 3]]);`

So the tf.topk example code works in the documentation

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1232)
<!-- Reviewable:end -->
