### PR TITLE
Add benchmark suite in benchmark test

### DIFF
--- a/integration_tests/benchmarks/README.md
+++ b/integration_tests/benchmarks/README.md
@@ -10,6 +10,12 @@ When running benchmarks locally, use:
 
 `yarn benchmark`
 
+You can only run the specific benchmark suite with `--grep`.
+
+`yarn benchmark --grep='pool(avg)'`
+
+Without any grep option, `matmul`, `conv2d` and `mobilenet_v1` are default benchmark suite.
+
 This will not write to firebase, it will simply log what would have been written
 to firebase.
 

--- a/integration_tests/benchmarks/karma.conf.js
+++ b/integration_tests/benchmarks/karma.conf.js
@@ -23,6 +23,9 @@ module.exports = function(config) {
   const args = [];
   if (config.grep) {
     args.push('--grep', config.grep);
+  } else {
+    // Run the benchmark suite tagged with '[default]'
+    args.push('--grep', '[default]');
   }
   if (config.firebaseKey) {
     args.push('--firebaseKey', config.firebaseKey);


### PR DESCRIPTION

#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
MISC

It added the following benchmark suites. 
- Batch normalization
- Pooling operation
- Reduction operation
- Unary operation

You can only run the specific benchmark suite with `--grep`.

```
$ yarn benchmark --grep='unary(avg)'
```

The default benchmark suites without any `--grep` option was unchanged. In short, `matmul`, `conv2d` and `mobilenet_v1` will run.


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1284)
<!-- Reviewable:end -->
