### PR TITLE
Fix ArgMinMaxProgram bestIndex initialization

### DIFF
--- a/src/kernels/webgl/argminmax_gpu.ts
+++ b/src/kernels/webgl/argminmax_gpu.ts
@@ -44,7 +44,7 @@ export class ArgMinMaxProgram implements GPGPUProgram {
         int outIdx = coords[1];
         int inOffset = outIdx * ${windowSize};
 
-        int bestIndex = 0;
+        int bestIndex = inOffset;
         float bestValue = getA(batch, inOffset);
 
         for (int i = 0; i < ${windowSize}; i++) {

--- a/src/kernels/webgl/argminmax_gpu.ts
+++ b/src/kernels/webgl/argminmax_gpu.ts
@@ -45,7 +45,7 @@ export class ArgMinMaxProgram implements GPGPUProgram {
         int inOffset = outIdx * ${windowSize};
 
         int bestIndex = inOffset;
-        float bestValue = getA(batch, inOffset);
+        float bestValue = getA(batch, bestIndex);
 
         for (int i = 0; i < ${windowSize}; i++) {
           int inIdx = ${indexSnippet};

--- a/src/ops/reduction_ops_test.ts
+++ b/src/ops/reduction_ops_test.ts
@@ -439,6 +439,18 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
     expect(result.get()).toBe(n - 1);
   });
 
+  it('max index corresponds to start of a non-initial window', () => {
+    const n = reduce_util.PARALLELIZE_THRESHOLD * 2;
+    const windowSize = reduce_util.computeOptimalWindowSize(n);
+    const values = new Float32Array(n);
+    const index = windowSize * 2;
+    values[index] = 1;
+    const a = tf.tensor1d(values);
+    const result = tf.argMax(a);
+    expect(result.dtype).toBe('int32');
+    expect(result.get()).toBe(index);
+  });
+
   it('ignores NaNs', () => {
     const a = tf.tensor1d([0, 3, 5, NaN, 3]);
     const res = tf.argMax(a);
@@ -526,6 +538,18 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
     const result = tf.argMin(a);
     expect(result.dtype).toBe('int32');
     expect(result.get()).toBe(n - 1);
+  });
+
+  it('min index corresponds to start of a non-initial window', () => {
+    const n = reduce_util.PARALLELIZE_THRESHOLD * 2;
+    const windowSize = reduce_util.computeOptimalWindowSize(n);
+    const values = new Float32Array(n);
+    const index = windowSize * 2;
+    values[index] = -1;
+    const a = tf.tensor1d(values);
+    const result = tf.argMin(a);
+    expect(result.dtype).toBe('int32');
+    expect(result.get()).toBe(index);
   });
 
   it('ignores NaNs', () => {


### PR DESCRIPTION


#### Description
Currently, bestIndex is initialized to zero, but should be set to inOffset to match how bestValue is initialized.

This fixes issues when an array is split into multiple windows, and the first value of a non-first window happens to be the largest value.

Fixes https://github.com/tensorflow/tfjs/issues/665

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1271)
<!-- Reviewable:end -->
