### PR TITLE
Replace the isNaN check which fails for iOS 12.0.1

### DIFF
--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -307,7 +307,7 @@ const SHADER_PREFIX = `
   };
 
   bool isNaN(float val) {
-    return (val < 1.0 || val > 0.0) ? false : true;
+    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
   }
 
   bool hasNaN(vec4 values) {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -277,6 +277,10 @@ const FLOAT_TEXTURE_SET_RGBA_SNIPPET = `
   }
 `;
 
+/*
+Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false : true' does
+not work on iOS 12
+ */
 const SHADER_PREFIX = `
   precision highp float;
   precision highp int;
@@ -303,7 +307,7 @@ const SHADER_PREFIX = `
   };
 
   bool isNaN(float val) {
-    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;
+    return val != val;
   }
 
   bool hasNaN(vec4 values) {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -307,7 +307,7 @@ const SHADER_PREFIX = `
   };
 
   bool isNaN(float val) {
-    return val != val;
+    return (val < 1.0 || val > 0.0) ? false : true;
   }
 
   bool hasNaN(vec4 values) {


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tfjs/issues/727

### Changes
- Replaces the `isNaN` check with `val < 1.0 || 0.0 < val || val == 0.0`

The current check causes strange behavior on iOS 12.0.1. For example, if `val = 3.0`:

`val > 0.0` is `true`
`val > 0.0 || val < 0.0` is `true`
`val > 0.0 || val < 0.0 || val == 0.0` is `false`

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1346)
<!-- Reviewable:end -->
