### PR TITLE
Centralize canvas and WebGL context creation to avoid 'WEBGL_CONTEXT_LOST'

### DIFF
--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-const contexes:
+const contexts:
     {[key: string]: {canvas: HTMLCanvasElement,
                      gl: WebGLRenderingContext}} = {};
 
@@ -30,18 +30,18 @@ const WEBGL_ATTRIBUTES: WebGLContextAttributes = {
 };
 
 export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
-  if (!(webGLVersion in contexes)) {
+  if (!(webGLVersion in contexts)) {
     const canvas = document.createElement('canvas');
     canvas.addEventListener('webglcontextlost', ev => {
       ev.preventDefault();
-      delete contexes[webGLVersion];
+      delete contexts[webGLVersion];
     }, false);
     const gl = getWebGLRenderingContext(webGLVersion);
-    contexes[webGLVersion] = {canvas, gl};
+    contexts[webGLVersion] = {canvas, gl};
   }
-  const gl = contexes[webGLVersion].gl;
+  const gl = contexts[webGLVersion].gl;
   if (gl.isContextLost()) {
-    delete contexes[webGLVersion];
+    delete contexts[webGLVersion];
     return getWebGLCanvas(webGLVersion);
   }
 
@@ -55,12 +55,12 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
   gl.enable(gl.CULL_FACE);
   gl.cullFace(gl.BACK);
 
-  return contexes[webGLVersion].canvas;
+  return contexts[webGLVersion].canvas;
 }
 
 export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
   getWebGLCanvas(webGLVersion);
-  return contexes[webGLVersion].gl;
+  return contexts[webGLVersion].gl;
 }
 
 function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {

--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+const contexes: {
+  [version: number]: {canvas: HTMLCanvasElement, gl: WebGLRenderingContext}
+} = {};
+
+export function getCanvas(webGLVersion: number): HTMLCanvasElement {
+  if (!(webGLVersion in contexes)) {
+    const canvas = document.createElement('canvas');
+    canvas.addEventListener('webglcontextlost', ev => {
+      ev.preventDefault();
+      delete contexes[webGLVersion];
+    }, false);
+    const gl = getWebGLRenderingContext(webGLVersion);
+    contexes[webGLVersion] = {canvas, gl};
+  }
+  const gl = contexes[webGLVersion].gl;
+  if (gl.isContextLost()) {
+    delete contexes[webGLVersion];
+    return getCanvas(webGLVersion);
+  }
+  return contexes[webGLVersion].canvas;
+}
+
+export function getContext(webGLVersion: number): WebGLRenderingContext {
+  getCanvas(webGLVersion);
+  return contexes[webGLVersion].gl;
+}
+
+function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {
+  if (webGLVersion !== 1 && webGLVersion !== 2) {
+    throw new Error('Cannot get WebGL rendering context, WebGL is disabled.');
+  }
+
+  const canvas = document.createElement('canvas');
+  if (webGLVersion === 1) {
+    return (canvas.getContext('webgl') ||
+            canvas.getContext('experimental-webgl')) as WebGLRenderingContext;
+  }
+  return canvas.getContext('webgl2') as WebGLRenderingContext;
+}

--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -15,9 +15,7 @@
  * =============================================================================
  */
 
-const contexts:
-    {[key: string]: {canvas: HTMLCanvasElement,
-                     gl: WebGLRenderingContext}} = {};
+const contexts: {[key: string]: WebGLRenderingContext} = {};
 
 const WEBGL_ATTRIBUTES: WebGLContextAttributes = {
   alpha: false,
@@ -29,20 +27,19 @@ const WEBGL_ATTRIBUTES: WebGLContextAttributes = {
   failIfMajorPerformanceCaveat: true
 };
 
-export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
+export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
   if (!(webGLVersion in contexts)) {
     const canvas = document.createElement('canvas');
     canvas.addEventListener('webglcontextlost', ev => {
       ev.preventDefault();
       delete contexts[webGLVersion];
     }, false);
-    const gl = getWebGLRenderingContext(webGLVersion);
-    contexts[webGLVersion] = {canvas, gl};
+    contexts[webGLVersion] = getWebGLRenderingContext(webGLVersion);
   }
-  const gl = contexts[webGLVersion].gl;
+  const gl = contexts[webGLVersion];
   if (gl.isContextLost()) {
     delete contexts[webGLVersion];
-    return getWebGLCanvas(webGLVersion);
+    return getWebGLContext(webGLVersion);
   }
 
   gl.disable(gl.DEPTH_TEST);
@@ -55,12 +52,7 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
   gl.enable(gl.CULL_FACE);
   gl.cullFace(gl.BACK);
 
-  return contexts[webGLVersion].canvas;
-}
-
-export function getWebGLContext(webGLVersion: number): WebGLRenderingContext {
-  getWebGLCanvas(webGLVersion);
-  return contexts[webGLVersion].gl;
+  return contexts[webGLVersion];
 }
 
 function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {

--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -42,6 +42,10 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
     contexes[webGLVersion] = {canvas, gl};
   }
   const gl = contexes[webGLVersion].gl;
+  if (gl.isContextLost()) {
+    delete contexes[webGLVersion];
+    return getWebGLCanvas(webGLVersion);
+  }
 
   callAndCheck(gl, () => gl.disable(gl.DEPTH_TEST));
   callAndCheck(gl, () => gl.disable(gl.STENCIL_TEST));
@@ -52,11 +56,6 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
   callAndCheck(gl, () => gl.enable(gl.SCISSOR_TEST));
   callAndCheck(gl, () => gl.enable(gl.CULL_FACE));
   callAndCheck(gl, () => gl.cullFace(gl.BACK));
-
-  if (gl.isContextLost()) {
-    delete contexes[webGLVersion];
-    return getWebGLCanvas(webGLVersion);
-  }
   return contexes[webGLVersion].canvas;
 }
 

--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -56,6 +56,7 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
   callAndCheck(gl, () => gl.enable(gl.SCISSOR_TEST));
   callAndCheck(gl, () => gl.enable(gl.CULL_FACE));
   callAndCheck(gl, () => gl.cullFace(gl.BACK));
+
   return contexes[webGLVersion].canvas;
 }
 

--- a/src/canvas_util.ts
+++ b/src/canvas_util.ts
@@ -15,8 +15,6 @@
  * =============================================================================
  */
 
-import {callAndCheck} from './kernels/webgl/webgl_util';
-
 const contexes:
     {[key: string]: {canvas: HTMLCanvasElement,
                      gl: WebGLRenderingContext}} = {};
@@ -47,15 +45,15 @@ export function getWebGLCanvas(webGLVersion: number): HTMLCanvasElement {
     return getWebGLCanvas(webGLVersion);
   }
 
-  callAndCheck(gl, () => gl.disable(gl.DEPTH_TEST));
-  callAndCheck(gl, () => gl.disable(gl.STENCIL_TEST));
-  callAndCheck(gl, () => gl.disable(gl.BLEND));
-  callAndCheck(gl, () => gl.disable(gl.DITHER));
-  callAndCheck(gl, () => gl.disable(gl.POLYGON_OFFSET_FILL));
-  callAndCheck(gl, () => gl.disable(gl.SAMPLE_COVERAGE));
-  callAndCheck(gl, () => gl.enable(gl.SCISSOR_TEST));
-  callAndCheck(gl, () => gl.enable(gl.CULL_FACE));
-  callAndCheck(gl, () => gl.cullFace(gl.BACK));
+  gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.STENCIL_TEST);
+  gl.disable(gl.BLEND);
+  gl.disable(gl.DITHER);
+  gl.disable(gl.POLYGON_OFFSET_FILL);
+  gl.disable(gl.SAMPLE_COVERAGE);
+  gl.enable(gl.SCISSOR_TEST);
+  gl.enable(gl.CULL_FACE);
+  gl.cullFace(gl.BACK);
 
   return contexes[webGLVersion].canvas;
 }

--- a/src/canvas_util_test.ts
+++ b/src/canvas_util_test.ts
@@ -18,8 +18,9 @@
 import {getWebGLCanvas, getWebGLContext} from './canvas_util';
 import {ENV} from './environment';
 import {describeWithFlags} from './jasmine_util';
+import {BROWSER_ENVS} from './test_util';
 
-describeWithFlags('canvas_util', {}, () => {
+describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   it('Returns a valid canvas', () => {
     const canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
     expect(canvas instanceof HTMLCanvasElement).toBe(true);

--- a/src/canvas_util_test.ts
+++ b/src/canvas_util_test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {getWebGLCanvas, getWebGLContext} from './canvas_util';
+import {ENV} from './environment';
+import {describeWithFlags} from './jasmine_util';
+
+describeWithFlags('canvas_util', {}, () => {
+  it('Returns a valid canvas', () => {
+    const canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
+    expect(canvas instanceof HTMLCanvasElement).toBe(true);
+  });
+
+  it('Returns a valid gl context', () => {
+    const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
+    expect(gl.isContextLost()).toBe(false);
+  });
+
+  it('The canvas and the gl are bounded', () => {
+    const canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
+    const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
+    expect(gl.canvas.isEqualNode(canvas)).toBe(true);
+  });
+});
+
+describeWithFlags('canvas_util webgl2', {WEBGL_VERSION: 2}, () => {
+  it('is ok when the user requests webgl 1 canvas', () => {
+    const canvas = getWebGLCanvas(1);
+    expect(canvas instanceof HTMLCanvasElement).toBe(true);
+  });
+});

--- a/src/canvas_util_test.ts
+++ b/src/canvas_util_test.ts
@@ -15,14 +15,14 @@
  * =============================================================================
  */
 
-import {getWebGLCanvas, getWebGLContext} from './canvas_util';
+import {getWebGLContext} from './canvas_util';
 import {ENV} from './environment';
 import {describeWithFlags} from './jasmine_util';
 import {BROWSER_ENVS} from './test_util';
 
 describeWithFlags('canvas_util', BROWSER_ENVS, () => {
   it('Returns a valid canvas', () => {
-    const canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
+    const canvas = getWebGLContext(ENV.get('WEBGL_VERSION')).canvas;
     expect(canvas instanceof HTMLCanvasElement).toBe(true);
   });
 
@@ -30,17 +30,11 @@ describeWithFlags('canvas_util', BROWSER_ENVS, () => {
     const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
     expect(gl.isContextLost()).toBe(false);
   });
-
-  it('The canvas and the gl are bounded', () => {
-    const canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
-    const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
-    expect(gl.canvas.isEqualNode(canvas)).toBe(true);
-  });
 });
 
 describeWithFlags('canvas_util webgl2', {WEBGL_VERSION: 2}, () => {
   it('is ok when the user requests webgl 1 canvas', () => {
-    const canvas = getWebGLCanvas(1);
+    const canvas = getWebGLContext(1).canvas;
     expect(canvas instanceof HTMLCanvasElement).toBe(true);
   });
 });

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -313,8 +313,7 @@ export class Environment {
     } else if (feature === 'WEBGL_PAGING_ENABLED') {
       return this.get('IS_BROWSER') && !this.get('PROD');
     } else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
-      return getWebGLMaxTextureSize(
-          this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+      return getWebGLMaxTextureSize(this.get('WEBGL_VERSION'));
     } else if (feature === 'IS_TEST') {
       return false;
     } else if (feature === 'BACKEND') {
@@ -325,29 +324,25 @@ export class Environment {
       if (webGLVersion === 0) {
         return 0;
       }
-      return getWebGLDisjointQueryTimerVersion(
-          webGLVersion, this.get('IS_BROWSER'));
+      return getWebGLDisjointQueryTimerVersion(webGLVersion);
     } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE') {
       return this.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0 &&
           !device_util.isMobile();
     } else if (feature === 'HAS_WEBGL') {
       return this.get('WEBGL_VERSION') > 0;
     } else if (feature === 'WEBGL_VERSION') {
-      if (isWebGLVersionEnabled(2, this.get('IS_BROWSER'))) {
+      if (isWebGLVersionEnabled(2)) {
         return 2;
-      } else if (isWebGLVersionEnabled(1, this.get('IS_BROWSER'))) {
+      } else if (isWebGLVersionEnabled(1)) {
         return 1;
       }
       return 0;
     } else if (feature === 'WEBGL_RENDER_FLOAT32_ENABLED') {
-      return isRenderToFloatTextureEnabled(
-          this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+      return isRenderToFloatTextureEnabled(this.get('WEBGL_VERSION'));
     } else if (feature === 'WEBGL_DOWNLOAD_FLOAT_ENABLED') {
-      return isDownloadFloatTextureEnabled(
-          this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+      return isDownloadFloatTextureEnabled(this.get('WEBGL_VERSION'));
     } else if (feature === 'WEBGL_FENCE_API_ENABLED') {
-      return isWebGLFenceEnabled(
-          this.get('WEBGL_VERSION'), this.get('IS_BROWSER'));
+      return isWebGLFenceEnabled(this.get('WEBGL_VERSION'));
     } else if (feature === 'WEBGL_SIZE_UPLOAD_UNIFORM') {
       // Use uniform uploads only when 32bit floats are supported. In 16bit
       // environments there are problems with comparing a 16bit texture value

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -369,7 +369,7 @@ export class Environment {
   }
 
   setFeatures(features: Features) {
-    this.features = Object.assign(this.features, features);
+    this.features = Object.assign({}, features);
   }
 
   reset() {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -369,7 +369,7 @@ export class Environment {
   }
 
   setFeatures(features: Features) {
-    this.features = Object.assign({}, features);
+    this.features = Object.assign(this.features, features);
   }
 
   reset() {

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -187,53 +187,6 @@ describeWithFlags('WEBGL_FENCE_API_ENABLED', WEBGL_ENVS, () => {
   });
 });
 
-describeWithFlags('WebGL version', WEBGL_ENVS, () => {
-  it('webgl 1', () => {
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl') {
-          return {
-            getExtension: (a: string) => {
-              return {loseContext: () => {}};
-            }
-          };
-        }
-        return null;
-      }
-    });
-
-    const env = new Environment();
-    expect(env.get('WEBGL_VERSION')).toBe(1);
-  });
-
-  it('webgl 2', () => {
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl2') {
-          return {
-            getExtension: (a: string) => {
-              return {loseContext: () => {}};
-            }
-          };
-        }
-        return null;
-      }
-    });
-
-    const env = new Environment();
-    expect(env.get('WEBGL_VERSION')).toBe(2);
-  });
-
-  it('no webgl', () => {
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string): WebGLRenderingContext => null
-    });
-
-    const env = new Environment();
-    expect(env.get('WEBGL_VERSION')).toBe(0);
-  });
-});
-
 describe('Backend', () => {
   beforeAll(() => {
     // Silences backend registration warnings.

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -25,63 +25,6 @@ import {MathBackendCPU} from './kernels/backend_cpu';
 import {MathBackendWebGL} from './kernels/backend_webgl';
 import {ALL_ENVS, expectArraysClose, WEBGL_ENVS} from './test_util';
 
-describeWithFlags('disjoint query timer enabled', WEBGL_ENVS, () => {
-  it('no webgl', () => {
-    const env = new Environment({'WEBGL_VERSION': 0});
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(0);
-  });
-
-  it('webgl 1', () => {
-    const features: Features = {'WEBGL_VERSION': 1};
-
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl' || context === 'experimental-webgl') {
-          return {
-            getExtension: (extensionName: string) => {
-              if (extensionName === 'EXT_disjoint_timer_query') {
-                return {};
-              } else if (extensionName === 'WEBGL_lose_context') {
-                return {loseContext: () => {}};
-              }
-              return null;
-            }
-          };
-        }
-        return null;
-      }
-    });
-
-    const env = new Environment(features);
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(1);
-  });
-
-  it('webgl 2', () => {
-    const features: Features = {'WEBGL_VERSION': 2};
-
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl2') {
-          return {
-            getExtension: (extensionName: string) => {
-              if (extensionName === 'EXT_disjoint_timer_query_webgl2') {
-                return {};
-              } else if (extensionName === 'WEBGL_lose_context') {
-                return {loseContext: () => {}};
-              }
-              return null;
-            }
-          };
-        }
-        return null;
-      }
-    });
-
-    const env = new Environment(features);
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(2);
-  });
-});
-
 describeWithFlags(
     'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', WEBGL_ENVS, () => {
       it('disjoint query timer disabled', () => {
@@ -145,45 +88,6 @@ describeWithFlags('WEBGL_PAGING_ENABLED', WEBGL_ENVS, testEnv => {
     const env = new Environment(features);
     env.set('PROD', true);
     expect(env.get('WEBGL_PAGING_ENABLED')).toBe(false);
-  });
-});
-
-describeWithFlags('WEBGL_FENCE_API_ENABLED', WEBGL_ENVS, () => {
-  beforeEach(() => {
-    spyOn(document, 'createElement').and.returnValue({
-      getContext: (context: string) => {
-        if (context === 'webgl2') {
-          return {
-            getExtension: (extensionName: string) => {
-              if (extensionName === 'WEBGL_get_buffer_sub_data_async') {
-                return {};
-              } else if (extensionName === 'WEBGL_lose_context') {
-                return {loseContext: () => {}};
-              }
-              return null;
-            },
-            fenceSync: () => 1
-          };
-        }
-        return null;
-      }
-    });
-  });
-
-  it('WebGL 2 enabled', () => {
-    const features: Features = {'WEBGL_VERSION': 2};
-
-    const env = new Environment(features);
-
-    expect(env.get('WEBGL_FENCE_API_ENABLED')).toBe(true);
-  });
-
-  it('WebGL 1 disabled', () => {
-    const features: Features = {'WEBGL_VERSION': 1};
-
-    const env = new Environment(features);
-
-    expect(env.get('WEBGL_FENCE_API_ENABLED')).toBe(false);
   });
 });
 

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {getContext} from './canvas_util';
+
 export interface Features {
   // Whether to enable debug mode.
   'DEBUG'?: boolean;
@@ -105,7 +107,7 @@ export interface URLProperty {
 
 export function isWebGLVersionEnabled(webGLVersion: 1|2, isBrowser: boolean) {
   try {
-    const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+    const gl = getContext(webGLVersion);
     if (gl != null) {
       return true;
     }
@@ -122,7 +124,7 @@ let MAX_TEXTURE_SIZE: number;
 export function getWebGLMaxTextureSize(
     webGLVersion: number, isBrowser: boolean): number {
   if (MAX_TEXTURE_SIZE == null) {
-    const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+    const gl = getContext(webGLVersion);
     MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
   }
   return MAX_TEXTURE_SIZE;
@@ -135,7 +137,7 @@ export function getWebGLDisjointQueryTimerVersion(
   }
 
   let queryTimerVersion: number;
-  const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+  const gl = getContext(webGLVersion);
 
   if (hasExtension(gl, 'EXT_disjoint_timer_query_webgl2') &&
       webGLVersion === 2) {
@@ -154,7 +156,7 @@ export function isRenderToFloatTextureEnabled(
     return false;
   }
 
-  const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+  const gl = getContext(webGLVersion);
 
   if (webGLVersion === 1) {
     if (!hasExtension(gl, 'OES_texture_float')) {
@@ -177,7 +179,7 @@ export function isDownloadFloatTextureEnabled(
     return false;
   }
 
-  const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+  const gl = getContext(webGLVersion);
 
   if (webGLVersion === 1) {
     if (!hasExtension(gl, 'OES_texture_float')) {
@@ -201,7 +203,7 @@ export function isWebGLFenceEnabled(webGLVersion: number, isBrowser: boolean) {
   if (webGLVersion !== 2) {
     return false;
   }
-  const gl = getWebGLRenderingContext(webGLVersion, isBrowser);
+  const gl = getContext(webGLVersion);
 
   // tslint:disable-next-line:no-any
   const isEnabled = (gl as any).fenceSync != null;
@@ -258,30 +260,6 @@ export function getFeaturesFromURL(): Features {
 function hasExtension(gl: WebGLRenderingContext, extensionName: string) {
   const ext = gl.getExtension(extensionName);
   return ext != null;
-}
-
-// Cache the canvases for faster evaluation of webgl capabilities.
-let canvasWebgl: HTMLCanvasElement;
-let canvasWebgl2: HTMLCanvasElement;
-
-function getWebGLRenderingContext(
-    webGLVersion: number, isBrowser: boolean): WebGLRenderingContext {
-  if (webGLVersion === 0 || !isBrowser) {
-    throw new Error('Cannot get WebGL rendering context, WebGL is disabled.');
-  }
-
-  if (webGLVersion === 1) {
-    if (canvasWebgl == null) {
-      canvasWebgl = document.createElement('canvas');
-    }
-    return (canvasWebgl.getContext('webgl') ||
-            canvasWebgl.getContext('experimental-webgl')) as
-        WebGLRenderingContext;
-  }
-  if (canvasWebgl2 == null) {
-    canvasWebgl2 = document.createElement('canvas');
-  }
-  return canvasWebgl2.getContext('webgl2') as WebGLRenderingContext;
 }
 
 function createFloatTextureAndBindToFramebuffer(

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getContext} from './canvas_util';
+import {getWebGLContext} from './canvas_util';
 
 export interface Features {
   // Whether to enable debug mode.
@@ -105,9 +105,9 @@ export interface URLProperty {
   type: Type;
 }
 
-export function isWebGLVersionEnabled(webGLVersion: 1|2, isBrowser: boolean) {
+export function isWebGLVersionEnabled(webGLVersion: 1|2) {
   try {
-    const gl = getContext(webGLVersion);
+    const gl = getWebGLContext(webGLVersion);
     if (gl != null) {
       return true;
     }
@@ -121,23 +121,22 @@ let MAX_TEXTURE_SIZE: number;
 // Caching MAX_TEXTURE_SIZE here because the environment gets reset between
 // unit tests and we don't want to constantly query the WebGLContext for
 // MAX_TEXTURE_SIZE.
-export function getWebGLMaxTextureSize(
-    webGLVersion: number, isBrowser: boolean): number {
+export function getWebGLMaxTextureSize(webGLVersion: number): number {
   if (MAX_TEXTURE_SIZE == null) {
-    const gl = getContext(webGLVersion);
+    const gl = getWebGLContext(webGLVersion);
     MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
   }
   return MAX_TEXTURE_SIZE;
 }
 
-export function getWebGLDisjointQueryTimerVersion(
-    webGLVersion: number, isBrowser: boolean): number {
+export function getWebGLDisjointQueryTimerVersion(webGLVersion: number):
+    number {
   if (webGLVersion === 0) {
     return 0;
   }
 
   let queryTimerVersion: number;
-  const gl = getContext(webGLVersion);
+  const gl = getWebGLContext(webGLVersion);
 
   if (hasExtension(gl, 'EXT_disjoint_timer_query_webgl2') &&
       webGLVersion === 2) {
@@ -150,13 +149,12 @@ export function getWebGLDisjointQueryTimerVersion(
   return queryTimerVersion;
 }
 
-export function isRenderToFloatTextureEnabled(
-    webGLVersion: number, isBrowser: boolean): boolean {
+export function isRenderToFloatTextureEnabled(webGLVersion: number): boolean {
   if (webGLVersion === 0) {
     return false;
   }
 
-  const gl = getContext(webGLVersion);
+  const gl = getWebGLContext(webGLVersion);
 
   if (webGLVersion === 1) {
     if (!hasExtension(gl, 'OES_texture_float')) {
@@ -173,13 +171,12 @@ export function isRenderToFloatTextureEnabled(
   return isFrameBufferComplete;
 }
 
-export function isDownloadFloatTextureEnabled(
-    webGLVersion: number, isBrowser: boolean): boolean {
+export function isDownloadFloatTextureEnabled(webGLVersion: number): boolean {
   if (webGLVersion === 0) {
     return false;
   }
 
-  const gl = getContext(webGLVersion);
+  const gl = getWebGLContext(webGLVersion);
 
   if (webGLVersion === 1) {
     if (!hasExtension(gl, 'OES_texture_float')) {
@@ -199,11 +196,11 @@ export function isDownloadFloatTextureEnabled(
   return isFrameBufferComplete;
 }
 
-export function isWebGLFenceEnabled(webGLVersion: number, isBrowser: boolean) {
+export function isWebGLFenceEnabled(webGLVersion: number) {
   if (webGLVersion !== 2) {
     return false;
   }
-  const gl = getContext(webGLVersion);
+  const gl = getWebGLContext(webGLVersion);
 
   // tslint:disable-next-line:no-any
   const isEnabled = (gl as any).fenceSync != null;

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -16,7 +16,6 @@
  */
 
 import * as seedrandom from 'seedrandom';
-
 import {ENV} from '../environment';
 import {warn} from '../log';
 import * as array_ops_util from '../ops/array_ops_util';
@@ -35,7 +34,6 @@ import {DataId, Scalar, setTensorTracker, Tensor, Tensor1D, Tensor2D, Tensor3D, 
 import {DataType, DataTypeMap, Rank, ShapeMap, TypedArray, upcastType} from '../types';
 import * as util from '../util';
 import {now} from '../util';
-
 import {BackendTimingInfo, DataMover, DataStorage, KernelBackend} from './backend';
 import * as backend_util from './backend_util';
 import * as complex_util from './complex_util';
@@ -57,12 +55,13 @@ export class MathBackendCPU implements KernelBackend {
   public blockSize = 48;
 
   private data: DataStorage<TensorData<DataType>>;
-  private canvas: HTMLCanvasElement;
+  private fromPixels2DContext: CanvasRenderingContext2D;
   private firstUse = true;
 
   constructor() {
     if (ENV.get('IS_BROWSER')) {
-      this.canvas = document.createElement('canvas');
+      this.fromPixels2DContext =
+          document.createElement('canvas').getContext('2d');
     }
   }
 
@@ -123,16 +122,16 @@ export class MathBackendCPU implements KernelBackend {
     } else if (
         pixels instanceof HTMLImageElement ||
         pixels instanceof HTMLVideoElement) {
-      if (this.canvas == null) {
+      if (this.fromPixels2DContext == null) {
         throw new Error(
             'Can\'t read pixels from HTMLImageElement outside ' +
             'the browser.');
       }
-      this.canvas.width = pixels.width;
-      this.canvas.height = pixels.height;
-      this.canvas.getContext('2d').drawImage(
+      this.fromPixels2DContext.canvas.width = pixels.width;
+      this.fromPixels2DContext.canvas.height = pixels.height;
+      this.fromPixels2DContext.drawImage(
           pixels, 0, 0, pixels.width, pixels.height);
-      vals = this.canvas.getContext('2d')
+      vals = this.fromPixels2DContext
                  .getImageData(0, 0, pixels.width, pixels.height)
                  .data;
     } else {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {getWebGLCanvas, getWebGLContext} from '../canvas_util';
+import {getWebGLContext} from '../canvas_util';
 import {MemoryInfo, TimingInfo} from '../engine';
 import {ENV} from '../environment';
 import {tidy} from '../globals';
@@ -484,14 +484,14 @@ export class MathBackendWebGL implements KernelBackend {
       throw new Error('WebGL is not supported on this device');
     }
 
-    if (ENV.get('IS_BROWSER')) {
-      this.canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
-    }
     if (gpgpu == null) {
-      this.gpgpu = new GPGPUContext(getWebGLContext(ENV.get('WEBGL_VERSION')));
+      const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
+      this.gpgpu = new GPGPUContext(gl);
+      this.canvas = gl.canvas;
       this.gpgpuCreatedLocally = true;
     } else {
       this.gpgpuCreatedLocally = false;
+      this.canvas = gpgpu.gl.canvas;
     }
     if (ENV.get('WEBGL_PAGING_ENABLED')) {
       // Use the device screen's resolution as a heuristic to decide on the

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {getWebGLCanvas, getWebGLContext} from '../canvas_util';
 import {MemoryInfo, TimingInfo} from '../engine';
 import {ENV} from '../environment';
 import {tidy} from '../globals';
@@ -34,7 +35,6 @@ import {DataId, Scalar, setTensorTracker, Tensor, Tensor1D, Tensor2D, Tensor3D, 
 import {DataType, DataTypeMap, Rank, RecursiveArray, ShapeMap, sumOutType, TypedArray, upcastType} from '../types';
 import * as util from '../util';
 import {getTypedArrayFromDType, sizeFromShape} from '../util';
-
 import {DataMover, DataStorage, KernelBackend} from './backend';
 import * as backend_util from './backend_util';
 import {mergeRealAndImagArrays} from './complex_util';
@@ -68,7 +68,6 @@ import {GatherNDProgram} from './webgl/gather_nd_gpu';
 import {GPGPUContext} from './webgl/gpgpu_context';
 import * as gpgpu_math from './webgl/gpgpu_math';
 import {GPGPUBinary, GPGPUProgram, TensorData} from './webgl/gpgpu_math';
-import * as gpgpu_util from './webgl/gpgpu_util';
 import {Im2ColProgram} from './webgl/im2col_gpu';
 import {LRNProgram} from './webgl/lrn_gpu';
 import {LRNGradProgram} from './webgl/lrn_grad_gpu';
@@ -153,7 +152,7 @@ export class MathBackendWebGL implements KernelBackend {
   private NUM_BYTES_BEFORE_PAGING: number;
 
   private canvas: HTMLCanvasElement;
-  private fromPixelsCanvas: HTMLCanvasElement;
+  private fromPixels2DContext: CanvasRenderingContext2D;
 
   private programTimersStack: TimerNode[];
   private activeTimers: TimerNode[];
@@ -201,7 +200,7 @@ export class MathBackendWebGL implements KernelBackend {
           `ImageData, but was ${(pixels as {}).constructor.name}`);
     }
     if (pixels instanceof HTMLVideoElement) {
-      if (this.fromPixelsCanvas == null) {
+      if (this.fromPixels2DContext == null) {
         if (!ENV.get('IS_BROWSER')) {
           throw new Error(
               'Can\'t read pixels from HTMLImageElement outside the browser.');
@@ -212,13 +211,14 @@ export class MathBackendWebGL implements KernelBackend {
               'once the DOM is ready. One way to do that is to add an event ' +
               'listener for `DOMContentLoaded` on the document object');
         }
-        this.fromPixelsCanvas = document.createElement('canvas');
+        this.fromPixels2DContext =
+            document.createElement('canvas').getContext('2d');
       }
-      this.fromPixelsCanvas.width = pixels.width;
-      this.fromPixelsCanvas.height = pixels.height;
-      this.fromPixelsCanvas.getContext('2d').drawImage(
+      this.fromPixels2DContext.canvas.width = pixels.width;
+      this.fromPixels2DContext.canvas.height = pixels.height;
+      this.fromPixels2DContext.drawImage(
           pixels, 0, 0, pixels.width, pixels.height);
-      pixels = this.fromPixelsCanvas;
+      pixels = this.fromPixels2DContext.canvas;
     }
     const tempPixelHandle = this.makeTensorHandle(texShape, 'int32');
     // This is a byte texture with pixels.
@@ -483,11 +483,12 @@ export class MathBackendWebGL implements KernelBackend {
     if (ENV.get('WEBGL_VERSION') < 1) {
       throw new Error('WebGL is not supported on this device');
     }
+
     if (ENV.get('IS_BROWSER')) {
-      this.canvas = document.createElement('canvas');
+      this.canvas = getWebGLCanvas(ENV.get('WEBGL_VERSION'));
     }
     if (gpgpu == null) {
-      this.gpgpu = new GPGPUContext(gpgpu_util.createWebGLContext(this.canvas));
+      this.gpgpu = new GPGPUContext(getWebGLContext(ENV.get('WEBGL_VERSION')));
       this.gpgpuCreatedLocally = true;
     } else {
       this.gpgpuCreatedLocally = false;
@@ -1782,8 +1783,8 @@ export class MathBackendWebGL implements KernelBackend {
     }
     this.textureManager.dispose();
     this.canvas.remove();
-    if (this.fromPixelsCanvas != null) {
-      this.fromPixelsCanvas.remove();
+    if (this.fromPixels2DContext != null) {
+      this.fromPixels2DContext.canvas.remove();
     }
     if (this.gpgpuCreatedLocally) {
       this.gpgpu.dispose();

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -103,7 +103,6 @@ export class GPGPUContext {
     webgl_util.callAndCheck(gl, () => gl.bindFramebuffer(gl.FRAMEBUFFER, null));
     webgl_util.callAndCheck(gl, () => gl.deleteFramebuffer(this.framebuffer));
     webgl_util.callAndCheck(gl, () => gl.bindBuffer(gl.ARRAY_BUFFER, null));
-    // webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.vertexBuffer));
     webgl_util.callAndCheck(
         gl, () => gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null));
     webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.indexBuffer));

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -15,8 +15,10 @@
  * =============================================================================
  */
 
+import {getWebGLContext} from '../../canvas_util';
 import {ENV} from '../../environment';
 import * as util from '../../util';
+
 import * as gpgpu_util from './gpgpu_util';
 import {TextureConfig} from './gpgpu_util';
 import * as tex_util from './tex_util';
@@ -35,7 +37,6 @@ export class GPGPUContext {
   colorBufferFloatExtension: {};
   colorBufferHalfFloatExtension: {};
   getBufferSubDataAsyncExtension: {};
-  loseContextExtension: WEBGL_lose_context;
   disjointQueryTimerExtension: WebGL2DisjointQueryTimerExtension|
       WebGL1DisjointQueryTimerExtension;
   vertexBuffer: WebGLBuffer;
@@ -52,7 +53,7 @@ export class GPGPUContext {
     if (gl != null) {
       this.gl = gl;
     } else {
-      this.gl = gpgpu_util.createWebGLContext();
+      this.gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
     }
     // WebGL 2.0 enables texture floats without an extension.
     if (ENV.get('WEBGL_VERSION') === 1) {
@@ -71,10 +72,6 @@ export class GPGPUContext {
       this.colorBufferFloatExtension =
           webgl_util.getExtensionOrThrow(this.gl, 'EXT_color_buffer_float');
     }
-
-    this.loseContextExtension =
-        webgl_util.getExtensionOrThrow(this.gl, 'WEBGL_lose_context') as
-        WEBGL_lose_context;
 
     this.vertexBuffer = gpgpu_util.createVertexBuffer(this.gl);
     this.indexBuffer = gpgpu_util.createIndexBuffer(this.gl);
@@ -106,11 +103,10 @@ export class GPGPUContext {
     webgl_util.callAndCheck(gl, () => gl.bindFramebuffer(gl.FRAMEBUFFER, null));
     webgl_util.callAndCheck(gl, () => gl.deleteFramebuffer(this.framebuffer));
     webgl_util.callAndCheck(gl, () => gl.bindBuffer(gl.ARRAY_BUFFER, null));
-    webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.vertexBuffer));
+    // webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.vertexBuffer));
     webgl_util.callAndCheck(
         gl, () => gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null));
     webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.indexBuffer));
-    this.loseContextExtension.loseContext();
     this.disposed = true;
   }
 

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -18,7 +18,6 @@
 import {getWebGLContext} from '../../canvas_util';
 import {ENV} from '../../environment';
 import * as util from '../../util';
-
 import * as gpgpu_util from './gpgpu_util';
 import {TextureConfig} from './gpgpu_util';
 import * as tex_util from './tex_util';

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -21,18 +21,6 @@ import * as util from '../../util';
 import * as tex_util from './tex_util';
 import * as webgl_util from './webgl_util';
 
-export function getWebGLContextAttributes(): WebGLContextAttributes {
-  return {
-    alpha: false,
-    antialias: false,
-    premultipliedAlpha: false,
-    preserveDrawingBuffer: false,
-    depth: false,
-    stencil: false,
-    failIfMajorPerformanceCaveat: true
-  };
-}
-
 export interface TextureConfig {
   internalFormatFloat: number;
   textureFormatFloat: number;
@@ -46,27 +34,6 @@ export interface TextureConfig {
 
   defaultNumChannels: number;
   textureTypeHalfFloat: number;
-}
-
-export function createWebGLContext(canvas?: HTMLCanvasElement) {
-  const attributes = getWebGLContextAttributes();
-  let gl: WebGLRenderingContext;
-  if (canvas != null) {
-    gl = webgl_util.createWebGLRenderingContextFromCanvas(canvas, attributes);
-  } else {
-    gl = webgl_util.createWebGLRenderingContext(attributes);
-  }
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.DEPTH_TEST));
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.STENCIL_TEST));
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.BLEND));
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.DITHER));
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.POLYGON_OFFSET_FILL));
-  webgl_util.callAndCheck(gl, () => gl.disable(gl.SAMPLE_COVERAGE));
-  webgl_util.callAndCheck(gl, () => gl.enable(gl.SCISSOR_TEST));
-  webgl_util.callAndCheck(gl, () => gl.enable(gl.CULL_FACE));
-  webgl_util.callAndCheck(gl, () => gl.cullFace(gl.BACK));
-
-  return gl;
 }
 
 export function createVertexShader(gl: WebGLRenderingContext): WebGLShader {

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -18,34 +18,6 @@
 import {ENV} from '../../environment';
 import * as util from '../../util';
 
-export function createWebGLRenderingContext(attributes: WebGLContextAttributes):
-    WebGLRenderingContext {
-  const canvas = document.createElement('canvas');
-  canvas.width = 1;
-  canvas.height = 1;
-  return createWebGLRenderingContextFromCanvas(canvas, attributes);
-}
-
-export function createWebGLRenderingContextFromCanvas(
-    canvas: HTMLCanvasElement,
-    attributes: WebGLContextAttributes): WebGLRenderingContext {
-  let gl: WebGLRenderingContext;
-
-  const webglVersion = ENV.get('WEBGL_VERSION');
-  if (webglVersion === 2) {
-    gl = canvas.getContext('webgl2', attributes) as WebGLRenderingContext;
-  } else if (webglVersion === 1) {
-    gl = (canvas.getContext('webgl', attributes) ||
-          canvas.getContext('experimental-webgl', attributes)) as
-        WebGLRenderingContext;
-  }
-
-  if (webglVersion === 0 || gl == null) {
-    throw new Error('This browser does not support WebGL.');
-  }
-  return gl;
-}
-
 export function callAndCheck<T>(gl: WebGLRenderingContext, func: () => T): T {
   const returnValue = func();
   checkWebGLError(gl);


### PR DESCRIPTION
Because of repeated canvas construction, some unit tests fail on Linux where document.createElement('canvas') starts returning null, and Safari results in a lot of WebGL_CONTEXT_LOST warnings.

To avoid this, we cache the canvas, which enables also faster evaluation of webgl capabilities and speeds-up unit tests (by 10%) and general library init time (did not measure this).

Environment and GPGPU now share the same code for getting a WebGL context and canvas creation.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1350)
<!-- Reviewable:end -->
