### PR TITLE
Add packed batchnormalization kernel behind an environment flag

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -306,6 +306,8 @@ export class Environment {
           (typeof process.versions.node !== 'undefined');
     } else if (feature === 'IS_CHROME') {
       return isChrome();
+    } else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
+      return false;
     } else if (feature === 'WEBGL_CONV_IM2COL') {
       return false;
     } else if (feature === 'WEBGL_PAGING_ENABLED') {

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -22,6 +22,8 @@ export interface Features {
   'IS_BROWSER'?: boolean;
   // Whether we are in the Node.js environment.
   'IS_NODE'?: boolean;
+  // Whether we will pack the batchnormalization op.
+  'WEBGL_PACK_BATCHNORMALIZATION'?: boolean;
   // Whether we will use the im2col algorithm to speed up convolutions.
   'WEBGL_CONV_IM2COL'?: boolean;
   // Whether we will perform memory paging.
@@ -79,6 +81,7 @@ export enum Type {
 export const URL_PROPERTIES: URLProperty[] = [
   {name: 'DEBUG', type: Type.BOOLEAN},
   {name: 'IS_BROWSER', type: Type.BOOLEAN},
+  {name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN},
   {name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN},
   {name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER},
   {name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN},

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -18,6 +18,7 @@
 import {MemoryInfo, TimingInfo} from '../engine';
 import {ENV} from '../environment';
 import {tidy} from '../globals';
+import * as tf from '../index';
 import {warn} from '../log';
 import * as array_ops_util from '../ops/array_ops_util';
 import * as axis_util from '../ops/axis_util';
@@ -674,8 +675,7 @@ export class MathBackendWebGL implements KernelBackend {
 
     const unpacked = this.unpackTensor(batchNorm);
 
-    packedInputs.forEach(d => d.dispose());
-    batchNorm.dispose();
+    tf.dispose([packedInputs, batchNorm]);
 
     return unpacked;
   }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -16,9 +16,8 @@
  */
 
 import {MemoryInfo, TimingInfo} from '../engine';
-import {ENV} from '../environment';
+import {ENV, Environment} from '../environment';
 import {tidy} from '../globals';
-import * as tf from '../index';
 import {warn} from '../log';
 import * as array_ops_util from '../ops/array_ops_util';
 import * as axis_util from '../ops/axis_util';
@@ -675,7 +674,7 @@ export class MathBackendWebGL implements KernelBackend {
 
     const unpacked = this.unpackTensor(batchNorm);
 
-    tf.dispose([packedInputs, batchNorm]);
+    Environment.dispose([packedInputs, batchNorm]);
 
     return unpacked;
   }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -597,8 +597,7 @@ export class MathBackendWebGL implements KernelBackend {
           program, [packedA, packedB],
           this.makePackedTensor<Tensor2D>(program.outputShape));
 
-      const unpackProgram = new UnpackProgram(result.shape);
-      const unpacked = this.compileAndRun(unpackProgram, [result]) as Tensor;
+      const unpacked = this.unpackTensor(result);
 
       packedA.dispose();
       packedB.dispose();
@@ -672,8 +671,7 @@ export class MathBackendWebGL implements KernelBackend {
         batchNormProgram, packedInputs,
         this.makePackedTensor<Tensor4D>(packedX.shape));
 
-    const unpackProgram = new UnpackProgram(batchNorm.shape);
-    const unpacked = this.compileAndRun<Tensor4D>(unpackProgram, [batchNorm]);
+    const unpacked = this.unpackTensor(batchNorm);
 
     packedInputs.forEach(d => d.dispose());
     batchNorm.dispose();
@@ -1399,8 +1397,7 @@ export class MathBackendWebGL implements KernelBackend {
         matmulProgram, [im2Col, packedW2Row],
         this.makePackedTensor<Tensor2D>(matmulProgram.outputShape));
 
-    const unpackProgram = new UnpackProgram(product.shape);
-    const unpacked = this.compileAndRun(unpackProgram, [product]) as Tensor;
+    const unpacked = this.unpackTensor(product);
 
     im2Col.dispose();
     packedW2Row.dispose();
@@ -1673,6 +1670,11 @@ export class MathBackendWebGL implements KernelBackend {
     const packProgram = new PackProgram(x.shape);
     return this.compileAndRun(
                packProgram, [x], this.makePackedTensor(x.shape)) as T;
+  }
+
+  private unpackTensor<T extends Tensor>(x: T): T {
+    const unpackProgram = new UnpackProgram(x.shape);
+    return this.compileAndRun(unpackProgram, [x]) as T;
   }
 
   public compileAndRun<

--- a/src/kernels/packing_util.ts
+++ b/src/kernels/packing_util.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/kernels/packing_util.ts
+++ b/src/kernels/packing_util.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export function getChannels(name: string): string[] {
+  return ['x', 'y', 'z', 'w'].map(d => `${name}.${d}`);
+}
+
+export function getInnerDims(rank: number, dims: string[]): string[] {
+  return dims.slice(0, rank).slice(-2);
+}
+
+export function getSourceCoords(rank: number, dims: string[]): string {
+  if (rank === 1) {
+    return 'rc';
+  }
+
+  let coords = '';
+  for (let i = 0; i < rank; i++) {
+    coords += dims[i];
+    if (i < rank - 1) {
+      coords += ',';
+    }
+  }
+  return coords;
+}

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google LLC. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -34,7 +34,7 @@ export class BatchNormPackedProgram implements GPGPUProgram {
     broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
 
     const meanSnippet = broadcastSample('mean', meanShape.length);
-    const varianceSnippet = broadcastSample('variance', varianceShape.length)
+    const varianceSnippet = broadcastSample('variance', varianceShape.length);
 
     let offsetSnippet = 'vec4 offset = vec4(0.0)';
     if (offsetShape != null) {

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as broadcast_util from '../../ops/broadcast_util';
+import {GPGPUProgram} from './gpgpu_math';
+
+export class BatchNormPackedProgram implements GPGPUProgram {
+  variableNames: string[];
+  outputShape: number[] = [];
+  userCode: string;
+  supportsBroadcasting = true;
+  packedInputs = true;
+
+  constructor(
+      xShape: number[], meanShape: number[], varianceShape: number[],
+      offsetShape: number[]|null, scaleShape: number[]|null,
+      varianceEpsilon: number) {
+    this.variableNames = ['x', 'mean', 'variance'];
+    broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
+    broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
+
+    let offsetSnippet = 'vec4 offset = vec4(0.0)';
+    if (offsetShape != null) {
+      broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
+      this.variableNames.push('offset');
+      offsetSnippet = sampleAndBroadcast('offset', offsetShape.length);
+    }
+
+    let scaleSnippet = 'vec4 scale = vec4(1.0)';
+    if (scaleShape != null) {
+      broadcast_util.assertAndGetBroadcastShape(xShape, scaleShape);
+      this.variableNames.push('scale');
+      scaleSnippet = sampleAndBroadcast('scale', scaleShape.length);
+    }
+
+    this.outputShape = xShape;
+    this.userCode = `
+      void main() {
+        ivec4 rc = getOutputCoords();
+
+        ${offsetSnippet};
+        ${scaleSnippet};
+
+        vec4 x = getX(rc.x, rc.y, rc.z, rc.w);
+        ${sampleAndBroadcast('mean', meanShape.length)};
+        ${sampleAndBroadcast('variance', varianceShape.length)};
+
+        vec4 inv = scale * inversesqrt(variance + vec4(${varianceEpsilon}));
+
+        gl_FragColor = (x - mean) * inv + offset;
+      }
+    `;
+  }
+}
+
+function sampleAndBroadcast(texName: string, rank: number): string {
+  const texSampler = `get${texName.charAt(0).toUpperCase()}${texName.slice(1)}`;
+  if (rank === 1) {
+    return `
+      vec4 ${texName}Sample = ${texSampler}(rc.w);
+      vec4 ${texName} = vec4(${texName}Sample.xy, ${texName}Sample.xy);
+    `;
+  }
+  return `vec4 ${texName} = ${texSampler}(rc.x, rc.y, rc.z, rc.w)`;
+}

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -61,7 +61,7 @@ export class BatchNormPackedProgram implements GPGPUProgram {
 
         vec4 inv = scale * inversesqrt(variance + vec4(${varianceEpsilon}));
 
-        gl_FragColor = dot((x - mean), inv) + offset;
+        gl_FragColor = (x - mean) * inv + offset;
       }
     `;
   }

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -20,7 +20,7 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class BatchNormPackedProgram implements GPGPUProgram {
   variableNames: string[];
-  outputShape: number[] = [];
+  outputShape: number[];
   userCode: string;
   supportsBroadcasting = true;
 

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -23,7 +23,6 @@ export class BatchNormPackedProgram implements GPGPUProgram {
   outputShape: number[] = [];
   userCode: string;
   supportsBroadcasting = true;
-  packedInputs = true;
 
   constructor(
       xShape: number[], meanShape: number[], varianceShape: number[],
@@ -64,7 +63,7 @@ export class BatchNormPackedProgram implements GPGPUProgram {
 
         vec4 inv = scale * inversesqrt(variance + vec4(${varianceEpsilon}));
 
-        gl_FragColor = (x - mean) * inv + offset;
+        setOutput((x - mean) * inv + offset);
       }
     `;
   }

--- a/src/kernels/webgl/batchnorm_packed_gpu.ts
+++ b/src/kernels/webgl/batchnorm_packed_gpu.ts
@@ -33,6 +33,9 @@ export class BatchNormPackedProgram implements GPGPUProgram {
     broadcast_util.assertAndGetBroadcastShape(xShape, meanShape);
     broadcast_util.assertAndGetBroadcastShape(xShape, varianceShape);
 
+    const meanSnippet = broadcastSample('mean', meanShape.length);
+    const varianceSnippet = broadcastSample('variance', varianceShape.length)
+
     let offsetSnippet = 'vec4 offset = vec4(0.0)';
     if (offsetShape != null) {
       broadcast_util.assertAndGetBroadcastShape(xShape, offsetShape);
@@ -56,8 +59,8 @@ export class BatchNormPackedProgram implements GPGPUProgram {
         ${scaleSnippet};
 
         vec4 x = getX(rc.x, rc.y, rc.z, rc.w);
-        ${broadcastSample('mean', meanShape.length)};
-        ${broadcastSample('variance', varianceShape.length)};
+        ${meanSnippet};
+        ${varianceSnippet};
 
         vec4 inv = scale * inversesqrt(variance + vec4(${varianceEpsilon}));
 

--- a/src/kernels/webgl/mulmat_packed_gpu.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu.ts
@@ -52,7 +52,7 @@ export class MatMulPackedProgram implements GPGPUProgram {
 
       void main() {
         ivec2 rc = getOutputCoords();
-        gl_FragColor = dot2x2ARowBCol(rc);
+        setOutput(dot2x2ARowBCol(rc));
       }
     `;
   }

--- a/src/kernels/webgl/pack_gpu.ts
+++ b/src/kernels/webgl/pack_gpu.ts
@@ -113,11 +113,11 @@ function getOutput(shape: number[], dims: string[]): string {
   if (rank === 1) {
     return `getA(rc),
             rc + 1 >= ${shape[0]} ? 0. : getA(rc + 1),
-            0, 0`
+            0, 0`;
   }
 
   return `getA(${sourceCoords[0]}),
           cEdge ? 0. : getA(${sourceCoords[1]}),
           rEdge ? 0. : getA(${sourceCoords[2]}),
-          rEdge || cEdge ? 0. : getA(${sourceCoords[3]})`
+          rEdge || cEdge ? 0. : getA(${sourceCoords[3]})`;
 }

--- a/src/kernels/webgl/pack_gpu.ts
+++ b/src/kernels/webgl/pack_gpu.ts
@@ -47,7 +47,7 @@ export class PackProgram implements GPGPUProgram {
         } else {
           ${setup}
 
-          gl_FragColor = vec4(${output});
+          setOutput(vec4(${output}));
         }
       }
     `;

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -648,8 +648,8 @@ function getPackedSampler1D(inputInfo: InputInfo): string {
 
   return `
     vec4 ${funcName}(int index) {
-      vec2 uv = packedUVfrom1D(${packedTexShape[0]}, ${
-      packedTexShape[1]}, index);
+      vec2 uv = packedUVfrom1D(
+        ${packedTexShape[0]}, ${packedTexShape[1]}, index);
       return texture2D(${texName}, uv);
     }
   `;
@@ -851,8 +851,9 @@ function getPackedSampler4D(inputInfo: InputInfo): string {
 
   return `
     vec4 ${funcName}(int b2, int b, int row, int col) {
-      vec2 uv = packedUVfrom4D(${texNumR}, ${texNumC}, ${texelsInBatch2}, ${
-      texelsInBatch}, ${valuesPerRow}, b2, b, row, col);
+      vec2 uv = packedUVfrom4D(
+        ${texNumR}, ${texNumC}, ${texelsInBatch2},
+        ${texelsInBatch}, ${valuesPerRow}, b2, b, row, col);
       return texture2D(${texName}, uv);
     }
   `;

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -46,19 +46,21 @@ export function makeShader(
           .join('\n');
   const outTexShape = outputShape.texShape;
   let outputSamplingSnippet: string;
+  let floatTextureSetOutputSnippet: string;
 
   if (outputShape.isPacked) {
     outputSamplingSnippet =
         getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
   } else {
     outputSamplingSnippet =
         getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
+    floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
   }
 
   const source = [
-    SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET,
-    FLOAT_TEXTURE_SETOUTPUT_SNIPPET, inputPrefixSnippet, outputSamplingSnippet,
-    inputSamplingSnippet, userCode
+    SHADER_PREFIX, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+    inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
   ].join('\n');
   return source;
 }
@@ -263,9 +265,15 @@ const FLOAT_TEXTURE_SAMPLE_SNIPPET = `
   }
 `;
 
-const FLOAT_TEXTURE_SETOUTPUT_SNIPPET = `
+const FLOAT_TEXTURE_SET_R_SNIPPET = `
   void setOutput(float val) {
     gl_FragColor = vec4(val, 0, 0, 0);
+  }
+`;
+
+const FLOAT_TEXTURE_SET_RGBA_SNIPPET = `
+  void setOutput(vec4 val) {
+    gl_FragColor = val;
   }
 `;
 

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -90,8 +90,12 @@ function getSamplerFromInInfo(inInfo: InputInfo): string {
 function getPackedSamplerFromInInfo(inInfo: InputInfo): string {
   const shape = inInfo.shapeInfo.logicalShape;
   switch (shape.length) {
+    case 1:
+      return getPackedSampler1D(inInfo);
     case 2:
       return getPackedSampler2D(inInfo);
+    case 4:
+      return getPackedSampler4D(inInfo);
     default:
       throw new Error(
           `Packed ${shape.length}-D input sampling` +
@@ -124,8 +128,13 @@ function getPackedOutputSamplingSnippet(
   switch (outShape.length) {
     case 0:
       return getOutputScalarCoords();
+    case 1:
+      return getOutputPacked1DCoords(outShape as [number], outTexShape);
     case 2:
       return getOutputPacked2DCoords(outShape as [number, number], outTexShape);
+    case 4:
+      return getOutputPacked4DCoords(
+          outShape as [number, number, number, number], outTexShape);
     default:
       throw new Error(
           `${outShape.length}-D output packed sampling is not yet supported`);
@@ -166,6 +175,12 @@ vec2 UVfrom1D(int texNumR, int texNumC, int index) {
   int texC = index - texR * texNumC;
   return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
 }
+vec2 packedUVfrom1D(int texNumR, int texNumC, int index) {
+  int texelIndex = index / 2;
+  int texR = texelIndex / texNumC;
+  int texC = texelIndex - texR * texNumC;
+  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
+}
 `;
 
 const SAMPLE_2D_SNIPPET = `
@@ -201,6 +216,15 @@ vec2 UVfrom4D(int texNumR, int texNumC, int stride0,
     int depth2) {
   // Explicitly use integer operations as dot() only works on floats.
   int index = row * stride0 + col * stride1 + depth * stride2 + depth2;
+  int texR = index / texNumC;
+  int texC = index - texR * texNumC;
+  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
+}
+vec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,
+    int texelsInBatch, int texelsInLogicalRow, int b2, int b,
+    int row, int col) {
+  int index = b2 * texelsInBatch2 + b * texelsInBatch +
+    (row / 2) * texelsInLogicalRow + (col / 2);
   int texR = index / texNumC;
   int texC = index - texR * texNumC;
   return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
@@ -318,6 +342,35 @@ function getOutputScalarCoords() {
   `;
 }
 
+function getOutputPacked1DCoords(
+    shape: [number], texShape: [number, number]): string {
+  const packedTexShape =
+      [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+  if (texShape[0] === 1) {
+    return `
+      int getOutputCoords() {
+        return 2 * int(resultUV.x * ${packedTexShape[1]}.0);
+      }
+    `;
+  }
+
+  if (texShape[1] === 1) {
+    return `
+      int getOutputCoords() {
+        return 2 * int(resultUV.y * ${packedTexShape[0]}.0);
+      }
+    `;
+  }
+
+  return `
+    int getOutputCoords() {
+      ivec2 resTexRC = ivec2(resultUV.yx *
+                             vec2(${packedTexShape[0]}, ${packedTexShape[1]}));
+      return resTexRC.x * ${packedTexShape[1]} + resTexRC.y;
+    }
+  `;
+}
+
 function getOutput1DCoords(
     shape: [number], texShape: [number, number]): string {
   if (texShape[0] === 1) {
@@ -357,6 +410,36 @@ function getOutput3DCoords(
       int c = index / ${stride1};
       int d = index - c * ${stride1};
       return ivec3(r, c, d);
+    }
+  `;
+}
+
+function getOutputPacked4DCoords(
+    shape: [number, number, number, number],
+    texShape: [number, number]): string {
+  const packedTexShape =
+      [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+
+  const texelsInLogicalRow = Math.ceil(shape[3] / 2);
+  const texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
+  const texelsInBatch2 = texelsInBatch * shape[1];
+
+  return `
+    ivec4 getOutputCoords() {
+      ivec2 resTexRC = ivec2(resultUV.yx *
+                             vec2(${packedTexShape[0]}, ${packedTexShape[1]}));
+      int index = resTexRC.x * ${packedTexShape[1]} + resTexRC.y;
+
+      int b2 = index / ${texelsInBatch2};
+      index -= b2 * ${texelsInBatch2};
+
+      int b = index / ${texelsInBatch};
+      index -= b * ${texelsInBatch};
+
+      int r = 2 * (index / ${texelsInLogicalRow});
+      int c = int(mod(float(index), ${texelsInLogicalRow}.)) * 2;
+
+      return ivec4(b2, b, r, c);
     }
   `;
 }
@@ -548,6 +631,22 @@ function getSamplerScalar(inputInfo: InputInfo): string {
   `;
 }
 
+function getPackedSampler1D(inputInfo: InputInfo): string {
+  const texName = inputInfo.name;
+  const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+  const texShape = inputInfo.shapeInfo.texShape;
+  const packedTexShape =
+      [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+
+  return `
+    vec4 ${funcName}(int index) {
+      vec2 uv = packedUVfrom1D(${packedTexShape[0]}, ${
+      packedTexShape[1]}, index);
+      return texture2D(${texName}, uv);
+    }
+  `;
+}
+
 function getSampler1D(inputInfo: InputInfo): string {
   const texName = inputInfo.name;
   const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
@@ -725,6 +824,29 @@ function getSampler3D(inputInfo: InputInfo): string {
             ${texNumR}, ${texNumC}, ${stride0}, ${stride1}, row, col, depth);
         return sampleTexture(${texName}, uv);
       }
+  `;
+}
+
+function getPackedSampler4D(inputInfo: InputInfo): string {
+  const shape = inputInfo.shapeInfo.logicalShape;
+  const texName = inputInfo.name;
+  const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+  const texShape = inputInfo.shapeInfo.texShape;
+  const packedTexShape =
+      [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+  const texNumR = packedTexShape[0];
+  const texNumC = packedTexShape[1];
+
+  const valuesPerRow = Math.ceil(shape[3] / 2);
+  const texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
+  const texelsInBatch2 = texelsInBatch * shape[1];
+
+  return `
+    vec4 ${funcName}(int b2, int b, int row, int col) {
+      vec2 uv = packedUVfrom4D(${texNumR}, ${texNumC}, ${texelsInBatch2}, ${
+      texelsInBatch}, ${valuesPerRow}, b2, b, row, col);
+      return texture2D(${texName}, uv);
+    }
   `;
 }
 

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -34,12 +34,12 @@ export class UnpackProgram implements GPGPUProgram {
     const dtype = getCoordsDataType(rank);
     const sourceCoords = getSourceCoords(rank, channels);
     const innerDims = getInnerDims(rank, channels);
+    const coords = rank === 1 ? 'rc' : innerDims.join(',');
 
     this.userCode = `
       void main() {
         ${dtype} rc = getOutputCoords();
-        vec2 modCoord = mod(vec2(${
-        rank === 1 ? 'rc' : innerDims.join(',')}), 2.);
+        vec2 modCoord = mod(vec2(${coords}), 2.);
         vec4 packedInput = getA(${sourceCoords});
 
         setOutput(

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {getChannels, getInnerDims, getSourceCoords} from '../packing_util';
+
 import {GPGPUProgram} from './gpgpu_math';
 import {getCoordsDataType} from './shader_compiler';
 
@@ -28,9 +30,10 @@ export class UnpackProgram implements GPGPUProgram {
     this.outputShape = outputShape;
     const rank = outputShape.length;
 
+    const channels = getChannels('rc');
     const dtype = getCoordsDataType(rank);
-    const sourceCoords = getSourceCoords(rank);
-    const innerDims = getInnerDims(rank);
+    const sourceCoords = getSourceCoords(rank, channels);
+    const innerDims = getInnerDims(rank, channels);
 
     this.userCode = `
       void main() {
@@ -47,25 +50,4 @@ export class UnpackProgram implements GPGPUProgram {
       }
     `;
   }
-}
-
-const dims = ['rc.x', 'rc.y', 'rc.z', 'rc.w'];
-
-function getInnerDims(rank: number): string[] {
-  return dims.slice(0, rank).slice(-2);
-}
-
-function getSourceCoords(rank: number): string {
-  if (rank === 1) {
-    return 'rc';
-  }
-
-  let coords = '';
-  for (let i = 0; i < rank; i++) {
-    coords += dims[i];
-    if (i < rank - 1) {
-      coords += ',';
-    }
-  }
-  return coords;
 }

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -33,18 +33,21 @@ describeWithFlags('packed batchNormalization', WEBGL_ENVS, () => {
         webglPackedBatchNormalizationSavedFlag);
   });
 
-  it('should not leak memory', () => {
+  fit('should not leak memory', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
     const startNumBytes = tf.memory().numBytes;
+    const startNumTensors = tf.memory().numTensors;
     tf.batchNormalization4d(
         x, mean, variance, varianceEpsilon, undefined, undefined);
     const endNumBytes = tf.memory().numBytes;
+    const endNumTensors = tf.memory().numTensors;
 
     expect(endNumBytes - startNumBytes).toEqual(16);
+    expect(endNumTensors - startNumTensors).toEqual(1);
   });
 
   it('simple batchnorm4D, no offset or scale, 2x1x1x2', () => {

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -17,7 +17,146 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {ALL_ENVS, expectArraysClose} from '../test_util';
+import {ALL_ENVS, expectArraysClose, WEBGL_ENVS} from '../test_util';
+
+describeWithFlags('packed batchNormalization', WEBGL_ENVS, () => {
+  const webglPackedBatchNormalizationSavedFlag =
+      tf.ENV.get('WEBGL_PACK_BATCHNORMALIZATION');
+
+  beforeAll(() => {
+    tf.ENV.set('WEBGL_PACK_BATCHNORMALIZATION', true);
+  });
+
+  afterAll(() => {
+    tf.ENV.set(
+        'WEBGL_PACK_BATCHNORMALIZATION',
+        webglPackedBatchNormalizationSavedFlag);
+  });
+
+  it('should not leak memory', () => {
+    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const mean = tf.tensor1d([1, 2]);
+    const variance = tf.tensor1d([2, 3]);
+    const varianceEpsilon = .001;
+
+    const startNumBytes = tf.memory().numBytes;
+    tf.batchNormalization4d(
+        x, mean, variance, varianceEpsilon, undefined, undefined);
+    const endNumBytes = tf.memory().numBytes;
+
+    expect(endNumBytes - startNumBytes).toEqual(16);
+  });
+
+  it('simple batchnorm4D, no offset or scale, 2x1x1x2', () => {
+    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const mean = tf.tensor1d([1, 2]);
+    const variance = tf.tensor1d([2, 3]);
+    const varianceEpsilon = .001;
+
+    const result = tf.batchNormalization4d(
+        x, mean, variance, varianceEpsilon, undefined, undefined);
+
+    expectArraysClose(result, [
+      (x.get(0, 0, 0, 0) - mean.get(0)) * 1 /
+          Math.sqrt(variance.get(0) + varianceEpsilon),
+      (x.get(0, 0, 0, 1) - mean.get(1)) * 1 /
+          Math.sqrt(variance.get(1) + varianceEpsilon),
+      (x.get(1, 0, 0, 0) - mean.get(0)) * 1 /
+          Math.sqrt(variance.get(0) + varianceEpsilon),
+      (x.get(1, 0, 0, 1) - mean.get(1)) * 1 /
+          Math.sqrt(variance.get(1) + varianceEpsilon)
+    ]);
+  });
+
+  it('simple batchnorm4D, 2x1x1x2', () => {
+    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const mean = tf.tensor1d([1, 2]);
+    const variance = tf.tensor1d([2, 3]);
+    const offset = tf.tensor1d([3, 4]);
+    const scale = tf.tensor1d([4, 5]);
+
+    const varianceEpsilon = .001;
+
+    const result = tf.batchNormalization4d(
+        x, mean, variance, varianceEpsilon, scale, offset);
+
+    expectArraysClose(result, [
+      offset.get(0) +
+          (x.get(0, 0, 0, 0) - mean.get(0)) * scale.get(0) /
+              Math.sqrt(variance.get(0) + varianceEpsilon),
+      offset.get(1) +
+          (x.get(0, 0, 0, 1) - mean.get(1)) * scale.get(1) /
+              Math.sqrt(variance.get(1) + varianceEpsilon),
+      offset.get(0) +
+          (x.get(1, 0, 0, 0) - mean.get(0)) * scale.get(0) /
+              Math.sqrt(variance.get(0) + varianceEpsilon),
+      offset.get(1) +
+          (x.get(1, 0, 0, 1) - mean.get(1)) * scale.get(1) /
+              Math.sqrt(variance.get(1) + varianceEpsilon)
+    ]);
+  });
+
+  it('batchnorm3D gradients, same shapes in x, mean and variance', () => {
+    const x = tf.tensor3d([10, 20, 30, 40], [2, 1, 2]);
+    const mean = tf.tensor3d([0, 5, 10, 15], [2, 1, 2]);
+    const variance = tf.tensor3d([2, 4, 6, 8], [2, 1, 2]);
+    const scale = tf.tensor3d([2, 5, 2, 5], [2, 1, 2]);
+    const offset = tf.tensor3d([0, 0, 0, 0], [2, 1, 2]);
+
+    const varianceEpsilon = .001;
+
+    const dy = tf.tensor3d([1, 1, 1, 1], [2, 1, 2]);
+    const gradX = tf.grad(
+        (x: tf.Tensor3D) => tf.batchNormalization3d(
+            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+    expectArraysClose(
+        gradX, tf.tensor3d([1.414, 2.500, 0.816, 1.768], [2, 1, 2]));
+    const gradMean = tf.grad(
+        (mean: tf.Tensor3D) => tf.batchNormalization3d(
+            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+    expectArraysClose(
+        gradMean, tf.tensor3d([-1.414, -2.500, -0.816, -1.768], [2, 1, 2]));
+    const gradVariance = tf.grad(
+        (variance: tf.Tensor3D) => tf.batchNormalization3d(
+            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+    expectArraysClose(
+        gradVariance, tf.tensor3d([-3.533, -4.686, -1.360, -2.762], [2, 1, 2]));
+    const gradOffset = tf.grad(
+        (offset: tf.Tensor3D) => tf.batchNormalization3d(
+            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+    expectArraysClose(gradOffset, tf.onesLike(offset));
+    const gradScale = tf.grad(
+        (scale: tf.Tensor3D) => tf.batchNormalization3d(
+            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+    expectArraysClose(
+        gradScale, tf.tensor3d([7.069, 7.499, 8.164, 8.838], [2, 1, 2]));
+  });
+
+  it('batchnorm matches tensorflow, 2x3x3', () => {
+    const x = tf.tensor3d(
+        [
+          0.49955603, 0.04158615, -1.09440524, 2.03854165, -0.61578344,
+          2.87533573, 1.18105987, 0.807462, 1.87888837, 2.26563962, -0.37040935,
+          1.35848753, -0.75347094, 0.15683117, 0.91925946, 0.34121279,
+          0.92717143, 1.89683965
+        ],
+        [2, 3, 3]);
+    const mean = tf.tensor1d([0.39745062, -0.48062894, 0.4847822]);
+    const variance = tf.tensor1d([0.32375343, 0.67117643, 1.08334653]);
+    const offset = tf.tensor1d([0.69398749, -1.29056387, 0.9429723]);
+    const scale = tf.tensor1d([-0.5607271, 0.9878457, 0.25181573]);
+    const varianceEpsilon = .001;
+
+    const result = tf.batchNormalization3d(
+        x, mean, variance, varianceEpsilon, scale, offset);
+
+    expectArraysClose(result, [
+      0.59352049, -0.66135202, 0.5610874, -0.92077015, -1.45341019, 1.52106473,
+      -0.07704776, 0.26144429, 1.28010017, -1.14422404, -1.15776136, 1.15425493,
+      1.82644104, -0.52249442, 1.04803919, 0.74932291, 0.40568101, 1.2844412
+    ]);
+  });
+});
 
 describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
   it('simple batchnorm4D, no offset or scale, 2x1x1x2', () => {

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -33,7 +33,7 @@ describeWithFlags('packed batchNormalization', WEBGL_ENVS, () => {
         webglPackedBatchNormalizationSavedFlag);
   });
 
-  fit('should not leak memory', () => {
+  it('should not leak memory', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tfjs/issues/774

### Changes
- Added packed 1D and 4D input sampling and output coordinate matching to `shaderCompiler`.
- Added support for n-D inputs to `pack_gpu` and `unpack_gpu`.
- Added packed batch normalization kernel.
- Added environment flag `WEBGL_PACK_BATCHNORMALIZATION` (defaults to `false`) which determines whether we use the packed batch normalization kernel. 

**Notes**

1. We've been adding environment flags to hide packed kernels that don't have an obvious performance benefit. In the case of batch normalization, the overhead of repeatedly packing its fixed inputs erases the performance gain from the packed kernel. I created an issue for us to think about uploading such inputs as packed in the first place: https://github.com/tensorflow/tfjs/issues/804.

2. I realize that the unpacked batch normalization kernel uses `get${var}AtOutCoords` rather than managing broadcasting itself. I've created an issue for us to add `get${var}AtOutCoords` support for packed textures: https://github.com/tensorflow/tfjs/issues/803. I think it makes sense as a separate PR.

FEATURE, PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1330)
<!-- Reviewable:end -->
