### PR TITLE
Update test commands

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ $ yarn lint
 To run a subset of tests and/or on a specific browser:
 
 ```bash
-$ yarn test -- --browsers=Chrome --grep='multinomial'
+$ yarn test --browsers=Chrome --grep='multinomial'
  
 > ...
 > Chrome 62.0.3202 (Mac OS X 10.12.6): Executed 28 of 1891 (skipped 1863) SUCCESS (6.914 secs / 0.634 secs)
@@ -42,7 +42,7 @@ $ yarn test -- --browsers=Chrome --grep='multinomial'
 To run the tests once and exit the karma process (helpful on Windows):
 
 ```bash
-$ yarn test -- --single-run
+$ yarn test --single-run
 ```
 
 #### Packaging (browser and npm)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ $ yarn lint
 To run a subset of tests and/or on a specific browser:
 
 ```bash
-$ yarn test --browsers=Chrome --grep='multinomial'
+$ yarn test -- --browsers=Chrome --grep='multinomial'
  
 > ...
 > Chrome 62.0.3202 (Mac OS X 10.12.6): Executed 28 of 1891 (skipped 1863) SUCCESS (6.914 secs / 0.634 secs)
@@ -42,7 +42,7 @@ $ yarn test --browsers=Chrome --grep='multinomial'
 To run the tests once and exit the karma process (helpful on Windows):
 
 ```bash
-$ yarn test --single-run
+$ yarn test -- --single-run
 ```
 
 #### Packaging (browser and npm)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/tf-core.esm.js",
   "module": "dist/tf-core.esm.js",
+  "engines": {
+    "yarn": ">= 1.4.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tensorflow/tfjs-core.git"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "jsnext:main": "dist/tf-core.esm.js",
   "module": "dist/tf-core.esm.js",
   "engines": {
-    "yarn": ">= 1.4.0"
+    "yarn": ">= 1.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Description
Currently, running `$ yarn test --browsers=Chrome --grep='multinomial'` don't filters tests.
 
The syntax to use to pass arguments to the package script running with `yarn (run)` has changed.

Because of this, the arguments that are passed to the `yarn test` which is posted in DEVELOPMENT.md are not applied to the `karma start` command.

So I updated the command to match the new syntax.

Please refer to the issue below
https://github.com/yarnpkg/yarn/issues/1667


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1245)
<!-- Reviewable:end -->
