### PR TITLE
Unpack eagerly within packed ops that reshape their outputs

### DIFF
--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -121,7 +121,7 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
     expectArraysClose(c, expected);
   });
 
-  it('should work when followed by an op that requires unpacked inputs', () => {
+  it('works when followed by an op that requires unpacked inputs', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
 
@@ -131,7 +131,8 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
     expectArraysClose(d, [1, 9, -2, 21]);
   });
 
-  it('should work when followed by a reshape that changes texture layout, and then an unpacked op',
+  // tslint:disable-next-line:max-line-length
+  it('works when followed by a reshape that changes texture layout, and then an unpacked op',
      () => {
        const a = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8, 9], [9, 1]);
        const b = tf.tensor2d([1], [1, 1]);
@@ -142,7 +143,7 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
        expectArraysClose(e, [2, 3, 4, 5, 6, 7, 8, 9, 10]);
      });
 
-  it('should work when preceded by an op that requires packed inputs', () => {
+  it('works when preceded by an op that requires packed inputs', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
 

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -131,6 +131,17 @@ describeWithFlags('packed matmul', WEBGL_ENVS, () => {
     expectArraysClose(d, [1, 9, -2, 21]);
   });
 
+  it('should work when followed by a reshape that changes texture layout, and then an unpacked op',
+     () => {
+       const a = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8, 9], [9, 1]);
+       const b = tf.tensor2d([1], [1, 1]);
+       const c = tf.matMul(a, b);
+
+       const d = tf.reshape(c, [1, 3, 3, 1]);
+       const e = tf.add(d, 1);
+       expectArraysClose(e, [2, 3, 4, 5, 6, 7, 8, 9, 10]);
+     });
+
   it('should work when preceded by an op that requires packed inputs', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);


### PR DESCRIPTION
This PR is a quick fix to https://github.com/tensorflow/tfjs/issues/834

### Changes
- Eagerly unpack outputs of `matMul` and `im2Row` so the final reshape occurs on the unpacked tensor
- Add a test that catches the issue

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1345)
<!-- Reviewable:end -->
