### PR TITLE
Fix ENV.get('EPSILON') and add a unit test

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -315,15 +315,11 @@ export class Environment {
       return isWebGLFenceEnabled(
           this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
     } else if (feature === 'TEST_EPSILON') {
-      if (this.backend.floatPrecision() === 32) {
-        return TEST_EPSILON_FLOAT32;
-      }
-      return TEST_EPSILON_FLOAT16;
+      return this.backend.floatPrecision() === 32 ? TEST_EPSILON_FLOAT32 :
+                                                    TEST_EPSILON_FLOAT16;
     } else if (feature === 'EPSILON') {
-      if (this.backend.floatPrecision() === 32) {
-        return EPSILON_FLOAT32;
-      }
-      return EPSILON_FLOAT16;
+      return this.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 :
+                                                    EPSILON_FLOAT16;
     }
     throw new Error(`Unknown feature ${feature}.`);
   }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -320,7 +320,7 @@ export class Environment {
       }
       return TEST_EPSILON_FLOAT16;
     } else if (feature === 'EPSILON') {
-      if (this.backend.floatPrecision() === 16) {
+      if (this.backend.floatPrecision() === 32) {
         return EPSILON_FLOAT32;
       }
       return EPSILON_FLOAT16;

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -282,3 +282,10 @@ describe('environment_util.getQueryParams', () => {
         .toEqual({'a': '1', 'b': 'hi', 'f': 'animal'});
   });
 });
+
+describeWithFlags('epsilon', {}, () => {
+  it('Epsilon is a function of float precision', () => {
+    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-8 : 1e-4;
+    expect(ENV.get('EPSILON')).toBe(epsilonValue);
+  });
+});


### PR DESCRIPTION
Epsilon was 1e-4 for 32bit, and 1e-8 for 16bit, which is the opposite of the correct value.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1239)
<!-- Reviewable:end -->
