### PR TITLE
Add tf.ifft().

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -282,6 +282,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
       iouThreshold: number, scoreThreshold?: number): Tensor1D;
 
   fft(x: Tensor2D): Tensor2D;
+  ifft(x: Tensor2D): Tensor2D;
   complex<T extends Tensor>(real: T, imag: T): T;
   real<T extends Tensor>(input: T): T;
   imag<T extends Tensor>(input: T): T;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1586,10 +1586,22 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   fft(x: Tensor2D): Tensor2D {
+    const inverse = false;
+    return this.fftImpl(x, inverse);
+  }
+
+  ifft(x: Tensor2D): Tensor2D {
+    const inverse = true;
+    return this.fftImpl(x, inverse);
+  }
+
+  private fftImpl(x: Tensor2D, inverse: boolean): Tensor2D {
     const xData = this.texData.get(x.dataId);
 
-    const realProgram = new FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape);
-    const imagProgram = new FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape);
+    const realProgram =
+        new FFTProgram(fft_gpu.COMPLEX_FFT.REAL, x.shape, inverse);
+    const imagProgram =
+        new FFTProgram(fft_gpu.COMPLEX_FFT.IMAG, x.shape, inverse);
     const inputs = [
       this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
       this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),

--- a/src/kernels/complex_util.ts
+++ b/src/kernels/complex_util.ts
@@ -107,10 +107,10 @@ export function complexWithOddIndex(complex: Float32Array):
  * @param complex The complex tensor values.
  * @param index An index of the target complex value.
  */
-export function getComplexWithIndex(complex: Float32Array, index: number):
-    {real: number, imag: number} {
-  const real = complex[index*2];
-  const imag = complex[index*2+1];
+export function getComplexWithIndex(
+    complex: Float32Array, index: number): {real: number, imag: number} {
+  const real = complex[index * 2];
+  const imag = complex[index * 2 + 1];
   return {real, imag};
 }
 
@@ -120,21 +120,21 @@ export function getComplexWithIndex(complex: Float32Array, index: number):
  * @param c The complex value to be inserted.
  * @param index An index of the target complex value.
  */
-export function assignToTypedArray(data: TypedArray,
-    real: number, imag: number, index: number) {
-  data[index*2] = real;
-  data[index*2+1] = imag;
+export function assignToTypedArray(
+    data: TypedArray, real: number, imag: number, index: number) {
+  data[index * 2] = real;
+  data[index * 2 + 1] = imag;
 }
 
 /**
  * Make the list of exponent terms used by FFT.
  */
-export function exponents(n: number):
-    {real: Float32Array, imag: Float32Array} {
+export function exponents(
+    n: number, inverse: boolean): {real: Float32Array, imag: Float32Array} {
   const real = new Float32Array(n / 2);
   const imag = new Float32Array(n / 2);
-  for (let i = 0; i < Math.ceil(n/2); i++) {
-    const x = -2 * Math.PI * (i / n);
+  for (let i = 0; i < Math.ceil(n / 2); i++) {
+    const x = (inverse ? 2 : -2) * Math.PI * (i / n);
     real[i] = Math.cos(x);
     imag[i] = Math.sin(x);
   }
@@ -144,9 +144,9 @@ export function exponents(n: number):
 /**
  * Make the exponent term used by FFT.
  */
-export function exponent(k: number, n: number):
-    {real: number, imag: number} {
-  const x = -2 * Math.PI * (k / n);
+export function exponent(
+    k: number, n: number, inverse: boolean): {real: number, imag: number} {
+  const x = (inverse ? 2 : -2) * Math.PI * (k / n);
   const real = Math.cos(x);
   const imag = Math.sin(x);
   return {real, imag};

--- a/src/kernels/complex_util_test.ts
+++ b/src/kernels/complex_util_test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  * =============================================================================
  */
-import * as complex_util from './complex_util';
-import {expectArraysClose, ALL_ENVS} from '../test_util';
 import {describeWithFlags} from '../jasmine_util';
+import {ALL_ENVS, expectArraysClose} from '../test_util';
+
+import * as complex_util from './complex_util';
 
 describe('complex_util', () => {
   it('mergeRealAndImagArrays', () => {
@@ -48,9 +49,10 @@ describe('complex_util', () => {
   });
 });
 
-describeWithFlags('complex_util exponents', ALL_ENVS, () => {
+describeWithFlags('complex_util exponents inverse=false', ALL_ENVS, () => {
   it('exponents', () => {
-    const result = complex_util.exponents(5);
+    const inverse = false;
+    const result = complex_util.exponents(5, inverse);
     expectArraysClose(result.real, new Float32Array([1, 0.30901700258255005]));
     expectArraysClose(result.imag, new Float32Array([0, -0.9510565400123596]));
   });

--- a/src/kernels/complex_util_test.ts
+++ b/src/kernels/complex_util_test.ts
@@ -49,12 +49,18 @@ describe('complex_util', () => {
   });
 });
 
-describeWithFlags('complex_util exponents inverse=false', ALL_ENVS, () => {
-  it('exponents', () => {
+describeWithFlags('complex_util exponents', ALL_ENVS, () => {
+  it('exponents inverse=false', () => {
     const inverse = false;
     const result = complex_util.exponents(5, inverse);
     expectArraysClose(result.real, new Float32Array([1, 0.30901700258255005]));
     expectArraysClose(result.imag, new Float32Array([0, -0.9510565400123596]));
+  });
+  it('exponents inverse=true', () => {
+    const inverse = true;
+    const result = complex_util.exponents(5, inverse);
+    expectArraysClose(result.real, new Float32Array([1, 0.30901700258255005]));
+    expectArraysClose(result.imag, new Float32Array([0, 0.9510565400123596]));
   });
 });
 

--- a/src/kernels/webgl/fft_gpu.ts
+++ b/src/kernels/webgl/fft_gpu.ts
@@ -31,9 +31,8 @@ export class FFTProgram implements GPGPUProgram {
     const innerDim = inputShape[1];
     this.outputShape = inputShape;
 
-    const pi = '3.1415926535897932384626433832795';
-
-    const exponentMultiplierSnippet = inverse ? `2.0 * ${pi}` : `-2.0 * ${pi}`;
+    const exponentMultiplierSnippet =
+        inverse ? `2.0 * ${Math.PI}` : `-2.0 * ${Math.PI}`;
     const resultDenominator = inverse ? `${innerDim}.0` : '1.0';
 
     this.userCode = `
@@ -58,8 +57,8 @@ export class FFTProgram implements GPGPUProgram {
           float real = getReal(batch, i);
           float imag = getImag(batch, i);
 
-          result += (
-            unaryOpComplex(real, expR, imag, expI) / ${resultDenominator});
+          result +=
+              unaryOpComplex(real, expR, imag, expI) / ${resultDenominator};
         }
 
         return result;

--- a/src/kernels/webgl/fft_gpu.ts
+++ b/src/kernels/webgl/fft_gpu.ts
@@ -58,10 +58,11 @@ export class FFTProgram implements GPGPUProgram {
           float real = getReal(batch, i);
           float imag = getImag(batch, i);
 
-          result += unaryOpComplex(real, expR, imag, expI);
+          result += (
+            unaryOpComplex(real, expR, imag, expI) / ${resultDenominator});
         }
 
-        return result / ${resultDenominator};
+        return result;
       }
 
       void main() {

--- a/src/kernels/webgl/fft_gpu.ts
+++ b/src/kernels/webgl/fft_gpu.ts
@@ -27,12 +27,17 @@ export class FFTProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
 
-  constructor(op: string, inputShape: [number, number]) {
+  constructor(op: string, inputShape: [number, number], inverse: boolean) {
     const innerDim = inputShape[1];
     this.outputShape = inputShape;
 
+    const pi = '3.1415926535897932384626433832795';
+
+    const exponentMultiplierSnippet = inverse ? `2.0 * ${pi}` : `-2.0 * ${pi}`;
+    const resultDenominator = inverse ? `${innerDim}.0` : '1.0';
+
     this.userCode = `
-      const float negativeTwoPi = -2.0 * 3.1415926535897932384626433832795;
+      const float exponentMultiplier = ${exponentMultiplierSnippet};
 
       float unaryOpComplex(float real, float expR, float imag, float expI) {
         ${op}
@@ -40,13 +45,14 @@ export class FFTProgram implements GPGPUProgram {
 
       float mulMatDFT(int batch, int index) {
         float indexRatio = float(index) / float(${innerDim});
-        float negativeTwoPiTimesIndexRatio = negativeTwoPi * indexRatio;
+        float exponentMultiplierTimesIndexRatio =
+            exponentMultiplier * indexRatio;
 
         float result = 0.0;
 
         for (int i = 0; i < ${innerDim}; i++) {
-          // x = (-2 * PI / N) * index * i;
-          float x = negativeTwoPiTimesIndexRatio * float(i);
+          // x = (-2|2 * PI / N) * index * i;
+          float x = exponentMultiplierTimesIndexRatio * float(i);
           float expR = cos(x);
           float expI = sin(x);
           float real = getReal(batch, i);
@@ -55,7 +61,7 @@ export class FFTProgram implements GPGPUProgram {
           result += unaryOpComplex(real, expR, imag, expI);
         }
 
-        return result;
+        return result / ${resultDenominator};
       }
 
       void main() {

--- a/src/ops/spectral_ops.ts
+++ b/src/ops/spectral_ops.ts
@@ -21,8 +21,10 @@ import {Tensor} from '../tensor';
 import {assert} from '../util';
 
 /**
- * Compute the 1-dimentional discrete fourier transform
- * The input is expected to be the 1D tensor with dtype complex64.
+ * Fast Fourier transform.
+ *
+ * Computes the 1-dimensional discrete Fourier transform over the inner-most
+ * dimension of input.
  *
  * ```js
  * const real = tf.tensor1d([1, 2, 3]);
@@ -52,4 +54,39 @@ function fft_(input: Tensor): Tensor {
   return ret.reshape(input.shape);
 }
 
+/**
+ * Inverse fast Fourier transform.
+ *
+ * Computes the inverse 1-dimensional discrete Fourier transform over the
+ * inner-most dimension of input.
+ *
+ * ```js
+ * const real = tf.tensor1d([1, 2, 3]);
+ * const imag = tf.tensor1d([1, 2, 3]);
+ * const x = tf.complex(real, imag);
+ *
+ * x.ifft().print();  // tf.spectral.ifft(x).print();
+ * ```
+ * @param input The complex input to compute an fft over.
+ */
+/**
+ * @doc {heading: 'Operations', subheading: 'Spectral', namespace: 'spectral'}
+ */
+function ifft_(input: Tensor): Tensor {
+  assert(
+      input.dtype === 'complex64',
+      `The dtype for tf.spectral.ifft() must be complex64 ` +
+          `but got ${input.dtype}.`);
+
+  // Collapse all outer dimensions to a single batch dimension.
+  const innerDimensionSize = input.shape[input.shape.length - 1];
+  const batch = input.size / innerDimensionSize;
+  const input2D = input.as2D(batch, innerDimensionSize);
+
+  const ret = ENV.engine.runKernel(backend => backend.ifft(input2D), {input});
+
+  return ret.reshape(input.shape);
+}
+
 export const fft = op({fft_});
+export const ifft = op({ifft_});

--- a/src/ops/spectral_ops.ts
+++ b/src/ops/spectral_ops.ts
@@ -67,7 +67,7 @@ function fft_(input: Tensor): Tensor {
  *
  * x.ifft().print();  // tf.spectral.ifft(x).print();
  * ```
- * @param input The complex input to compute an fft over.
+ * @param input The complex input to compute an ifft over.
  */
 /**
  * @doc {heading: 'Operations', subheading: 'Spectral', namespace: 'spectral'}

--- a/src/ops/spectral_ops_test.ts
+++ b/src/ops/spectral_ops_test.ts
@@ -77,7 +77,7 @@ describeWithFlags('1D FFT', ALL_ENVS, () => {
      });
 });
 
-describeWithFlags('FFT', WEBGL_ENVS, () => {
+describeWithFlags('2D FFT', WEBGL_ENVS, () => {
   it('2D: should return the same value as TensorFlow', () => {
     const t1Real = tf.tensor2d([1, 2, 3, 4], [2, 2]);
     const t1Imag = tf.tensor2d([5, 6, 7, 8], [2, 2]);
@@ -112,5 +112,106 @@ describeWithFlags('FFT CPU', BROWSER_CPU_ENVS, () => {
     const t1Imag = tf.tensor3d([5, 6, 7, 8, -5, -6, -7, -8], [2, 2, 2]);
     const t1 = tf.complex(t1Real, t1Imag);
     expect(() => tf.spectral.fft(t1)).toThrow();
+  });
+});
+
+describeWithFlags('1D IFFT', ALL_ENVS, () => {
+  it('should return the same value with TensorFlow (2 elements)', () => {
+    const t1Real = tf.tensor1d([1, 2]);
+    const t1Imag = tf.tensor1d([1, 1]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expectArraysClose(tf.spectral.ifft(t1), [1.5, 1, -0.5, 0]);
+  });
+
+  it('should calculate FFT from Tensor directly', () => {
+    const t1Real = tf.tensor1d([1, 2]);
+    const t1Imag = tf.tensor1d([1, 1]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expectArraysClose(t1.ifft(), [1.5, 1, -0.5, 0]);
+  });
+
+  it('should return the same value as TensorFlow (3 elements)', () => {
+    const t1Real = tf.tensor1d([1, 2, 3]);
+    const t1Imag = tf.tensor1d([0, 0, 0]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expectArraysClose(tf.spectral.ifft(t1), [
+      2, -3.9736431e-08, -0.49999997, -.28867507, -0.49999994, 2.8867519e-01
+    ]);
+  });
+
+  it('should return the same value as TensorFlow with imaginary (3 elements)',
+     () => {
+       const t1Real = tf.tensor1d([1, 2, 3]);
+       const t1Imag = tf.tensor1d([1, 2, 3]);
+       const t1 = tf.complex(t1Real, t1Imag);
+       expectArraysClose(
+           tf.spectral.ifft(t1),
+           [2, 1.9999999, -0.21132492, -0.78867507, -0.7886752, -0.2113249]);
+     });
+
+  it('should return the same value as TensorFlow (negative 3 elements)', () => {
+    const t1Real = tf.tensor1d([-1, -2, -3]);
+    const t1Imag = tf.tensor1d([-1, -2, -3]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expectArraysClose(
+        tf.spectral.ifft(t1),
+        [-2, -1.9999999, 0.21132492, 0.78867507, 0.7886752, 0.2113249]);
+  });
+
+  it('should return the same value with TensorFlow (4 elements)', () => {
+    const t1Real = tf.tensor1d([1, 2, 3, 4]);
+    const t1Imag = tf.tensor1d([0, 0, 0, 0]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expectArraysClose(
+        tf.spectral.ifft(t1), [2.5, 0, -0.5, -0.5, -0.5, 0, -0.5, 0.5]);
+  });
+
+  it('should return the same value as TensorFlow with imaginary (4 elements)',
+     () => {
+       const t1Real = tf.tensor1d([1, 2, 3, 4]);
+       const t1Imag = tf.tensor1d([1, 2, 3, 4]);
+       const t1 = tf.complex(t1Real, t1Imag);
+       expectArraysClose(
+           tf.spectral.ifft(t1), [2.5, 2.5, 0, -1, -0.5, -0.5, -1, 0]);
+     });
+});
+
+describeWithFlags('2D IFFT', WEBGL_ENVS, () => {
+  it('2D: should return the same value as TensorFlow', () => {
+    const t1Real = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+    const t1Imag = tf.tensor2d([5, 6, 7, 8], [2, 2]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    const y = tf.spectral.ifft(t1);
+    expectArraysClose(y, [1.5, 5.5, -0.5, -0.5, 3.5, 7.5, -0.5, -0.5]);
+    expect(y.shape).toEqual(t1Real.shape);
+  });
+
+  it('3D: should return the same value as TensorFlow', () => {
+    const t1Real = tf.tensor3d([1, 2, 3, 4, -1, -2, -3, -4], [2, 2, 2]);
+    const t1Imag = tf.tensor3d([5, 6, 7, 8, -5, -6, -7, -8], [2, 2, 2]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    const y = tf.spectral.ifft(t1);
+    expectArraysClose(y, [
+      1.5, 5.5, -0.5, -0.5, 3.5, 7.5, -0.5, -0.5, -1.5, -5.5, 0.5, 0.5, -3.5,
+      -7.5, 0.5, 0.5
+    ]);
+    expect(y.shape).toEqual(t1Real.shape);
+  });
+});
+
+// TODO: Remove this once we support higher-dimensional FFTs on CPU.
+describeWithFlags('IFFT CPU', BROWSER_CPU_ENVS, () => {
+  it('2D throws', () => {
+    const t1Real = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+    const t1Imag = tf.tensor2d([5, 6, 7, 8], [2, 2]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expect(() => tf.spectral.ifft(t1)).toThrow();
+  });
+
+  it('3D throws', () => {
+    const t1Real = tf.tensor3d([1, 2, 3, 4, -1, -2, -3, -4], [2, 2, 2]);
+    const t1Imag = tf.tensor3d([5, 6, 7, 8, -5, -6, -7, -8], [2, 2, 2]);
+    const t1 = tf.complex(t1Real, t1Imag);
+    expect(() => tf.spectral.ifft(t1)).toThrow();
   });
 });

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -333,7 +333,7 @@ export interface OpHandler {
       x: T, begin: number[], end: number[], strides: number[],
       beginMask: number, endMask: number): T;
   depthToSpace(x: Tensor4D, blockSize: number, dataFormat: string): Tensor4D;
-  spectral: {fft(x: Tensor): Tensor;};
+  spectral: {fft(x: Tensor): Tensor; ifft(x: Tensor): Tensor;};
 }
 
 // For tracking tensor creation and disposal.
@@ -1266,6 +1266,11 @@ export class Tensor<R extends Rank = Rank> {
   fft(this: Tensor): Tensor {
     this.throwIfDisposed();
     return opHandler.spectral.fft(this);
+  }
+
+  ifft(this: Tensor): Tensor {
+    this.throwIfDisposed();
+    return opHandler.spectral.ifft(this);
   }
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {


### PR DESCRIPTION
This is the inverse of tf.fft(). Luckily this is simple as changing -2 * PI to 2 * PI.

Like tf.fft(), only implements 1D on CPU. For GPU, all dimensions are supported.

Towards https://github.com/tensorflow/tfjs/issues/782

For reference:
https://www.mathworks.com/help/matlab/ref/ifft.html
https://www.tensorflow.org/api_docs/python/tf/spectral/ifft

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1341)
<!-- Reviewable:end -->
