### PR TITLE
Fix bug in gradient of concat when axis is -1

### DIFF
--- a/src/ops/concat_split.ts
+++ b/src/ops/concat_split.ts
@@ -158,6 +158,7 @@ function concat4d_(tensors: Tensor4D[]|TensorLike[], axis: number): Tensor4D {
 function concat_<T extends Tensor>(tensors: T[]|TensorLike[], axis = 0): T {
   assert(tensors.length >= 1, 'Pass at least one tensor to concat');
   let $tensors = convertToTensorArray(tensors, 'tensors', 'concat');
+  axis = parseAxisParam(axis, $tensors[0].shape)[0];
   const outShape = computeOutShape($tensors.map(t => t.shape), axis);
   if (sizeFromShape(outShape) === 0) {
     return tensor([], outShape) as T;
@@ -167,9 +168,9 @@ function concat_<T extends Tensor>(tensors: T[]|TensorLike[], axis = 0): T {
   if ($tensors.length === 1) {
     return $tensors[0];
   }
-  const axes = parseAxisParam(axis, $tensors[0].shape)[0];
+
   const shapes = $tensors.map(t => t.shape);
-  assertParamsConsistent(shapes, axes);
+  assertParamsConsistent(shapes, axis);
   const der = (dy: T) => {
     const sizeSplits = shapes.map(s => s[axis]);
     const derTensors = split(dy, sizeSplits, axis);
@@ -177,7 +178,7 @@ function concat_<T extends Tensor>(tensors: T[]|TensorLike[], axis = 0): T {
   };
   const inputs = $tensors as {};
   return ENV.engine.runKernel(
-      backend => backend.concat($tensors, axes) as T, inputs, der);
+      backend => backend.concat($tensors, axis) as T, inputs, der);
 }
 
 /**

--- a/src/ops/concat_test.ts
+++ b/src/ops/concat_test.ts
@@ -321,6 +321,24 @@ describeWithFlags('concat3d', ALL_ENVS, () => {
     expectArraysClose(dx2, [40, 400, 30, 300, 20, 200, 10, 100]);
   });
 
+  it('gradient concat axis=-1', () => {
+    const x1 = tf.tensor3d([1, 2, 3, 4], [2, 2, 1]);
+    const x2 = tf.tensor3d([5, 55, 6, 66, 7, 77, 8, 88], [2, 2, 2]);
+    const dy = tf.tensor3d(
+        [4, 40, 400, 3, 30, 300, 2, 20, 200, 1, 10, 100], [2, 2, 3]);
+    const axis = -1;
+
+    const grads = tf.grads(
+        (x1: tf.Tensor3D, x2: tf.Tensor3D) => tf.concat3d([x1, x2], axis));
+    const [dx1, dx2] = grads([x1, x2], dy);
+
+    expect(dx1.shape).toEqual(x1.shape);
+    expectArraysClose(dx1, [4, 3, 2, 1]);
+
+    expect(dx2.shape).toEqual(x2.shape);
+    expectArraysClose(dx2, [40, 400, 30, 300, 20, 200, 10, 100]);
+  });
+
   it('accepts a tensor-like object', () => {
     const tensor1 = [[[1, 2, 3]]];  // 1x1x3
     const tensor2 = [[[4, 5, 6]]];  // 1x1x3


### PR DESCRIPTION
The gradient of concat had a bug where the axis passed wasn't normalized to be between 0 and R-1 (e.g. when the user passes a negative axis)

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1267)
<!-- Reviewable:end -->
