### PR TITLE
Move auto-incremented tensor and variable ids to Engine

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -175,12 +175,12 @@ export class Engine implements TensorManager, DataMover {
   }
 
   private static nextTensorId = 0;
-  nextTensorID(): number {
+  nextTensorId(): number {
     return Engine.nextTensorId++;
   }
 
   private static nextVariableId = 0;
-  nextVariableID(): number {
+  nextVariableId(): number {
     return Engine.nextVariableId++;
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -174,6 +174,16 @@ export class Engine implements TensorManager, DataMover {
     }
   }
 
+  private static nextTensorId = 0;
+  nextTensorID(): number {
+    return Engine.nextTensorId++;
+  }
+
+  private static nextVariableId = 0;
+  nextVariableID(): number {
+    return Engine.nextVariableId++;
+  }
+
   runKernel<T extends Tensor|Tensor[], I extends NamedTensorMap>(
       forwardFunc: ForwardFunc<T>,
       inputs: I,

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -146,6 +146,8 @@ export interface TensorTracker {
   read(dataId: DataId): Promise<TypedArray>;
   readSync(dataId: DataId): TypedArray;
   registerVariable(v: Variable): void;
+  nextTensorID(): number;
+  nextVariableID(): number;
 }
 
 /**
@@ -376,8 +378,6 @@ export type DataId = object;  // object instead of {} to force non-primitive.
  */
 /** @doc {heading: 'Tensors', subheading: 'Classes'} */
 export class Tensor<R extends Rank = Rank> {
-  private static nextId = 0;
-
   /** Unique id of this tensor. */
   readonly id: number;
   /**
@@ -417,7 +417,7 @@ export class Tensor<R extends Rank = Rank> {
 
     this.strides = computeStrides(shape);
     this.dataId = dataId != null ? dataId : {};
-    this.id = Tensor.nextId++;
+    this.id = trackerFn().nextTensorID();
     this.rankType = (this.rank < 5 ? this.rank.toString() : 'higher') as R;
     trackerFn().registerTensor(this);
     if (values != null) {
@@ -1294,7 +1294,6 @@ export type Tensor6D = Tensor<Rank.R6>;
  */
 /** @doc {heading: 'Tensors', subheading: 'Classes'} */
 export class Variable<R extends Rank = Rank> extends Tensor<R> {
-  private static nextVarId = 0;
   name: string;
 
   /**
@@ -1309,8 +1308,7 @@ export class Variable<R extends Rank = Rank> extends Tensor<R> {
         initialValue.dataId);
     this.name = name;
     if (this.name == null) {
-      this.name = Variable.nextVarId.toString();
-      Variable.nextVarId++;
+      this.name = trackerFn().nextVariableID().toString();
     }
     try {
       trackerFn().registerVariable(this);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -146,8 +146,8 @@ export interface TensorTracker {
   read(dataId: DataId): Promise<TypedArray>;
   readSync(dataId: DataId): TypedArray;
   registerVariable(v: Variable): void;
-  nextTensorID(): number;
-  nextVariableID(): number;
+  nextTensorId(): number;
+  nextVariableId(): number;
 }
 
 /**
@@ -417,7 +417,7 @@ export class Tensor<R extends Rank = Rank> {
 
     this.strides = computeStrides(shape);
     this.dataId = dataId != null ? dataId : {};
-    this.id = trackerFn().nextTensorID();
+    this.id = trackerFn().nextTensorId();
     this.rankType = (this.rank < 5 ? this.rank.toString() : 'higher') as R;
     trackerFn().registerTensor(this);
     if (values != null) {
@@ -1308,7 +1308,7 @@ export class Variable<R extends Rank = Rank> extends Tensor<R> {
         initialValue.dataId);
     this.name = name;
     if (this.name == null) {
-      this.name = trackerFn().nextVariableID().toString();
+      this.name = trackerFn().nextVariableId().toString();
     }
     try {
       trackerFn().registerVariable(this);


### PR DESCRIPTION
Move the `nextTensorID` and `nextVariableID` to the `Engine` class, which is a singleton. This solves the issue of colliding ids when having multiple instances of tfjs-core on the page and using training.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1349)
<!-- Reviewable:end -->
