### PR TITLE
Lazily pack and unpack textures in WebGL kernels

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1611,7 +1611,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private packTensor<T extends Tensor>(x: T): T {
-    if (this.texData.get(x.dataId).usage === TextureUsage.PACK) {
+    if (this.texData.get(x.dataId).packed) {
       return x;
     }
 
@@ -1660,8 +1660,7 @@ export class MathBackendWebGL implements KernelBackend {
         };
       }
 
-      if (texData.usage === TextureUsage.PACK &&
-          program.packedInputs !== true) {
+      if (texData.packed && program.packedInputs !== true) {
         const unpackProgram = new UnpackProgram(input.shape);
         input = this.compileAndRun(unpackProgram, [input]);
         texData = this.texData.get(input.dataId);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1646,10 +1646,10 @@ export class MathBackendWebGL implements KernelBackend {
         };
       }
 
-      if (texData.packed !== !!program.isPacked) {
+      if (texData.isPacked !== !!program.isPacked) {
         let preProcessProgram: UnpackProgram|PackProgram;
         let processedInput: Tensor;
-        if (texData.packed) {
+        if (texData.isPacked) {
           preProcessProgram = new UnpackProgram(input.shape);
           processedInput = this.compileAndRun(preProcessProgram, [input]);
         } else {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -653,13 +653,11 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     let output = null;
-    let envSpecificBatchNormProgram: BatchNormProgram|BatchNormPackedProgram;
+    let envSpecificBatchNormProgram = BatchNormProgram;
 
     if (ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
       output = this.makePackedTensor(x.shape);
       envSpecificBatchNormProgram = BatchNormPackedProgram;
-    } else {
-      envSpecificBatchNormProgram = BatchNormProgram;
     }
 
     const program = new envSpecificBatchNormProgram(

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -656,7 +656,8 @@ export class MathBackendWebGL implements KernelBackend {
         BatchNormPackedProgram :
         BatchNormProgram;
     const program = new batchNormProgram(
-        x.shape, mean.shape, variance.shape, offsetShape, scaleShape);
+        x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
+        varianceEpsilon);
     return this.compileAndRun(program, inputs);
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1658,7 +1658,8 @@ export class MathBackendWebGL implements KernelBackend {
       // to problems when comparing 16bit floats with 32bit floats.
       // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it possible
       // for packed shaders to sample from uniforms.
-      if (texData.texture == null && !(!texData.isPacked && program.isPacked) &&
+      if (texData.texture == null &&
+          !(!texData.isPacked && program.usesPackedTextures) &&
           util.sizeFromShape(input.shape) <=
               ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
         return {
@@ -1669,7 +1670,7 @@ export class MathBackendWebGL implements KernelBackend {
         };
       }
 
-      if (texData.isPacked !== !!program.isPacked) {
+      if (texData.isPacked !== !!program.usesPackedTextures) {
         let preProcessProgram: UnpackProgram|PackProgram;
         let processedInput: Tensor;
         if (texData.isPacked) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1659,8 +1659,6 @@ export class MathBackendWebGL implements KernelBackend {
         }
 
         texData = this.texData.get(processedInput.dataId);
-
-        (input as Tensor).dispose();
         input = processedInput;
       }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1621,17 +1621,6 @@ export class MathBackendWebGL implements KernelBackend {
     return packedTensor as T;
   }
 
-  private packTensor<T extends Tensor>(x: T): T {
-    const packProgram = new PackProgram(x.shape);
-    return this.compileAndRun(
-               packProgram, [x], this.makePackedTensor(x.shape)) as T;
-  }
-
-  private unpackTensor<T extends Tensor>(x: T): T {
-    const unpackProgram = new UnpackProgram(x.shape);
-    return this.compileAndRun(unpackProgram, [x]) as T;
-  }
-
   public compileAndRun<
       K extends {dtype: DataType, size: number, dataId: {}, shape: number[]}>(
       program: GPGPUProgram, inputs: TensorHandle[], output?: K,

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -653,16 +653,16 @@ export class MathBackendWebGL implements KernelBackend {
     }
 
     let output = null;
-    let EnvSpecificBatchNormProgram: BatchNormProgram|BatchNormPackedProgram;
+    let envSpecificBatchNormProgram: BatchNormProgram|BatchNormPackedProgram;
 
     if (ENV.get('WEBGL_PACK_BATCHNORMALIZATION')) {
       output = this.makePackedTensor(x.shape);
-      EnvSpecificBatchNormProgram = BatchNormPackedProgram;
+      envSpecificBatchNormProgram = BatchNormPackedProgram;
     } else {
-      EnvSpecificBatchNormProgram = BatchNormProgram;
+      envSpecificBatchNormProgram = BatchNormProgram;
     }
 
-    const program = new EnvSpecificBatchNormProgram(
+    const program = new envSpecificBatchNormProgram(
         x.shape, mean.shape, variance.shape, offsetShape, scaleShape,
         varianceEpsilon);
     return this.compileAndRun(program, inputs, output);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1662,8 +1662,11 @@ export class MathBackendWebGL implements KernelBackend {
 
       if (texData.packed && program.packedInputs !== true) {
         const unpackProgram = new UnpackProgram(input.shape);
-        input = this.compileAndRun(unpackProgram, [input]);
-        texData = this.texData.get(input.dataId);
+        const unpackedInput = this.compileAndRun(unpackProgram, [input]);
+        texData = this.texData.get(unpackedInput.dataId);
+
+        (input as Tensor).dispose();
+        input = unpackedInput;
       }
 
       this.uploadToGPU(input.dataId);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -16,7 +16,7 @@
  */
 
 import {MemoryInfo, TimingInfo} from '../engine';
-import {ENV, Environment} from '../environment';
+import {ENV} from '../environment';
 import {tidy} from '../globals';
 import {warn} from '../log';
 import * as array_ops_util from '../ops/array_ops_util';
@@ -652,11 +652,11 @@ export class MathBackendWebGL implements KernelBackend {
       inputs.push(scale);
     }
 
-    const inputShapes = [...inputs.map(d => d.shape), offsetShape, scaleShape];
-
-    const program = ENV.get('WEBGL_PACK_BATCHNORMALIZATION') ?
-        new BatchNormPackedProgram(...inputShapes) :
-        new BatchNormProgram(...inputShapes);
+    const batchNormProgram = ENV.get('WEBGL_PACK_BATCHNORMALIZATION') ?
+        BatchNormPackedProgram :
+        BatchNormProgram;
+    const program = new batchNormProgram(
+        x.shape, mean.shape, variance.shape, offsetShape, scaleShape);
     return this.compileAndRun(program, inputs);
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1635,7 +1635,9 @@ export class MathBackendWebGL implements KernelBackend {
       // Upload small tensors that live on the CPU as uniforms, not as
       // textures. Do this only when the environment supports 32bit floats due
       // to problems when comparing 16bit floats with 32bit floats.
-      if (texData.texture == null &&
+      // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it possible
+      // for packed shaders to sample from uniforms.
+      if (texData.texture == null && !(!texData.isPacked && program.isPacked) &&
           util.sizeFromShape(input.shape) <=
               ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
         return {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1646,7 +1646,7 @@ export class MathBackendWebGL implements KernelBackend {
         };
       }
 
-      if (texData.packed !== !!program.packedInputs) {
+      if (texData.packed !== !!program.isPacked) {
         let preProcessProgram: UnpackProgram|PackProgram;
         let processedInput: Tensor;
         if (texData.packed) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -587,8 +587,8 @@ export class MathBackendWebGL implements KernelBackend {
       const aSqueezed = a.as2D(a.shape[1], a.shape[2]);
       const bSqueezed = b.as2D(b.shape[1], b.shape[2]);
 
-      const packedA = this.packTensor(aSqueezed);
-      const packedB = this.packTensor(bSqueezed);
+      const packedA = this.packTensor<Tensor2D>(aSqueezed);
+      const packedB = this.packTensor<Tensor2D>(bSqueezed);
 
       const program = new MatMulPackedProgram(
           packedA.shape, packedB.shape, [outerShapeA, outerShapeB], transposeA,
@@ -1330,7 +1330,7 @@ export class MathBackendWebGL implements KernelBackend {
     const x2ColShape = [sharedDim, numCols];
 
     const xSqueezed = x.squeeze([0]);
-    const w2Row = filter.reshape([sharedDim, -1]);
+    const w2Row = filter.reshape([sharedDim, -1]) as Tensor2D;
 
     const im2ColProgram =
         new Im2ColProgram(x2ColShape, xSqueezed.shape, convInfo);
@@ -1338,7 +1338,7 @@ export class MathBackendWebGL implements KernelBackend {
         im2ColProgram, [xSqueezed],
         this.makePackedTensor<Tensor2D>(x2ColShape));
 
-    const packedW2Row = this.packTensor(w2Row);
+    const packedW2Row = this.packTensor<Tensor2D>(w2Row);
 
     const matmulProgram = new MatMulPackedProgram(
         im2Col.shape, packedW2Row.shape, [numCols, convInfo.outChannels], true,
@@ -1645,7 +1645,7 @@ export class MathBackendWebGL implements KernelBackend {
             `parts.`);
       }
 
-      const texData = this.texData.get(input.dataId);
+      let texData = this.texData.get(input.dataId);
       // Upload small tensors that live on the CPU as uniforms, not as
       // textures. Do this only when the environment supports 32bit floats due
       // to problems when comparing 16bit floats with 32bit floats.

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -32,10 +32,23 @@ describeWithFlags('lazy packing and unpacking', WEBGL_ENVS, () => {
 
     tf.add(c, 1);
 
-    const endNumBytes = tf.memory().numBytes;
-    const endNumTensors = tf.memory().numTensors;
-    expect(endNumBytes - startNumBytes).toEqual(0);
-    expect(endNumTensors - startNumTensors).toEqual(0);
+    expect(startNumBytes).toEqual(tf.memory().numBytes);
+    expect(startNumTensors).toEqual(tf.memory().numTensors);
+  });
+
+  it('should not leak memory when lazily packing', () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+
+    const c = tf.add(a, 1);
+
+    const startNumBytes = tf.memory().numBytes;
+    const startNumTensors = tf.memory().numTensors;
+
+    tf.matMul(b, c);
+
+    expect(tf.memory().numBytes - startNumBytes).toEqual(36);
+    expect(tf.memory().numTensors - startNumTensors).toEqual(1);
   });
 });
 

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -32,8 +32,8 @@ describeWithFlags('lazy packing and unpacking', WEBGL_ENVS, () => {
 
     tf.add(c, 1);
 
-    expect(startNumBytes).toEqual(tf.memory().numBytes);
-    expect(startNumTensors).toEqual(tf.memory().numTensors);
+    expect(tf.memory().numBytes - startNumBytes).toEqual(16);
+    expect(tf.memory().numTensors - startNumTensors).toEqual(1);
   });
 
   it('should not leak memory when lazily packing', () => {

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -20,6 +20,25 @@ import {describeWithFlags} from '../jasmine_util';
 import {expectArraysClose, expectArraysEqual, WEBGL_ENVS} from '../test_util';
 import {MathBackendWebGL, SIZE_UPLOAD_UNIFORM, WebGLMemoryInfo} from './backend_webgl';
 
+describeWithFlags('lazy packing and unpacking', WEBGL_ENVS, () => {
+  it('should not leak memory when lazily unpacking', () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+
+    const c = tf.matMul(a, b);
+
+    const startNumBytes = tf.memory().numBytes;
+    const startNumTensors = tf.memory().numTensors;
+
+    tf.add(c, 1);
+
+    const endNumBytes = tf.memory().numBytes;
+    const endNumTensors = tf.memory().numTensors;
+    expect(endNumBytes - startNumBytes).toEqual(0);
+    expect(endNumTensors - startNumTensors).toEqual(0);
+  });
+});
+
 describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
   let prevBackend: string;
 

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -23,6 +23,7 @@ export class BatchNormPackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   supportsBroadcasting = true;
+  isPacked = true;
 
   constructor(
       xShape: number[], meanShape: number[], varianceShape: number[],

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -23,7 +23,7 @@ export class BatchNormPackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
   supportsBroadcasting = true;
-  isPacked = true;
+  usesPackedTextures = true;
 
   constructor(
       xShape: number[], meanShape: number[], varianceShape: number[],

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -28,6 +28,7 @@ export interface GPGPUProgram {
   variableNames: string[];
   outputShape: number[];
   userCode: string;
+  packedInputs?: boolean;
   supportsBroadcasting?: boolean;
 }
 

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -58,7 +58,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
       logicalShape: input.shape,
       texShape: input.isUniform ? null : input.texData.texShape,
       isUniform: input.isUniform,
-      isPacked: input.isUniform ? false : input.texData.packed
+      isPacked: input.isUniform ? false : input.texData.isPacked
     };
     return {name: program.variableNames[i], shapeInfo};
   });
@@ -67,7 +67,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     logicalShape: output.shape,
     texShape: output.texData.texShape,
     isUniform: false,
-    isPacked: output.texData.packed
+    isPacked: output.texData.isPacked
   };
   const source = shader_compiler.makeShader(
       inputInfos, outShapeInfo, userCode,
@@ -137,7 +137,7 @@ export function runProgram<T extends Tensor, K extends Tensor>(
   const outTex = output.texData.texture;
   const outTexShape = output.texData.texShape;
   const gpgpu = binary.gpgpu;
-  if (output.texData.packed) {
+  if (output.texData.isPacked) {
     gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
   } else {
     gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -22,7 +22,7 @@ import * as util from '../../util';
 import {GPGPUContext} from './gpgpu_context';
 import * as shader_compiler from './shader_compiler';
 import {InputInfo, ShapeInfo} from './shader_compiler';
-import {TextureData, TextureUsage} from './tex_util';
+import {TextureData} from './tex_util';
 
 export interface GPGPUProgram {
   variableNames: string[];
@@ -58,8 +58,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
       logicalShape: input.shape,
       texShape: input.isUniform ? null : input.texData.texShape,
       isUniform: input.isUniform,
-      isPacked: input.isUniform ? false :
-                                  input.texData.usage === TextureUsage.PACK
+      isPacked: input.isUniform ? false : input.texData.packed
     };
     return {name: program.variableNames[i], shapeInfo};
   });
@@ -68,7 +67,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     logicalShape: output.shape,
     texShape: output.texData.texShape,
     isUniform: false,
-    isPacked: output.texData.usage === TextureUsage.PACK
+    isPacked: output.texData.packed
   };
   const source = shader_compiler.makeShader(
       inputInfos, outShapeInfo, userCode,
@@ -138,7 +137,7 @@ export function runProgram<T extends Tensor, K extends Tensor>(
   const outTex = output.texData.texture;
   const outTexShape = output.texData.texShape;
   const gpgpu = binary.gpgpu;
-  if (output.texData.usage === TextureUsage.PACK) {
+  if (output.texData.packed) {
     gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
   } else {
     gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -28,7 +28,7 @@ export interface GPGPUProgram {
   variableNames: string[];
   outputShape: number[];
   userCode: string;
-  isPacked?: boolean;
+  usesPackedTextures?: boolean;
   supportsBroadcasting?: boolean;
 }
 

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -28,7 +28,7 @@ export interface GPGPUProgram {
   variableNames: string[];
   outputShape: number[];
   userCode: string;
-  packedInputs?: boolean;
+  isPacked?: boolean;
   supportsBroadcasting?: boolean;
 }
 

--- a/src/kernels/webgl/mulmat_packed_gpu.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu.ts
@@ -19,7 +19,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MatMulPackedProgram implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
-  packedInputs = true;
+  isPacked = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/mulmat_packed_gpu.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu.ts
@@ -19,7 +19,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MatMulPackedProgram implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
-  isPacked = true;
+  usesPackedTextures = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/mulmat_packed_gpu.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu.ts
@@ -19,6 +19,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MatMulPackedProgram implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
+  packedInputs = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/tex_util.ts
+++ b/src/kernels/webgl/tex_util.ts
@@ -46,7 +46,7 @@ export interface TextureData {
   dtype: DataType;
   values: DataTypeMap[DataType];
   usage: TextureUsage;
-  packed: boolean
+  packed: boolean;
 }
 
 export function getUnpackedMatrixTextureShapeWidthHeight(

--- a/src/kernels/webgl/tex_util.ts
+++ b/src/kernels/webgl/tex_util.ts
@@ -46,7 +46,7 @@ export interface TextureData {
   dtype: DataType;
   values: DataTypeMap[DataType];
   usage: TextureUsage;
-  packed: boolean;
+  isPacked: boolean;
 }
 
 export function getUnpackedMatrixTextureShapeWidthHeight(

--- a/src/kernels/webgl/tex_util.ts
+++ b/src/kernels/webgl/tex_util.ts
@@ -22,8 +22,7 @@ export enum TextureUsage {
   RENDER,
   UPLOAD,
   PIXELS,
-  DOWNLOAD,
-  PACK
+  DOWNLOAD
 }
 
 export enum PhysicalTextureType {
@@ -47,6 +46,7 @@ export interface TextureData {
   dtype: DataType;
   values: DataTypeMap[DataType];
   usage: TextureUsage;
+  packed: boolean
 }
 
 export function getUnpackedMatrixTextureShapeWidthHeight(

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -31,10 +31,10 @@ export class TextureManager {
 
   acquireTexture(
       shapeRC: [number, number], usage: TextureUsage,
-      packed: boolean): WebGLTexture {
-    const physicalTexType = getPhysicalFromLogicalTextureType(usage, packed);
+      isPacked: boolean): WebGLTexture {
+    const physicalTexType = getPhysicalFromLogicalTextureType(usage, isPacked);
 
-    const shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, packed);
+    const shapeKey = getKeyFromTextureShape(shapeRC, physicalTexType, isPacked);
     if (!(shapeKey in this.freeTextures)) {
       this.freeTextures[shapeKey] = [];
     }
@@ -78,14 +78,14 @@ export class TextureManager {
 
   releaseTexture(
       texture: WebGLTexture, shape: [number, number],
-      logicalTexType: TextureUsage, packed: boolean): void {
+      logicalTexType: TextureUsage, isPacked: boolean): void {
     if (this.freeTextures == null) {
       // Already disposed.
       return;
     }
     const physicalTexType =
-        getPhysicalFromLogicalTextureType(logicalTexType, packed);
-    const shapeKey = getKeyFromTextureShape(shape, physicalTexType, packed);
+        getPhysicalFromLogicalTextureType(logicalTexType, isPacked);
+    const shapeKey = getKeyFromTextureShape(shape, physicalTexType, isPacked);
     if (!(shapeKey in this.freeTextures)) {
       this.freeTextures[shapeKey] = [];
     }
@@ -144,8 +144,8 @@ export class TextureManager {
 }
 
 function getPhysicalFromLogicalTextureType(
-    logicalTexType: TextureUsage, packed: boolean): PhysicalTextureType {
-  if (packed) {
+    logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
+  if (isPacked) {
     return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
         PhysicalTextureType.PACKED_2X2_FLOAT32 :
         PhysicalTextureType.PACKED_2X2_FLOAT16;
@@ -165,7 +165,6 @@ function getPhysicalFromLogicalTextureType(
 
 function getKeyFromTextureShape(
     shapeRowsCol: [number, number], physicalTexType: PhysicalTextureType,
-    packed: boolean): string {
-  return `${shapeRowsCol[0]}_${shapeRowsCol[1]}_${physicalTexType}${
-      packed ? '_packed' : ''}`;
+    isPacked: boolean): string {
+  return `${shapeRowsCol[0]}_${shapeRowsCol[1]}_${physicalTexType}_${isPacked}`;
 }

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -22,7 +22,7 @@ import {getCoordsDataType} from './shader_compiler';
 
 export class UnpackProgram implements GPGPUProgram {
   variableNames = ['A'];
-  isPacked = true;
+  usesPackedTextures = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -19,7 +19,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class UnpackProgram implements GPGPUProgram {
   variableNames = ['A'];
-  packedInputs = true;
+  isPacked = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -19,6 +19,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class UnpackProgram implements GPGPUProgram {
   variableNames = ['A'];
+  packedInputs = true;
   outputShape: number[];
   userCode: string;
 

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../../environment';
 import * as util from '../../util';
-import {TextureUsage} from '../webgl/tex_util';
 
 export function createWebGLRenderingContext(attributes: WebGLContextAttributes):
     WebGLRenderingContext {
@@ -357,10 +356,9 @@ function validateTextureUnit(gl: WebGLRenderingContext, textureUnit: number) {
 }
 
 export function getTextureShapeFromLogicalShape(
-    logShape: number[],
-    usage: TextureUsage = TextureUsage.UPLOAD): [number, number] {
+    logShape: number[], packed: boolean = false): [number, number] {
   let maxTexSize = ENV.get('WEBGL_MAX_TEXTURE_SIZE');
-  if (usage === TextureUsage.PACK) {
+  if (packed) {
     maxTexSize = maxTexSize * 2;
 
     // This logic ensures we accurately count the number of packed texels needed

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -356,9 +356,9 @@ function validateTextureUnit(gl: WebGLRenderingContext, textureUnit: number) {
 }
 
 export function getTextureShapeFromLogicalShape(
-    logShape: number[], packed = false): [number, number] {
+    logShape: number[], isPacked = false): [number, number] {
   let maxTexSize = ENV.get('WEBGL_MAX_TEXTURE_SIZE');
-  if (packed) {
+  if (isPacked) {
     maxTexSize = maxTexSize * 2;
 
     // This logic ensures we accurately count the number of packed texels needed

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -356,7 +356,7 @@ function validateTextureUnit(gl: WebGLRenderingContext, textureUnit: number) {
 }
 
 export function getTextureShapeFromLogicalShape(
-    logShape: number[], packed: false): [number, number] {
+    logShape: number[], packed = false): [number, number] {
   let maxTexSize = ENV.get('WEBGL_MAX_TEXTURE_SIZE');
   if (packed) {
     maxTexSize = maxTexSize * 2;

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -356,7 +356,7 @@ function validateTextureUnit(gl: WebGLRenderingContext, textureUnit: number) {
 }
 
 export function getTextureShapeFromLogicalShape(
-    logShape: number[], packed: boolean = false): [number, number] {
+    logShape: number[], packed: false): [number, number] {
   let maxTexSize = ENV.get('WEBGL_MAX_TEXTURE_SIZE');
   if (packed) {
     maxTexSize = maxTexSize * 2;

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -83,27 +83,30 @@ describeWithFlags('getTextureShapeFromLogicalShape', WEBGL_ENVS, () => {
 
 describeWithFlags('getTextureShapeFromLogicalShape packed', WEBGL_ENVS, () => {
   it('textures less than 2x max size of platform preserve their shapes', () => {
+    const isPacked = true;
     const logicalShape =
         [2, util.nearestLargerEven(tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE') + 1)];
     const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, isPacked);
     expect(texShape).toEqual(logicalShape);
   });
 
   it('rows/columns do not get squeezed', () => {
+    const isPacked = true;
     const logicalShape = [1, 1, 1];
     const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, isPacked);
     expect(texShape).toEqual([2, 2]);
   });
 
   it('squarified texture shapes account for packing constraints', () => {
+    const isPacked = true;
     const max = tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
 
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 5);
     const logicalShape = [1, 12];
     const texShape =
-        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, isPacked);
 
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', max);
     expect(texShape).toEqual([4, 6]);

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -20,7 +20,6 @@ import {describeWithFlags} from '../../jasmine_util';
 import {WEBGL_ENVS} from '../../test_util';
 import * as util from '../../util';
 
-import {TextureUsage} from './tex_util';
 import * as webgl_util from './webgl_util';
 
 describeWithFlags('getTextureShapeFromLogicalShape', WEBGL_ENVS, () => {
@@ -86,15 +85,15 @@ describeWithFlags('getTextureShapeFromLogicalShape packed', WEBGL_ENVS, () => {
   it('textures less than 2x max size of platform preserve their shapes', () => {
     const logicalShape =
         [2, util.nearestLargerEven(tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE') + 1)];
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(
-        logicalShape, TextureUsage.PACK);
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
     expect(texShape).toEqual(logicalShape);
   });
 
   it('rows/columns do not get squeezed', () => {
     const logicalShape = [1, 1, 1];
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(
-        logicalShape, TextureUsage.PACK);
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
     expect(texShape).toEqual([2, 2]);
   });
 
@@ -103,8 +102,8 @@ describeWithFlags('getTextureShapeFromLogicalShape packed', WEBGL_ENVS, () => {
 
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 5);
     const logicalShape = [1, 12];
-    const texShape = webgl_util.getTextureShapeFromLogicalShape(
-        logicalShape, TextureUsage.PACK);
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, true);
 
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', max);
     expect(texShape).toEqual([4, 6]);

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -131,7 +131,7 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
     expectArraysClose(d, [1, 9, -2, 21]);
   });
 
-  fit('should work when preceded by an op that requires packed inputs', () => {
+  it('should work when preceded by an op that requires packed inputs', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
 

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -120,6 +120,26 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
     const expected = [11, 13, 14, 20];
     expectArraysClose(c, expected);
   });
+
+  it('should work when followed by an op that requires unpacked inputs', () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+
+    const c = tf.matMul(a, b);
+    const d = tf.add(c, 1);
+
+    expectArraysClose(d, [1, 9, -2, 21]);
+  });
+
+  fit('should work when preceded by an op that requires packed inputs', () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+
+    const c = tf.add(a, 1);
+    const d = tf.matMul(b, c);
+
+    expectArraysClose(d, [5, 6, 7, 4, 3, 2, 9, 12, 15]);
+  });
 });
 
 describeWithFlags('matmul', ALL_ENVS, () => {


### PR DESCRIPTION
### Changes
- Add `packedInput` boolean property to GPGPUProgram to identify WebGL kernels that require packed inputs (`batchMatMul`, `conv2DWithIm2Col`).
- Such kernels no longer unpack their outputs, and they only pack their inputs if they are not already packed.
- In `compileAndRun`, check whether the GPGPUProgram requires packed inputs. If it does not, and an input texture is packed, unpack it before passing it to the program.

PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1329)
<!-- Reviewable:end -->
