### PR TITLE
Stop polling for the query timer extension when the GPGPU context is disposed

### DIFF
--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -46,8 +46,6 @@ export class GPGPUContext {
   private disposed = false;
   private autoDebugValidate = false;
   private disjoint: boolean;
-  private checkedAvailability: boolean;
-
   private textureConfig: TextureConfig;
 
   constructor(gl?: WebGLRenderingContext) {
@@ -447,12 +445,13 @@ export class GPGPUContext {
   }
 
   public async waitForQueryAndGetTime(query: WebGLQuery): Promise<number> {
-    if (this.checkedAvailability == null) {
-      await util.repeatedTry(
-          () => this.isQueryAvailable(
-              query, ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')));
-      this.checkedAvailability = true;
-    }
+    await util.repeatedTry(
+        () => this.disposed ||  // while testing contexts are created / disposed
+                                // in rapid succession, so without this check we
+                                // may poll for the query timer indefinitely
+            this.isQueryAvailable(
+                query,
+                ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')));
     return this.getQueryTime(
         query, ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION'));
   }

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -46,6 +46,7 @@ export class GPGPUContext {
   private disposed = false;
   private autoDebugValidate = false;
   private disjoint: boolean;
+  private checkedAvailability: boolean;
 
   private textureConfig: TextureConfig;
 
@@ -446,9 +447,12 @@ export class GPGPUContext {
   }
 
   public async waitForQueryAndGetTime(query: WebGLQuery): Promise<number> {
-    await util.repeatedTry(
-        () => this.isQueryAvailable(
-            query, ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')));
+    if (this.checkedAvailability == null) {
+      await util.repeatedTry(
+          () => this.isQueryAvailable(
+              query, ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')));
+      this.checkedAvailability = true;
+    }
     return this.getQueryTime(
         query, ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION'));
   }


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tfjs/issues/823

### Changes
- Bail out of polling for the query timer if the context has been disposed

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1352)
<!-- Reviewable:end -->
