### PR TITLE
Move FFT ops under the spectral namespace.

### DIFF
--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -41,7 +41,6 @@ export * from './moving_average';
 export * from './strided_slice';
 export * from './topk';
 export * from './scatter_nd';
-export * from './spectral_ops';
 
 export {op} from './operation';
 
@@ -49,4 +48,6 @@ export {op} from './operation';
 import * as losses from './loss_ops';
 import * as linalg from './linalg_ops';
 import * as image from './image_ops';
-export {image, linalg, losses};
+import * as spectral from './spectral_ops';
+
+export {image, linalg, losses, spectral};

--- a/src/ops/spectral_ops.ts
+++ b/src/ops/spectral_ops.ts
@@ -29,7 +29,7 @@ import {assert} from '../util';
  * const imag = tf.tensor1d([1, 2, 3]);
  * const x = tf.complex(real, imag);
  *
- * x.fft().print();
+ * x.fft().print();  // tf.spectral.fft(x).print();
  * ```
  * @param input The complex input to compute an fft over.
  */

--- a/src/ops/spectral_ops.ts
+++ b/src/ops/spectral_ops.ts
@@ -32,6 +32,10 @@ import {assert} from '../util';
  * x.fft().print();
  * ```
  * @param input The complex input to compute an fft over.
+ *
+ */
+/**
+ * @doc {heading: 'Operations', subheading: 'Spectral', namespace: 'spectral'}
  */
 function fft_(input: Tensor1D): Tensor1D {
   assert(input.dtype === 'complex64', 'dtype must be complex64');

--- a/src/ops/spectral_ops.ts
+++ b/src/ops/spectral_ops.ts
@@ -32,7 +32,6 @@ import {assert} from '../util';
  * x.fft().print();
  * ```
  * @param input The complex input to compute an fft over.
- *
  */
 /**
  * @doc {heading: 'Operations', subheading: 'Spectral', namespace: 'spectral'}

--- a/src/ops/spectral_ops_test.ts
+++ b/src/ops/spectral_ops_test.ts
@@ -17,14 +17,14 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {expectArraysClose, ALL_ENVS} from '../test_util';
+import {ALL_ENVS, expectArraysClose} from '../test_util';
 
 describeWithFlags('FFT', ALL_ENVS, () => {
   it('should return the same value with TensorFlow (2 elements)', () => {
     const t1Real = tf.tensor1d([1, 2]);
     const t1Imag = tf.tensor1d([1, 1]);
     const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(tf.fft(t1), [3, 2, -1, 0]);
+    expectArraysClose(tf.spectral.fft(t1), [3, 2, -1, 0]);
   });
 
   it('should calculate FFT from Tensor directly', () => {
@@ -38,38 +38,41 @@ describeWithFlags('FFT', ALL_ENVS, () => {
     const t1Real = tf.tensor1d([1, 2, 3]);
     const t1Imag = tf.tensor1d([0, 0, 0]);
     const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(tf.fft(t1), [6, 0, -1.5, 0.866025, -1.5, -0.866025]);
+    expectArraysClose(
+        tf.spectral.fft(t1), [6, 0, -1.5, 0.866025, -1.5, -0.866025]);
   });
 
   it('should return the same value as TensorFlow with imaginary (3 elements)',
-      () => {
-    const t1Real = tf.tensor1d([1, 2, 3]);
-    const t1Imag = tf.tensor1d([1, 2, 3]);
-    const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(
-        tf.fft(t1), [6, 6, -2.3660252, -0.63397473, -0.6339747, -2.3660254]);
-  });
+     () => {
+       const t1Real = tf.tensor1d([1, 2, 3]);
+       const t1Imag = tf.tensor1d([1, 2, 3]);
+       const t1 = tf.complex(t1Real, t1Imag);
+       expectArraysClose(
+           tf.spectral.fft(t1),
+           [6, 6, -2.3660252, -0.63397473, -0.6339747, -2.3660254]);
+     });
 
   it('should return the same value as TensorFlow (negative 3 elements)', () => {
     const t1Real = tf.tensor1d([-1, -2, -3]);
     const t1Imag = tf.tensor1d([-1, -2, -3]);
     const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(tf.fft(t1),
-      [-5.9999995, -6, 2.3660252, 0.63397473, 0.6339747, 2.3660254]);
+    expectArraysClose(
+        tf.spectral.fft(t1),
+        [-5.9999995, -6, 2.3660252, 0.63397473, 0.6339747, 2.3660254]);
   });
 
   it('should return the same value with TensorFlow (4 elements)', () => {
     const t1Real = tf.tensor1d([1, 2, 3, 4]);
     const t1Imag = tf.tensor1d([0, 0, 0, 0]);
     const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(tf.fft(t1), [10, 0, -2, 2, -2, 0, -2, -2]);
+    expectArraysClose(tf.spectral.fft(t1), [10, 0, -2, 2, -2, 0, -2, -2]);
   });
 
   it('should return the same value as TensorFlow with imaginary (4 elements)',
-      () => {
-    const t1Real = tf.tensor1d([1, 2, 3, 4]);
-    const t1Imag = tf.tensor1d([1, 2, 3, 4]);
-    const t1 = tf.complex(t1Real, t1Imag);
-    expectArraysClose(tf.fft(t1), [10, 10, -4, 0, -2, -2, 0, -4]);
-  });
+     () => {
+       const t1Real = tf.tensor1d([1, 2, 3, 4]);
+       const t1Imag = tf.tensor1d([1, 2, 3, 4]);
+       const t1 = tf.complex(t1Real, t1Imag);
+       expectArraysClose(tf.spectral.fft(t1), [10, 10, -4, 0, -2, -2, 0, -4]);
+     });
 });

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -329,7 +329,7 @@ export interface OpHandler {
       x: T, begin: number[], end: number[], strides: number[],
       beginMask: number, endMask: number): T;
   depthToSpace(x: Tensor4D, blockSize: number, dataFormat: string): Tensor4D;
-  fft(x: Tensor1D): Tensor1D;
+  spectral: {fft(x: Tensor1D): Tensor1D;};
 }
 
 // For tracking tensor creation and disposal.
@@ -1253,7 +1253,7 @@ export class Tensor<R extends Rank = Rank> {
 
   fft(this: Tensor1D): Tensor1D {
     this.throwIfDisposed();
-    return opHandler.fft(this);
+    return opHandler.spectral.fft(this);
   }
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {


### PR DESCRIPTION
`tf.fft` is now `tf.spectral.fft`, to match TensorFlow: https://www.tensorflow.org/api_docs/python/tf/spectral/fft

We do not support `tf.fft` as an alias, as this is the old way to do it in TensorFlow (the other spectral ops do not have an alias in the top-level namespace).

Note that the chain API does not change, users still call `tensor.fft()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1309)
<!-- Reviewable:end -->
