### PR TITLE
Fix lint issue in benchmark tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - '8'
   - '10'
 script:
-  - cd integration_tests/benchmarks && yarn && yarn benchmark-travis && cd ../../
+  - cd integration_tests/benchmarks && yarn && yarn lint && yarn benchmark-travis && cd ../../
   - yarn && yarn build && yarn lint && if [[ $(node -v) = *v10* ]]; then yarn test-all; fi
 cache: yarn
 git:

--- a/integration_tests/benchmarks/firebase.ts
+++ b/integration_tests/benchmarks/firebase.ts
@@ -57,7 +57,7 @@ export async function logBenchmarkRun(
   if (day.length === 1) {
     day = '0' + day;
   }
-  const humanReadableDate = date.getFullYear() + '-' + month + '-' + day;
+  const humanReadableDate = `${date.getFullYear}-${month}-${day}`;
 
   const runs: {[params: string]: BenchmarkRunEntry} = {};
   logs.forEach(log => {


### PR DESCRIPTION
#### Description
MISC

```
tfjs-core/integration_tests/benchmarks/firebase.ts[60, 29]: Operands of '+' operation must either be both strings or both numbers, consider using template literals
```

And also make sure to run `yarn lint` in benchmark tools.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1282)
<!-- Reviewable:end -->
