### PR TITLE
Add 16bit support for packed matmul

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -599,8 +599,7 @@ export class MathBackendWebGL implements KernelBackend {
     // We're restricting packed matMul to these conditions because for now, our
     // packed matMul shader needs its inputs to be 2D matrices whose physical
     // dimensions match their logical dimensions.
-    if (ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') && a.shape[0] === 1 &&
-        b.shape[0] === 1 &&
+    if (a.shape[0] === 1 && b.shape[0] === 1 &&
         this.textureCanMatchShape(
             [a.shape[1], a.shape[2]], TextureUsage.PACK) &&
         this.textureCanMatchShape(

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1407,8 +1407,7 @@ export class MathBackendWebGL implements KernelBackend {
     const x2ColShape = [sharedDim, numCols];
     const w2RowShape = [convInfo.outChannels, sharedDim];
 
-    if (ENV.get('WEBGL_CONV_IM2COL') &&
-        ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') && x.shape[0] === 1 &&
+    if (ENV.get('WEBGL_CONV_IM2COL') && x.shape[0] === 1 &&
         this.textureCanMatchShape(x2ColShape, TextureUsage.PACK) &&
         this.textureCanMatchShape(w2RowShape, TextureUsage.PACK)) {
       return this.conv2dWithIm2Row(x, filter, convInfo);

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -148,6 +148,13 @@ export class GPGPUContext {
     gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
   }
 
+  public createFloat16PackedMatrixTexture(rows: number, columns: number):
+      WebGLTexture {
+    this.throwIfDisposed();
+    return gpgpu_util.createFloat16PackedMatrixTexture(
+        this.gl, rows, columns, this.textureConfig);
+  }
+
   public createPackedMatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -210,6 +210,16 @@ export function createPackedMatrixTexture(
       gl.FLOAT);
 }
 
+export function createFloat16PackedMatrixTexture(
+    gl: WebGLRenderingContext, rows: number, columns: number,
+    textureConfig: TextureConfig): WebGLTexture {
+  const [width, height] =
+      tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
+  return createAndConfigureTexture(
+      gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA,
+      textureConfig.textureTypeHalfFloat);
+}
+
 export function bindVertexProgramAttributeStreams(
     gl: WebGLRenderingContext, program: WebGLProgram,
     vertexBuffer: WebGLBuffer): boolean {

--- a/src/kernels/webgl/tex_util.ts
+++ b/src/kernels/webgl/tex_util.ts
@@ -30,7 +30,8 @@ export enum PhysicalTextureType {
   UNPACKED_FLOAT16,
   UNPACKED_FLOAT32,
   PACKED_4X1_UNSIGNED_BYTE,
-  PACKED_2X2_FLOAT32
+  PACKED_2X2_FLOAT32,
+  PACKED_2X2_FLOAT16
 }
 
 export interface TextureData {

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -54,6 +54,9 @@ export class TextureManager {
     let newTexture: WebGLTexture;
     if (physicalTexType === PhysicalTextureType.PACKED_2X2_FLOAT32) {
       newTexture = this.gpgpu.createPackedMatrixTexture(shapeRC[0], shapeRC[1]);
+    } else if (physicalTexType === PhysicalTextureType.PACKED_2X2_FLOAT16) {
+      newTexture =
+          this.gpgpu.createFloat16PackedMatrixTexture(shapeRC[0], shapeRC[1]);
     } else if (physicalTexType === PhysicalTextureType.UNPACKED_FLOAT32) {
       newTexture =
           this.gpgpu.createFloat32MatrixTexture(shapeRC[0], shapeRC[1]);
@@ -149,7 +152,9 @@ function getPhysicalFromLogicalTextureType(logicalTexType: TextureUsage):
         PhysicalTextureType.UNPACKED_FLOAT32 :
         PhysicalTextureType.UNPACKED_FLOAT16;
   } else if (logicalTexType === TextureUsage.PACK) {
-    return PhysicalTextureType.PACKED_2X2_FLOAT32;
+    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+        PhysicalTextureType.PACKED_2X2_FLOAT32 :
+        PhysicalTextureType.PACKED_2X2_FLOAT16;
   }
   throw new Error(`Unknown logical texture type ${logicalTexType}`);
 }


### PR DESCRIPTION
This PR addresses the issue https://github.com/tensorflow/tfjs/issues/694

### Changes

- Added a new `PhysicalTextureType` - `PACKED_2X2_FLOAT16`. This is used to determine which texture type / internal format are used to create packed WebGL textures.
- Removed the check on `WEBGL_RENDER_FLOAT32_ENABLED` before sending ops to the packed matMul path

### MobileNet v2 benchmarks

The inference times over 20 runs for MobileNet v2 on an iPhone6 Chrome average out to be 260.6ms. On the `packed_16bit` build, this is reduced to 117.8ms *(+120%)*.

PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1308)
<!-- Reviewable:end -->
