### PR TITLE
Prevent TypeError of 'arraysEqual()' for null arguments

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -163,6 +163,13 @@ export function isScalarShape(shape: number[]): boolean {
 }
 
 export function arraysEqual(n1: FlatVector, n2: FlatVector) {
+  if (n1 === n2) {
+    return true;
+  }
+  if (n1 == null || n2 == null) {
+    return false;
+  }
+
   if (n1.length !== n2.length) {
     return false;
   }


### PR DESCRIPTION
#### Description
Prevent possible errors in 'arraysEqual()' when arguments are null.
For example, in the src/kernels/webgl/gpgpu_math.ts, 'texShapeB' is null in case of 'input.isUniform' is true:
```
    const texShapeB = input.isUniform ? null : input.texData.texShape;
    if (!util.arraysEqual(texShapeA, texShapeB)) {
```
Then 'arraysEqual()' fails when accessing 'n2.length'.

* So I added some checks prior to length check.
* I found from this. Please see it: https://deepscan.io/dashboard/#view=project&pid=3218&bid=27161&subview=issues&status=%5B%22fixed%22%5D

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1281)
<!-- Reviewable:end -->
