### PR TITLE
allow backend engine to be cached by backend name

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -403,6 +403,10 @@ export class Environment {
     }
     this.registry[name].backend.dispose();
     delete this.registry[name];
+
+    if (name in this.engines) {
+      delete this.engines[name];
+    }
   }
 
   get engine(): Engine {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,6 +31,7 @@ const TEST_EPSILON_FLOAT32 = 1e-3;
 
 export class Environment {
   private features: Features = {};
+  private engines: {[id: string]: Engine} = {};
   private globalEngine: Engine;
   private registry:
       {[id: string]: {backend: KernelBackend, priority: number}} = {};
@@ -341,8 +342,14 @@ export class Environment {
 
   private initBackend(backendName?: string, safeMode = false) {
     this.backendName = backendName;
-    const backend = this.findBackend(backendName);
-    this.globalEngine = new Engine(backend, safeMode, () => this.get('DEBUG'));
+    if (this.engines[backendName]) {
+      this.globalEngine = this.engines[backendName];
+    } else {
+      const backend = this.findBackend(backendName);
+      this.globalEngine =
+          new Engine(backend, safeMode, () => this.get('DEBUG'));
+      this.engines[backendName] = this.globalEngine;
+    }
   }
 
   get backend(): KernelBackend {

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -288,8 +288,10 @@ describe('Backend', () => {
     Environment.setBackend('custom');
     const engine3 = ENV.engine;
 
-    expect(engine1).not.toEqual(engine2);
-    expect(engine1).toEqual(engine3);
+    expect(engine1).not.toBe(engine2);
+    expect(engine1).toBe(engine3);
+    ENV.removeBackend('custom');
+    ENV.removeBackend('custom2');
   });
 });
 

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -274,6 +274,23 @@ describe('Backend', () => {
     expect(ENV.findBackend('custom')).toEqual(backend);
     ENV.removeBackend('custom');
   });
+
+  it('should reuse backend engine if has been instantiated', () => {
+    const backend = new MathBackendCPU();
+    ENV.registerBackend('custom', () => backend);
+    const backend2 = new MathBackendCPU();
+    ENV.registerBackend('custom2', () => backend2);
+
+    Environment.setBackend('custom');
+    const engine1 = ENV.engine;
+    Environment.setBackend('custom2');
+    const engine2 = ENV.engine;
+    Environment.setBackend('custom');
+    const engine3 = ENV.engine;
+
+    expect(engine1).not.toEqual(engine2);
+    expect(engine1).toEqual(engine3);
+  });
 });
 
 describe('environment_util.getQueryParams', () => {


### PR DESCRIPTION


#### Description
This would allow multiple backends used in the same session, and it will prevent
tensor ref count being cleared when switching between backends.


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1233)
<!-- Reviewable:end -->
