### PR TITLE
Cache MAX_TEXTURE_SIZE

### DIFF
--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -121,12 +121,10 @@ export const getWebGLMaxTextureSize = (() => {
   // MAX_TEXTURE_SIZE.
   let MAX_TEXTURE_SIZE: number = null;
   return (webGLVersion: number, isBrowser: boolean): number => {
-    if (MAX_TEXTURE_SIZE != null) {
-      return MAX_TEXTURE_SIZE;
+    if (MAX_TEXTURE_SIZE === null) {
+      const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+      MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
     }
-
-    const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
-    MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
     return MAX_TEXTURE_SIZE;
   };
 })();

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -115,11 +115,21 @@ export function isWebGLVersionEnabled(webGLVersion: 1|2, isBrowser: boolean) {
   return false;
 }
 
-export function getWebGLMaxTextureSize(
-    webGLVersion: number, isBrowser: boolean): number {
-  const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
-  return gl.getParameter(gl.MAX_TEXTURE_SIZE);
-}
+export const getWebGLMaxTextureSize = (() => {
+  // Caching MAX_TEXTURE_SIZE here because the environment gets reset between
+  // unit tests and we don't want to constantly query the WebGLContext for
+  // MAX_TEXTURE_SIZE.
+  let MAX_TEXTURE_SIZE: number = null;
+  return (webGLVersion: number, isBrowser: boolean): number => {
+    if (MAX_TEXTURE_SIZE != null) {
+      return MAX_TEXTURE_SIZE;
+    }
+
+    const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+    MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    return MAX_TEXTURE_SIZE;
+  };
+})();
 
 export function getWebGLDisjointQueryTimerVersion(
     webGLVersion: number, isBrowser: boolean): number {


### PR DESCRIPTION
This PR addresses the issue https://github.com/tensorflow/tfjs/issues/786 by caching the value of `MAX_TEXTURE_SIZE` within the function that queries the WebGL context.

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1312)
<!-- Reviewable:end -->
