### PR TITLE
Tiny fix for internal build

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -139,8 +139,8 @@ export class BrowserHTTPRequest implements IOHandler {
     const graphPromise = this.loadBinaryTopology();
     const manifestPromise = await fetch(this.path[1], this.requestInit);
 
-    const [modelTopology, weightsManifestResponse] =
-        await Promise.all([graphPromise, manifestPromise]);
+    const results = await Promise.all([graphPromise, manifestPromise]);
+    const [modelTopology, weightsManifestResponse] = results;
 
     const weightsManifest =
         await weightsManifestResponse.json() as WeightsManifestConfig;
@@ -148,7 +148,8 @@ export class BrowserHTTPRequest implements IOHandler {
     let weightSpecs: WeightsManifestEntry[];
     let weightData: ArrayBuffer;
     if (weightsManifest != null) {
-      [weightSpecs, weightData] = await this.loadWeights(weightsManifest);
+      const results = await this.loadWeights(weightsManifest);
+      [weightSpecs, weightData] = results;
     }
 
     return {modelTopology, weightSpecs, weightData};
@@ -173,7 +174,8 @@ export class BrowserHTTPRequest implements IOHandler {
     if (weightsManifest != null) {
       const weightsManifest =
           modelConfig['weightsManifest'] as WeightsManifestConfig;
-      [weightSpecs, weightData] = await this.loadWeights(weightsManifest);
+      const results = await this.loadWeights(weightsManifest);
+      [weightSpecs, weightData] = results;
     }
 
     return {modelTopology, weightSpecs, weightData};

--- a/src/kernels/webgl/lrn_grad_gpu.ts
+++ b/src/kernels/webgl/lrn_grad_gpu.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import {GPGPUProgram} from './gpgpu_math';
 
 export class LRNGradProgram implements GPGPUProgram {


### PR DESCRIPTION
This change makes the internal TS compiler at Google happy.

According to the internal compiler:
`This code cannot be converted from ES6. Undecomposable expression: Please rewrite the yield or await as a separate statement.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1264)
<!-- Reviewable:end -->
