### PR TITLE
Preserve TextureUsage when caching on the CPU if it was previously set to PACK

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1803,7 +1803,8 @@ export class MathBackendWebGL implements KernelBackend {
       texData.texture = null;
       texData.texShape = null;
     }
-    texData.usage = TextureUsage.UPLOAD;
+    texData.usage =
+        usage === TextureUsage.PACK ? TextureUsage.PACK : TextureUsage.UPLOAD;
     if (float32Values != null) {
       texData.values = float32ToTypedArray(float32Values, dtype);
     }


### PR DESCRIPTION
This PR changes `cacheOnCPU` so that the texture usage is preserved if it was previously `TextureUsage.PACK`. 

This will be useful for implementing lazy packing / unpacking as part of packing batchNormalization (https://github.com/tensorflow/tfjs/issues/774). When `DEBUG` is on, we call `cacheOnCPU` for every texture in order to check for NaN's. This sets the `TextureUsage` of the texture to `UPLOAD`, regardless of its original `TextureUsage`. This makes it difficult to lazily unpack while debugging. 

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1328)
<!-- Reviewable:end -->
