### PR TITLE
Change epsilon for 32 bit float to 1e-7 and add couple more unit tests

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -26,7 +26,7 @@ import {getTensorsInContainer} from './tensor_util';
 const EPSILON_FLOAT16 = 1e-4;
 const TEST_EPSILON_FLOAT16 = 1e-1;
 
-const EPSILON_FLOAT32 = 1e-8;
+const EPSILON_FLOAT32 = 1e-7;
 const TEST_EPSILON_FLOAT32 = 1e-3;
 
 export class Environment {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -23,7 +23,7 @@ import {setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
-const EPSILON_FLOAT16 = 1e-4;
+const EPSILON_FLOAT16 = 1e-3;
 const TEST_EPSILON_FLOAT16 = 1e-1;
 
 const EPSILON_FLOAT32 = 1e-7;

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -18,6 +18,7 @@
 import * as device_util from './device_util';
 import {ENV, Environment} from './environment';
 import {Features, getQueryParams} from './environment_util';
+import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
 import {KernelBackend} from './kernels/backend';
 import {MathBackendCPU} from './kernels/backend_cpu';
@@ -287,5 +288,9 @@ describeWithFlags('epsilon', {}, () => {
   it('Epsilon is a function of float precision', () => {
     const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-8 : 1e-4;
     expect(ENV.get('EPSILON')).toBe(epsilonValue);
+  });
+
+  it('abs(epsilon) > 0', () => {
+    expect(tf.abs(ENV.get('EPSILON')).get()).toBeGreaterThan(0);
   });
 });

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -286,7 +286,7 @@ describe('environment_util.getQueryParams', () => {
 
 describeWithFlags('epsilon', {}, () => {
   it('Epsilon is a function of float precision', () => {
-    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-7 : 1e-4;
+    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-7 : 1e-3;
     expect(ENV.get('EPSILON')).toBe(epsilonValue);
   });
 

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -286,7 +286,7 @@ describe('environment_util.getQueryParams', () => {
 
 describeWithFlags('epsilon', {}, () => {
   it('Epsilon is a function of float precision', () => {
-    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-8 : 1e-4;
+    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-7 : 1e-4;
     expect(ENV.get('EPSILON')).toBe(epsilonValue);
   });
 

--- a/src/kernels/webgl/clip_gpu.ts
+++ b/src/kernels/webgl/clip_gpu.ts
@@ -24,8 +24,6 @@ export class ClipProgram implements GPGPUProgram {
 
   constructor(aShape: number[], min: number, max: number) {
     this.outputShape = aShape;
-    const minFixed = min.toFixed(20);
-    const maxFixed = max.toFixed(20);
     this.userCode = `
       void main() {
         float value = getAAtOutCoords();
@@ -34,7 +32,7 @@ export class ClipProgram implements GPGPUProgram {
           return;
         }
 
-        setOutput(clamp(value, ${minFixed}, ${maxFixed}));
+        setOutput(clamp(value, float(${min}), float(${max})));
       }
     `;
   }

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2425,6 +2425,15 @@ describeWithFlags('clip', ALL_ENVS, () => {
     const result = tf.clipByValue([3, -1, 0, 100, -7, 2], min, max);
     expectArraysClose(result, [3, -1, 0, 50, -1, 2]);
   });
+
+  it('clip(x, eps, 1-eps) never returns 0 or 1', () => {
+    const min = tf.ENV.get('EPSILON');
+    const max = 1 - min;
+    const res = tf.clipByValue([0, 1], min, max).dataSync();
+    expect(res[0]).toBeGreaterThan(0);
+    expect(res[1]).toBeLessThan(1);
+    console.log(res);
+  });
 });
 
 describeWithFlags('round', ALL_ENVS, () => {

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2432,7 +2432,6 @@ describeWithFlags('clip', ALL_ENVS, () => {
     const res = tf.clipByValue([0, 1], min, max).dataSync();
     expect(res[0]).toBeGreaterThan(0);
     expect(res[1]).toBeLessThan(1);
-    console.log(res);
   });
 });
 


### PR DESCRIPTION
Epsilon for 32 bit floats is changed to 1e-7 so that `tf.clip([0, 1], eps, 1-eps)` returns `[eps, 1-eps]` instead of `[0, 1]`.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1244)
<!-- Reviewable:end -->
