### PR TITLE
Add subkernel timing information to the Profiler output

### DIFF
--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -252,8 +252,7 @@
         const nameSpan = document.createElement('span');
         nameSpan.setAttribute('title', k.scopes.slice(0, -1).join(' --> '));
         nameSpan.textContent = k.scopes[k.scopes.length - 1];
-        let subKernelsInfo = k.subKernelsInfo;
-        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, subKernelsInfo);
+        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, k.subKernelsInfo);
       });
     }
 

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -252,8 +252,8 @@
         const nameSpan = document.createElement('span');
         nameSpan.setAttribute('title', k.scopes.slice(0, -1).join(' --> '));
         nameSpan.textContent = k.scopes[k.scopes.length - 1];
-        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output);
-        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, k.subKernelsInfo);
+        let subKernelsInfo = k.subKernelsInfo;
+        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, subKernelsInfo);
       });
     }
 
@@ -271,7 +271,8 @@
           kernels.push({
             scopes: scopes,
             time: Number.parseFloat(parts[1]),
-            output: parts[2].trim()
+            output: parts[2].trim(),
+            subKernelsInfo: parts[4]
           });
         }
       }

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -106,7 +106,7 @@
           <th>Kernel</th>
           <th>Time(ms)</th>
           <th>Output</th>
-          <th>Subkernels</th>
+          <th>GPUPrograms</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -252,7 +252,7 @@
         const nameSpan = document.createElement('span');
         nameSpan.setAttribute('title', k.scopes.slice(0, -1).join(' --> '));
         nameSpan.textContent = k.scopes[k.scopes.length - 1];
-        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, k.subKernelsInfo);
+        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, k.gpuProgramsInfo);
       });
     }
 
@@ -271,7 +271,7 @@
             scopes: scopes,
             time: Number.parseFloat(parts[1]),
             output: parts[2].trim(),
-            subKernelsInfo: parts[4]
+            gpuProgramsInfo: parts[4]
           });
         }
       }

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -106,6 +106,7 @@
           <th>Kernel</th>
           <th>Time(ms)</th>
           <th>Output</th>
+          <th>Subkernels</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -252,6 +253,7 @@
         nameSpan.setAttribute('title', k.scopes.slice(0, -1).join(' --> '));
         nameSpan.textContent = k.scopes[k.scopes.length - 1];
         appendRow(tbody, nameSpan, k.time.toFixed(2), k.output);
+        appendRow(tbody, nameSpan, k.time.toFixed(2), k.output, k.subKernelsInfo);
       });
     }
 
@@ -262,14 +264,16 @@
       let kernels = [];
       console.log = msg => {
         const parts = msg.split('\t').map(x => x.slice(2));
-        const scopes = parts[0].trim()
-          .split('||')
-          .filter(s => s !== 'unnamed scope');
-        kernels.push({
-          scopes: scopes,
-          time: Number.parseFloat(parts[1]),
-          output: parts[2].trim()
-        });
+        if(parts.length) {
+          const scopes = parts[0].trim()
+            .split('||')
+            .filter(s => s !== 'unnamed scope');
+          kernels.push({
+            scopes: scopes,
+            time: Number.parseFloat(parts[1]),
+            output: parts[2].trim()
+          });
+        }
       }
       let res = predict(model);
       if (res instanceof Promise) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -63,6 +63,10 @@ export interface TimingInfo extends BackendTimingInfo {
   wallMs: number;
 }
 
+export type SubKernelInfo = {
+  name: string; ms: number;
+};
+
 /** @docalias Function */
 export type ScopeFn<T extends TensorContainer> = () => T;
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {BackendTimingInfo, DataMover, KernelBackend, SubKernelInfo} from './kernels/backend';
+import {BackendTimingInfo, DataMover, KernelBackend} from './kernels/backend';
 import {Profiler} from './profiler';
 import {backpropagateGradients, getFilteredNodesXToY, NamedGradientMap, TapeNode} from './tape';
 import {DataId, Tensor, Tensor3D, Variable} from './tensor';

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {BackendTimingInfo, DataMover, KernelBackend} from './kernels/backend';
+import {BackendTimingInfo, DataMover, KernelBackend, SubKernelInfo} from './kernels/backend';
 import {Profiler} from './profiler';
 import {backpropagateGradients, getFilteredNodesXToY, NamedGradientMap, TapeNode} from './tape';
 import {DataId, Tensor, Tensor3D, Variable} from './tensor';
@@ -62,10 +62,6 @@ export type ProfileInfo = {
 export interface TimingInfo extends BackendTimingInfo {
   wallMs: number;
 }
-
-export type SubKernelInfo = {
-  name: string; ms: number;
-};
 
 /** @docalias Function */
 export type ScopeFn<T extends TensorContainer> = () => T;

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -22,6 +22,8 @@ import {DataType, Rank, ShapeMap, TypedArray} from '../types';
 // Required information for all backends.
 export interface BackendTimingInfo {
   kernelMs: number;
+  getExtraProfileInfo?(): string;  // a field for additional timing information
+                                   // e.g. packing / unpacking for WebGL backend
 }
 
 export interface TensorStorage {

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {SubKernelInfo} from '../engine';
 import {Conv2DInfo} from '../ops/conv_util';
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {DataType, Rank, ShapeMap, TypedArray} from '../types';
@@ -22,8 +23,9 @@ import {DataType, Rank, ShapeMap, TypedArray} from '../types';
 // Required information for all backends.
 export interface BackendTimingInfo {
   kernelMs: number;
-  subKernelsInfo?: string;  // a field for additional timing information about
-                            // subkernels, e.g. packing / unpacking
+  subKernelsInfo?:
+      SubKernelInfo[];  // a field for additional timing information
+                        // about subkernels, e.g. packing / unpacking
 }
 
 export interface TensorStorage {

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -22,6 +22,8 @@ import {DataType, Rank, ShapeMap, TypedArray} from '../types';
 // Required information for all backends.
 export interface BackendTimingInfo {
   kernelMs: number;
+  subKernelsInfo?: string;  // a field for additional timing information about
+                            // subkernels, e.g. packing / unpacking
 }
 
 export interface TensorStorage {

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -15,10 +15,13 @@
  * =============================================================================
  */
 
-import {SubKernelInfo} from '../engine';
 import {Conv2DInfo} from '../ops/conv_util';
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {DataType, Rank, ShapeMap, TypedArray} from '../types';
+
+export type SubKernelInfo = {
+  name: string; ms: number;
+};
 
 // Required information for all backends.
 export interface BackendTimingInfo {

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -19,16 +19,9 @@ import {Conv2DInfo} from '../ops/conv_util';
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {DataType, Rank, ShapeMap, TypedArray} from '../types';
 
-export type SubKernelInfo = {
-  name: string; ms: number;
-};
-
 // Required information for all backends.
 export interface BackendTimingInfo {
   kernelMs: number;
-  subKernelsInfo?:
-      SubKernelInfo[];  // a field for additional timing information
-                        // about subkernels, e.g. packing / unpacking
 }
 
 export interface TensorStorage {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -385,9 +385,10 @@ export class MathBackendWebGL implements KernelBackend {
     f();
 
     const flattenedActiveTimerQueries =
-        util.flatten(this.activeTimers.map(d => d.query));
+        util.flatten(this.activeTimers.map(d => d.query))
+            .filter(util.isDefined);
     const flattenedActiveTimerNames =
-        util.flatten(this.activeTimers.map(d => d.name));
+        util.flatten(this.activeTimers.map(d => d.name)).filter(util.isDefined);
     this.activeTimers = oldActiveTimers;
 
     if (outerMostTime) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -116,9 +116,16 @@ export interface WebGLMemoryInfo extends MemoryInfo {
   unreliable: boolean;
 }
 
+export type SubKernelInfo = {
+  name: string; ms: number;
+};
+
 export interface WebGLTimingInfo extends TimingInfo {
   uploadWaitMs: number;
   downloadWaitMs: number;
+  subKernelsInfo?:
+      SubKernelInfo[];  // a field for additional timing information
+                        // about subkernels, e.g. packing / unpacking
 }
 
 // Combines a dataId, a shape, and a dtype without a Tensor object so that

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -385,10 +385,10 @@ export class MathBackendWebGL implements KernelBackend {
     f();
 
     // needing to split these up because util.flatten only accepts certain types
-    const flattenedActiveTimerQueries: Promise<number>[] =
+    const flattenedActiveTimerQueries =
         util.flatten(this.activeTimers.map((d: KernelInfo) => d.query))
             .filter(util.isDefined);
-    const flattenedActiveTimerNames: string[] =
+    const flattenedActiveTimerNames =
         util.flatten(this.activeTimers.map((d: KernelInfo) => d.name))
             .filter(util.isDefined);
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -101,8 +101,8 @@ import * as webgl_util from './webgl/webgl_util';
 import {whereImpl} from './where_impl';
 
 type KernelInfo = {
-  name: string; query: Promise<number>
-}
+  name: string; query: Promise<number>;
+};
 
 export type TimerNode = RecursiveArray<KernelInfo>|KernelInfo;
 export interface CPUTimerQuery {
@@ -369,6 +369,18 @@ export class MathBackendWebGL implements KernelBackend {
     return vals;
   }
 
+  private flattenTimers(timers: TimerNode, ret: KernelInfo[] = []):
+      KernelInfo[] {
+    if (Array.isArray(timers)) {
+      for (let i = 0; i < timers.length; ++i) {
+        this.flattenTimers(timers[i], ret);
+      }
+    } else {
+      ret.push(timers as T);
+    }
+    return ret;
+  }
+
   async time(f: () => void): Promise<WebGLTimingInfo> {
     const oldActiveTimers = this.activeTimers;
     const newActiveTimers: TimerNode[] = [];
@@ -384,7 +396,7 @@ export class MathBackendWebGL implements KernelBackend {
 
     f();
 
-    const flattenedActiveTimers = util.flatten(this.activeTimers);
+    const flattenedActiveTimers = this.flattenTimers(this.activeTimers);
     this.activeTimers = oldActiveTimers;
 
     if (outerMostTime) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -125,7 +125,7 @@ export interface WebGLTimingInfo extends TimingInfo {
   downloadWaitMs: number;
   gpuProgramsInfo?:
       GPUProgramsInfo[];  // a field for additional timing information
-                          // about subkernels, e.g. packing / unpacking
+                          // about GPU programs, e.g. packing / unpacking
 }
 
 // Combines a dataId, a shape, and a dtype without a Tensor object so that

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -100,7 +100,12 @@ import {UnpackProgram} from './webgl/unpack_gpu';
 import * as webgl_util from './webgl/webgl_util';
 import {whereImpl} from './where_impl';
 
-type TimerNode = RecursiveArray<Promise<number>>|Promise<number>;
+interface KernelInfo {
+  name: string;
+  query: Promise<number>
+}
+
+export type TimerNode = RecursiveArray<KernelInfo>|KernelInfo;
 export interface CPUTimerQuery {
   startMs: number;
   endMs?: number;
@@ -387,7 +392,9 @@ export class MathBackendWebGL implements KernelBackend {
       this.programTimersStack = null;
     }
 
-    const kernelMs = await Promise.all(flattenedActiveTimers.map(d => d.query));
+    const kernelMs =
+        await Promise.all(flattenedActiveTimers.map((d) => d.query));
+
     const res: WebGLTimingInfo = {
       uploadWaitMs: this.uploadWaitMs,
       downloadWaitMs: this.downloadWaitMs,

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -116,16 +116,16 @@ export interface WebGLMemoryInfo extends MemoryInfo {
   unreliable: boolean;
 }
 
-export type SubKernelInfo = {
+export type GPUProgramsInfo = {
   name: string; ms: number;
 };
 
 export interface WebGLTimingInfo extends TimingInfo {
   uploadWaitMs: number;
   downloadWaitMs: number;
-  subKernelsInfo?:
-      SubKernelInfo[];  // a field for additional timing information
-                        // about subkernels, e.g. packing / unpacking
+  gpuProgramsInfo?:
+      GPUProgramsInfo[];  // a field for additional timing information
+                          // about subkernels, e.g. packing / unpacking
 }
 
 // Combines a dataId, a shape, and a dtype without a Tensor object so that
@@ -416,7 +416,7 @@ export class MathBackendWebGL implements KernelBackend {
       uploadWaitMs: this.uploadWaitMs,
       downloadWaitMs: this.downloadWaitMs,
       kernelMs: util.sum(kernelMs),
-      subKernelsInfo:
+      gpuProgramsInfo:
           kernelMs.map((d, i) => ({name: flattenedActiveTimerNames[i], ms: d})),
       wallMs: null  // will be filled by the engine
     };

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -384,6 +384,7 @@ export class MathBackendWebGL implements KernelBackend {
 
     f();
 
+    // needing to split these up because util.flatten only accepts certain types
     const flattenedActiveTimerQueries: Promise<number>[] =
         util.flatten(this.activeTimers.map((d: KernelInfo) => d.query))
             .filter(util.isDefined);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1814,10 +1814,17 @@ export class MathBackendWebGL implements KernelBackend {
     const newTexture = this.acquireTexture(dataId, texShape, usage, isPacked);
     texData.texture = newTexture;
     if (values != null) {
-      this.gpgpu.uploadMatrixToTexture(
-          newTexture, texShape[0],
-          // TODO(smilkov): Propagate the original typed array to gpgpu.
-          texShape[1], typedArrayToFloat32(values, dtype));
+      // TODO(smilkov): Propagate the original typed array to gpgpu.
+      if (isPacked) {
+        const batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+        this.gpgpu.uploadMatrixToPackedTexture(
+            newTexture, batch, texShape[0], texShape[1],
+            typedArrayToFloat32(values, dtype));
+      } else {
+        this.gpgpu.uploadMatrixToTexture(
+            newTexture, texShape[0], texShape[1],
+            typedArrayToFloat32(values, dtype));
+      }
       // Once uploaded, don't store the values on cpu.
       texData.values = null;
       if (shouldTimeProgram) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1817,8 +1817,10 @@ export class MathBackendWebGL implements KernelBackend {
       // TODO(smilkov): Propagate the original typed array to gpgpu.
       if (isPacked) {
         const batch = util.sizeFromShape(shape.slice(0, shape.length - 2));
+        const rows = shape.length > 1 ? shape[shape.length - 2] : 1;
+        const cols = shape[shape.length - 1];
         this.gpgpu.uploadMatrixToPackedTexture(
-            newTexture, batch, texShape[0], texShape[1],
+            newTexture, batch, rows, cols,
             typedArrayToFloat32(values, dtype));
       } else {
         this.gpgpu.uploadMatrixToTexture(

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -388,10 +388,10 @@ export class MathBackendWebGL implements KernelBackend {
     // needing to split these up because util.flatten only accepts certain types
     const flattenedActiveTimerQueries =
         util.flatten(this.activeTimers.map((d: KernelInfo) => d.query))
-            .filter(util.isDefined);
+            .filter(d => d != null);
     const flattenedActiveTimerNames =
         util.flatten(this.activeTimers.map((d: KernelInfo) => d.name))
-            .filter(util.isDefined);
+            .filter(d => d != null);
 
     this.activeTimers = oldActiveTimers;
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -384,11 +384,13 @@ export class MathBackendWebGL implements KernelBackend {
 
     f();
 
-    const flattenedActiveTimerQueries =
-        util.flatten(this.activeTimers.map(d => d.query))
+    const flattenedActiveTimerQueries: Promise<number>[] =
+        util.flatten(this.activeTimers.map((d: KernelInfo) => d.query))
             .filter(util.isDefined);
-    const flattenedActiveTimerNames =
-        util.flatten(this.activeTimers.map(d => d.name)).filter(util.isDefined);
+    const flattenedActiveTimerNames: string[] =
+        util.flatten(this.activeTimers.map((d: KernelInfo) => d.name))
+            .filter(util.isDefined);
+
     this.activeTimers = oldActiveTimers;
 
     if (outerMostTime) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -100,9 +100,8 @@ import {UnpackProgram} from './webgl/unpack_gpu';
 import * as webgl_util from './webgl/webgl_util';
 import {whereImpl} from './where_impl';
 
-interface KernelInfo {
-  name: string;
-  query: Promise<number>
+type KernelInfo = {
+  name: string; query: Promise<number>
 }
 
 export type TimerNode = RecursiveArray<KernelInfo>|KernelInfo;
@@ -399,10 +398,8 @@ export class MathBackendWebGL implements KernelBackend {
       uploadWaitMs: this.uploadWaitMs,
       downloadWaitMs: this.downloadWaitMs,
       kernelMs: util.sum(kernelMs),
-      subKernelsInfo:
-          kernelMs
-              .map((d, i) => `name: ${flattenedActiveTimers[i].name}, ms: ${d}`)
-              .join(', '),
+      subKernelsInfo: kernelMs.map(
+          (d, i) => ({name: flattenedActiveTimers[i].name, ms: d})),
       wallMs: null  // will be filled by the engine
     };
     this.uploadWaitMs = 0;

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -16,6 +16,7 @@
  */
 
 import {BackendTimer, SubKernelInfo} from './kernels/backend';
+import {GPUProgramsInfo} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
 import {TypedArray} from './types';
 import * as util from './util';
@@ -43,7 +44,7 @@ export class Profiler {
 
       timer.then(timing => {
         this.logger.logKernelProfile(
-            name, r, vals, timing.kernelMs, timing.subKernelsInfo);
+            name, r, vals, timing.kernelMs, timing.gpuProgramsInfo);
       });
     });
 
@@ -54,19 +55,20 @@ export class Profiler {
 export class Logger {
   logKernelProfile(
       name: string, result: Tensor, vals: TypedArray, timeMs: number,
-      subKernels?: SubKernelInfo[]) {
+      gpuProgramsInfo?: GPUProgramsInfo[]) {
     const time = util.rightPad(`${timeMs}ms`, 9);
     const paddedName = util.rightPad(name, 25);
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
-    const subKernelsDescription = subKernels != null && subKernels.length > 1 ?
-        subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') :
+    const gpuProgramsDescription =
+        gpuProgramsInfo != null && gpuProgramsInfo.length > 1 ?
+        gpuProgramsInfo.map(d => `${d.name}: ${d.ms}`).join(', ') :
         '';
 
     console.log(
         `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}\t%c${
-            subKernelsDescription}`,
+            gpuProgramsDescription}`,
         'font-weight:bold', 'color:red', 'color:blue', 'color: orange',
         'color: green');
   }

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -60,8 +60,9 @@ export class Logger {
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
-    const subKernelsDescription =
-        subKernels ? subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') : '';
+    const subKernelsDescription = subKernels.length > 1 ?
+        subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') :
+        '';
 
     console.log(
         `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}\t%c${

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-import {SubKernelInfo} from '../engine';
-import {BackendTimer} from './kernels/backend';
+import {BackendTimer, SubKernelInfo} from './kernels/backend';
 import {Tensor} from './tensor';
 import {TypedArray} from './types';
 import * as util from './util';

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {SubKernelInfo} from '../engine';
 import {BackendTimer} from './kernels/backend';
 import {Tensor} from './tensor';
 import {TypedArray} from './types';
@@ -54,15 +55,18 @@ export class Profiler {
 export class Logger {
   logKernelProfile(
       name: string, result: Tensor, vals: TypedArray, timeMs: number,
-      subKernels?: string) {
+      subKernels?: SubKernelInfo[]) {
     const time = util.rightPad(`${timeMs}ms`, 9);
     const paddedName = util.rightPad(name, 25);
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
+    const subKernelsDescription =
+        subKernels ? subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') : '';
+
     console.log(
         `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}\t%c${
-            subKernels}`,
+            subKernelsDescription}`,
         'font-weight:bold', 'color:red', 'color:blue', 'color: orange',
         'color: green');
   }

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {BackendTimer, SubKernelInfo} from './kernels/backend';
-import {GPUProgramsInfo} from './kernels/backend_webgl';
+import {BackendTimer} from './kernels/backend';
+import {GPUProgramsInfo, WebGLTimingInfo} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
 import {TypedArray} from './types';
 import * as util from './util';
@@ -44,7 +44,8 @@ export class Profiler {
 
       timer.then(timing => {
         this.logger.logKernelProfile(
-            name, r, vals, timing.kernelMs, timing.gpuProgramsInfo);
+            name, r, vals, timing.kernelMs,
+            (timing as WebGLTimingInfo).gpuProgramsInfo);
       });
     });
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -43,7 +43,7 @@ export class Profiler {
 
       timer.then(timing => {
         let extraInfo = '';
-        if (timing.getExtraProfileInfo) {
+        if (timing.getExtraProfileInfo != null) {
           extraInfo = timing.getExtraProfileInfo();
         }
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -16,7 +16,6 @@
  */
 
 import {BackendTimer} from './kernels/backend';
-import {GPUProgramsInfo, WebGLTimingInfo} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
 import {TypedArray} from './types';
 import * as util from './util';
@@ -44,8 +43,7 @@ export class Profiler {
 
       timer.then(timing => {
         this.logger.logKernelProfile(
-            name, r, vals, timing.kernelMs,
-            (timing as WebGLTimingInfo).gpuProgramsInfo);
+            name, r, vals, timing.kernelMs, timing.getExtraProfileInfo());
       });
     });
 
@@ -56,20 +54,16 @@ export class Profiler {
 export class Logger {
   logKernelProfile(
       name: string, result: Tensor, vals: TypedArray, timeMs: number,
-      gpuProgramsInfo?: GPUProgramsInfo[]) {
+      extraInfo?: string) {
     const time = util.rightPad(`${timeMs}ms`, 9);
     const paddedName = util.rightPad(name, 25);
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
-    const gpuProgramsDescription =
-        gpuProgramsInfo != null && gpuProgramsInfo.length > 1 ?
-        gpuProgramsInfo.map(d => `${d.name}: ${d.ms}`).join(', ') :
-        '';
 
     console.log(
         `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}\t%c${
-            gpuProgramsDescription}`,
+            extraInfo}`,
         'font-weight:bold', 'color:red', 'color:blue', 'color: orange',
         'color: green');
   }

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -60,7 +60,7 @@ export class Logger {
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
-    const subKernelsDescription = subKernels && subKernels.length > 1 ?
+    const subKernelsDescription = subKernels != null && subKernels.length > 1 ?
         subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') :
         '';
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -60,7 +60,7 @@ export class Logger {
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
-    const subKernelsDescription = subKernels.length > 1 ?
+    const subKernelsDescription = subKernels && subKernels.length > 1 ?
         subKernels.map(d => `${d.name}: ${d.ms}`).join(', ') :
         '';
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -42,8 +42,12 @@ export class Profiler {
       util.checkComputationForNaN(vals, r.dtype, name);
 
       timer.then(timing => {
-        this.logger.logKernelProfile(
-            name, r, vals, timing.kernelMs, timing.getExtraProfileInfo());
+        let extraInfo = '';
+        if (timing.getExtraProfileInfo) {
+          extraInfo = timing.getExtraProfileInfo();
+        }
+
+        this.logger.logKernelProfile(name, r, vals, timing.kernelMs, extraInfo);
       });
     });
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -42,7 +42,8 @@ export class Profiler {
       util.checkComputationForNaN(vals, r.dtype, name);
 
       timer.then(timing => {
-        this.logger.logKernelProfile(name, r, vals, timing.kernelMs);
+        this.logger.logKernelProfile(
+            name, r, vals, timing.kernelMs, timing.subKernelsInfo);
       });
     });
 
@@ -52,14 +53,17 @@ export class Profiler {
 
 export class Logger {
   logKernelProfile(
-      name: string, result: Tensor, vals: TypedArray, timeMs: number) {
+      name: string, result: Tensor, vals: TypedArray, timeMs: number,
+      subKernels?: string) {
     const time = util.rightPad(`${timeMs}ms`, 9);
     const paddedName = util.rightPad(name, 25);
     const rank = result.rank;
     const size = result.size;
     const shape = util.rightPad(result.shape.toString(), 14);
     console.log(
-        `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}`,
-        'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+        `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}\t%c${
+            subKernels}`,
+        'font-weight:bold', 'color:red', 'color:blue', 'color: orange',
+        'color: green');
   }
 }

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -71,7 +71,8 @@ describe('profiler.Profiler', () => {
       expect(logKernelProfileSpy.calls.count()).toBe(1);
 
       expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs,
+        undefined
       ]);
 
       expect(kernelCalled).toBe(true);
@@ -110,10 +111,11 @@ describe('profiler.Profiler', () => {
 
       expect(logKernelProfileSpy.calls.count()).toBe(2);
       expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'Max', resultScalar, new Float32Array([result]), queryTimeMs
+        'Max', resultScalar, new Float32Array([result]), queryTimeMs, undefined
       ]);
       expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2,
+        undefined
       ]);
 
       expect(matmulKernelCalled).toBe(true);
@@ -150,7 +152,7 @@ class TestWebGLLogger extends Logger {
       gpuProgramsInfo?: GPUProgramsInfo[]) {}
 }
 
-describeWithFlags('profiler.Profiler', WEBGL_ENVS, () => {
+describeWithFlags('webgl profiler.Profiler', WEBGL_ENVS, () => {
   it('profiles simple function', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -16,13 +16,10 @@
  */
 
 import * as tf from './index';
-import {describeWithFlags} from './jasmine_util';
 import {BackendTimer, BackendTimingInfo} from './kernels/backend';
-import {GPUProgramsInfo, WebGLTimingInfo} from './kernels/backend_webgl';
 import {TypedArray} from './kernels/webgl/tex_util';
 import {Logger, Profiler} from './profiler';
 import {Tensor} from './tensor';
-import {WEBGL_ENVS} from './test_util';
 
 class TestBackendTimer implements BackendTimer {
   private counter = 1;
@@ -120,74 +117,6 @@ describe('profiler.Profiler', () => {
 
       expect(matmulKernelCalled).toBe(true);
       expect(maxKernelCalled).toBe(true);
-      doneFn();
-    }, delayMs * 2);
-  });
-});
-
-class TestBackendWebGLTimer implements BackendTimer {
-  private counter = 1;
-  constructor(
-      private delayMs: number, private queryTimeMs: number,
-      private gpuProgramsInfo: GPUProgramsInfo[]) {}
-
-  async time(query: () => void): Promise<WebGLTimingInfo> {
-    query();
-    const kernelMs = await new Promise<number>(
-        resolve => setTimeout(
-            resolve(this.queryTimeMs * this.counter++), this.delayMs));
-    return {
-      uploadWaitMs: 0,
-      downloadWaitMs: 0,
-      wallMs: 0,
-      kernelMs,
-      gpuProgramsInfo: this.gpuProgramsInfo
-    };
-  }
-}
-
-class TestWebGLLogger extends Logger {
-  logKernelProfile(
-      name: string, result: Tensor, vals: TypedArray, timeMs: number,
-      gpuProgramsInfo?: GPUProgramsInfo[]) {}
-}
-
-describeWithFlags('webgl profiler.Profiler', WEBGL_ENVS, () => {
-  it('profiles simple function', doneFn => {
-    const delayMs = 5;
-    const queryTimeMs = 10;
-    const gpuProgramsInfo = [{name: '', ms: 0}];
-    const timer =
-        new TestBackendWebGLTimer(delayMs, queryTimeMs, gpuProgramsInfo);
-    const logger = new TestWebGLLogger();
-    const profiler = new Profiler(timer, logger);
-
-    spyOn(timer, 'time').and.callThrough();
-    spyOn(logger, 'logKernelProfile').and.callThrough();
-
-    const timeSpy = timer.time as jasmine.Spy;
-    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
-
-    let kernelCalled = false;
-    const result = 1;
-    const resultScalar = tf.scalar(result);
-
-    profiler.profileKernel('MatMul', () => {
-      kernelCalled = true;
-      return resultScalar;
-    });
-
-    setTimeout(() => {
-      expect(timeSpy.calls.count()).toBe(1);
-
-      expect(logKernelProfileSpy.calls.count()).toBe(1);
-
-      expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs,
-        gpuProgramsInfo
-      ]);
-
-      expect(kernelCalled).toBe(true);
       doneFn();
     }, delayMs * 2);
   });

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -67,7 +67,8 @@ describe('profiler.Profiler', () => {
 
       expect(logKernelProfileSpy.calls.count()).toBe(1);
       expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs,
+        undefined
       ]);
 
       expect(kernelCalled).toBe(true);
@@ -106,10 +107,11 @@ describe('profiler.Profiler', () => {
 
       expect(logKernelProfileSpy.calls.count()).toBe(2);
       expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'Max', resultScalar, new Float32Array([result]), queryTimeMs
+        'Max', resultScalar, new Float32Array([result]), queryTimeMs, undefined
       ]);
       expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2,
+        undefined
       ]);
 
       expect(matmulKernelCalled).toBe(true);

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -23,14 +23,16 @@ import {Tensor} from './tensor';
 
 class TestBackendTimer implements BackendTimer {
   private counter = 1;
-  constructor(private delayMs: number, private queryTimeMs: number) {}
+  constructor(
+      private delayMs: number, private queryTimeMs: number,
+      private extraInfo: string) {}
 
   async time(query: () => void): Promise<BackendTimingInfo> {
     query();
     const kernelMs = await new Promise<number>(
         resolve => setTimeout(
             resolve(this.queryTimeMs * this.counter++), this.delayMs));
-    return {kernelMs};
+    return {kernelMs, getExtraProfileInfo: () => this.extraInfo};
   }
 }
 
@@ -43,7 +45,8 @@ describe('profiler.Profiler', () => {
   it('profiles simple function', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;
-    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const extraInfo = '';
+    const timer = new TestBackendTimer(delayMs, queryTimeMs, extraInfo);
     const logger = new TestLogger();
     const profiler = new Profiler(timer, logger);
 
@@ -69,7 +72,7 @@ describe('profiler.Profiler', () => {
 
       expect(logKernelProfileSpy.calls.first().args).toEqual([
         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs,
-        undefined
+        extraInfo
       ]);
 
       expect(kernelCalled).toBe(true);
@@ -80,7 +83,8 @@ describe('profiler.Profiler', () => {
   it('profiles nested kernel', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;
-    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const extraInfo = '';
+    const timer = new TestBackendTimer(delayMs, queryTimeMs, extraInfo);
     const logger = new TestLogger();
     const profiler = new Profiler(timer, logger);
 
@@ -108,11 +112,11 @@ describe('profiler.Profiler', () => {
 
       expect(logKernelProfileSpy.calls.count()).toBe(2);
       expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'Max', resultScalar, new Float32Array([result]), queryTimeMs, undefined
+        'Max', resultScalar, new Float32Array([result]), queryTimeMs, extraInfo
       ]);
       expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2,
-        undefined
+        extraInfo
       ]);
 
       expect(matmulKernelCalled).toBe(true);

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -44,7 +44,7 @@ class TestLogger extends Logger {
 }
 
 describe('profiler.Profiler', () => {
-  fit('profiles simple function', doneFn => {
+  it('profiles simple function', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;
     const subKernels = [{name: '', ms: 0}];
@@ -82,7 +82,7 @@ describe('profiler.Profiler', () => {
     }, delayMs * 2);
   });
 
-  fit('profiles nested kernel', doneFn => {
+  it('profiles nested kernel', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;
     const subKernels = [{name: '', ms: 0}];

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -15,14 +15,116 @@
  * =============================================================================
  */
 
+import {describeWithFlags} from '../jasmine_util';
+import {WEBGL_ENVS} from '../test_util';
+
 import * as tf from './index';
 import {BackendTimer, BackendTimingInfo} from './kernels/backend';
-import {GPUProgramsInfo} from './kernels/backend_webgl';
+import {GPUProgramsInfo, WebGLTimingInfo} from './kernels/backend_webgl';
 import {TypedArray} from './kernels/webgl/tex_util';
 import {Logger, Profiler} from './profiler';
 import {Tensor} from './tensor';
 
 class TestBackendTimer implements BackendTimer {
+  private counter = 1;
+  constructor(private delayMs: number, private queryTimeMs: number) {}
+
+  async time(query: () => void): Promise<BackendTimingInfo> {
+    query();
+    const kernelMs = await new Promise<number>(
+        resolve => setTimeout(
+            resolve(this.queryTimeMs * this.counter++), this.delayMs));
+    return {kernelMs};
+  }
+}
+
+class TestLogger extends Logger {
+  logKernelProfile(
+      name: string, result: Tensor, vals: TypedArray, timeMs: number) {}
+}
+
+describe('profiler.Profiler', () => {
+  it('profiles simple function', doneFn => {
+    const delayMs = 5;
+    const queryTimeMs = 10;
+    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const logger = new TestLogger();
+    const profiler = new Profiler(timer, logger);
+
+    spyOn(timer, 'time').and.callThrough();
+    spyOn(logger, 'logKernelProfile').and.callThrough();
+
+    const timeSpy = timer.time as jasmine.Spy;
+    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
+
+    let kernelCalled = false;
+    const result = 1;
+    const resultScalar = tf.scalar(result);
+
+    profiler.profileKernel('MatMul', () => {
+      kernelCalled = true;
+      return resultScalar;
+    });
+
+    setTimeout(() => {
+      expect(timeSpy.calls.count()).toBe(1);
+
+      expect(logKernelProfileSpy.calls.count()).toBe(1);
+
+      expect(logKernelProfileSpy.calls.first().args).toEqual([
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+      ]);
+
+      expect(kernelCalled).toBe(true);
+      doneFn();
+    }, delayMs * 2);
+  });
+
+  it('profiles nested kernel', doneFn => {
+    const delayMs = 5;
+    const queryTimeMs = 10;
+    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const logger = new TestLogger();
+    const profiler = new Profiler(timer, logger);
+
+    spyOn(timer, 'time').and.callThrough();
+    spyOn(logger, 'logKernelProfile').and.callThrough();
+    const timeSpy = timer.time as jasmine.Spy;
+    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
+
+    let matmulKernelCalled = false;
+    let maxKernelCalled = false;
+    const result = 1;
+    const resultScalar = tf.scalar(result);
+
+    profiler.profileKernel('MatMul', () => {
+      const result = profiler.profileKernel('Max', () => {
+        maxKernelCalled = true;
+        return resultScalar;
+      });
+      matmulKernelCalled = true;
+      return result;
+    });
+
+    setTimeout(() => {
+      expect(timeSpy.calls.count()).toBe(2);
+
+      expect(logKernelProfileSpy.calls.count()).toBe(2);
+      expect(logKernelProfileSpy.calls.first().args).toEqual([
+        'Max', resultScalar, new Float32Array([result]), queryTimeMs
+      ]);
+      expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2
+      ]);
+
+      expect(matmulKernelCalled).toBe(true);
+      expect(maxKernelCalled).toBe(true);
+      doneFn();
+    }, delayMs * 2);
+  });
+});
+
+class TestBackendWebGLTimer implements BackendTimer {
   private counter = 1;
   constructor(
       private delayMs: number, private queryTimeMs: number,
@@ -43,7 +145,7 @@ class TestLogger extends Logger {
       gpuProgramsInfo?: GPUProgramsInfo[]) {}
 }
 
-describe('profiler.Profiler', () => {
+describeWithFlags('profiler.Profiler', WEBGL_ENVS, () => {
   it('profiles simple function', doneFn => {
     const delayMs = 5;
     const queryTimeMs = 10;
@@ -78,52 +180,6 @@ describe('profiler.Profiler', () => {
       ]);
 
       expect(kernelCalled).toBe(true);
-      doneFn();
-    }, delayMs * 2);
-  });
-
-  it('profiles nested kernel', doneFn => {
-    const delayMs = 5;
-    const queryTimeMs = 10;
-    const gpuProgramsInfo = [{name: '', ms: 0}];
-    const timer = new TestBackendTimer(delayMs, queryTimeMs, gpuProgramsInfo);
-    const logger = new TestLogger();
-    const profiler = new Profiler(timer, logger);
-
-    spyOn(timer, 'time').and.callThrough();
-    spyOn(logger, 'logKernelProfile').and.callThrough();
-    const timeSpy = timer.time as jasmine.Spy;
-    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
-
-    let matmulKernelCalled = false;
-    let maxKernelCalled = false;
-    const result = 1;
-    const resultScalar = tf.scalar(result);
-
-    profiler.profileKernel('MatMul', () => {
-      const result = profiler.profileKernel('Max', () => {
-        maxKernelCalled = true;
-        return resultScalar;
-      });
-      matmulKernelCalled = true;
-      return result;
-    });
-
-    setTimeout(() => {
-      expect(timeSpy.calls.count()).toBe(2);
-
-      expect(logKernelProfileSpy.calls.count()).toBe(2);
-      expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'Max', resultScalar, new Float32Array([result]), queryTimeMs,
-        gpuProgramsInfo
-      ]);
-      expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2,
-        gpuProgramsInfo
-      ]);
-
-      expect(matmulKernelCalled).toBe(true);
-      expect(maxKernelCalled).toBe(true);
       doneFn();
     }, delayMs * 2);
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-import {TimerNode} from './kernels/backend_webgl';
 import {ArrayData, DataType, DataTypeMap, FlatVector, RecursiveArray, RegularArray, TensorLike, TypedArray} from './types';
-
 
 /** Shuffles the array using Fisher-Yates algorithm. */
 // tslint:disable-next-line:no-any
@@ -100,7 +98,7 @@ export function assertNonNull(a: TensorLike): void {
 // NOTE: We explicitly type out what T extends instead of any so that
 // util.flatten on a nested array of number doesn't try to infer T as a
 // number[][], causing us to explicitly type util.flatten<number>().
-export function flatten<T extends number|boolean|Promise<number>|TimerNode>(
+export function flatten<T extends number|boolean|Promise<number>>(
     arr: T|RecursiveArray<T>, ret: T[] = []): T[] {
   if (Array.isArray(arr)) {
     for (let i = 0; i < arr.length; ++i) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,11 +54,6 @@ export function sum(arr: number[]): number {
   return sum;
 }
 
-// tslint:disable-next-line:no-any
-export function isDefined(val: any): boolean {
-  return typeof val !== 'undefined';
-}
-
 /**
  * Returns a sample from a uniform [a, b) distribution.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,7 +98,7 @@ export function assertNonNull(a: TensorLike): void {
 // NOTE: We explicitly type out what T extends instead of any so that
 // util.flatten on a nested array of number doesn't try to infer T as a
 // number[][], causing us to explicitly type util.flatten<number>().
-export function flatten<T extends number|boolean|Promise<number>>(
+export function flatten<T extends number|boolean|Promise<number>|string>(
     arr: T|RecursiveArray<T>, ret: T[] = []): T[] {
   if (Array.isArray(arr)) {
     for (let i = 0; i < arr.length; ++i) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,6 +46,14 @@ export function nearestLargerEven(val: number): number {
   return val % 2 === 0 ? val : val + 1;
 }
 
+export function sum(arr: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < arr.length; i++) {
+    sum += arr[i];
+  }
+  return sum;
+}
+
 /**
  * Returns a sample from a uniform [a, b) distribution.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,9 @@
  * =============================================================================
  */
 
+import {TimerNode} from './kernels/backend_webgl';
 import {ArrayData, DataType, DataTypeMap, FlatVector, RecursiveArray, RegularArray, TensorLike, TypedArray} from './types';
+
 
 /** Shuffles the array using Fisher-Yates algorithm. */
 // tslint:disable-next-line:no-any
@@ -98,7 +100,7 @@ export function assertNonNull(a: TensorLike): void {
 // NOTE: We explicitly type out what T extends instead of any so that
 // util.flatten on a nested array of number doesn't try to infer T as a
 // number[][], causing us to explicitly type util.flatten<number>().
-export function flatten<T extends number|boolean|Promise<number>>(
+export function flatten<T extends number|boolean|Promise<number>|TimerNode>(
     arr: T|RecursiveArray<T>, ret: T[] = []): T[] {
   if (Array.isArray(arr)) {
     for (let i = 0; i < arr.length; ++i) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,6 +54,11 @@ export function sum(arr: number[]): number {
   return sum;
 }
 
+// tslint:disable-next-line:no-any
+export function isDefined(val: any): boolean {
+  return typeof val !== 'undefined';
+}
+
 /**
  * Returns a sample from a uniform [a, b) distribution.
  *


### PR DESCRIPTION
This PR addresses the issue https://github.com/tensorflow/tfjs/issues/809

This is what the profile of `matMul` will look like:

`matMul 0.422ms	3D 1,3,5   15	PackProgram: 0.332, PackProgram: 0.046, MatMulPackedProgram: 0.025, UnpackProgram: 0.019`

### Changes
- Add subKernel timing information to the Profiler so when `DEBUG` is true, the user will see, for example, not only how long `matMul` took to execute but also how much of that time was spent on `pack` / `unpack`
- Also update the standalone benchmarking page to report subkernel timing info

FEATURE

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1334)
<!-- Reviewable:end -->
