### PR TITLE
Specify dtypes of both arguments in multiply

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -617,7 +617,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   multiply(a: Tensor, b: Tensor): Tensor {
-    if (a.dtype === 'complex64') {
+    if (a.dtype === 'complex64' && b.dtype === 'complex64') {
       const aData = this.texData.get(a.dataId);
       const bData = this.texData.get(b.dataId);
 


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->

MISC

As indicated in [the multiply kernel in `backend_cpu`](https://github.com/tensorflow/tfjs-core/blob/master/src/kernels/backend_cpu.ts#L443), we should also specify the dtype of both argument in `backend_gpu.`


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1278)
<!-- Reviewable:end -->
