### PR TITLE
Convert ComplexAbs to a kernel.

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -175,6 +175,7 @@ export interface KernelBackend extends TensorStorage, BackendTimer {
   clip<T extends Tensor>(x: T, min: number, max: number): T;
 
   abs<T extends Tensor>(x: T): T;
+  complexAbs<T extends Tensor>(x: T): T;
 
   sigmoid<T extends Tensor>(x: T): T;
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -1108,19 +1108,22 @@ export class MathBackendCPU implements KernelBackend {
   abs<T extends Tensor>(x: T): T {
     const resultValues = new Float32Array(x.size);
     const values = x.dataSync();
-
-    if (x.dtype === 'complex64') {
-      for (let i = 0; i < x.size; ++i) {
-        const real = values[i * 2];
-        const imag = values[i * 2 + 1];
-        resultValues[i] = Math.sqrt(real * real + imag * imag);
-      }
-    } else {
-      for (let i = 0; i < values.length; ++i) {
-        resultValues[i] = Math.abs(values[i]);
-      }
+    for (let i = 0; i < values.length; ++i) {
+      resultValues[i] = Math.abs(values[i]);
     }
 
+    return Tensor.make(x.shape, {values: resultValues}) as T;
+  }
+
+  complexAbs<T extends Tensor>(x: T): T {
+    const resultValues = new Float32Array(x.size);
+    const values = x.dataSync();
+
+    for (let i = 0; i < x.size; ++i) {
+      const real = values[i * 2];
+      const imag = values[i * 2 + 1];
+      resultValues[i] = Math.sqrt(real * real + imag * imag);
+    }
     return Tensor.make(x.shape, {values: resultValues}) as T;
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1241,19 +1241,20 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   abs<T extends Tensor>(x: T): T {
-    if (x.dtype === 'complex64') {
-      const xData = this.texData.get(x.dataId);
-
-      const program = new ComplexAbsProgram(x.shape);
-      const inputs = [
-        this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
-        this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
-      ];
-
-      return this.compileAndRun<Tensor>(program, inputs) as T;
-    }
     const program = new UnaryOpProgram(x.shape, unary_op.ABS);
     return this.compileAndRun(program, [x]) as T;
+  }
+
+  complexAbs<T extends Tensor>(x: T): T {
+    const xData = this.texData.get(x.dataId);
+
+    const program = new ComplexAbsProgram(x.shape);
+    const inputs = [
+      this.makeComplexComponentTensorHandle(x, xData.complexTensors.real),
+      this.makeComplexComponentTensorHandle(x, xData.complexTensors.imag),
+    ];
+
+    return this.compileAndRun<Tensor>(program, inputs) as T;
   }
 
   sigmoid<T extends Tensor>(x: T): T {

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -310,6 +310,10 @@ function reciprocal_<T extends Tensor>(x: T|TensorLike): T {
 function abs_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'abs');
 
+  if ($x.dtype === 'complex64') {
+    return ENV.engine.runKernel(backend => backend.complexAbs($x), {$x});
+  }
+
   const grad = (dy: T) => {
     return {$x: () => dy.mulStrict($x.toFloat().step(-1))};
   };


### PR DESCRIPTION
Node.js expects complex_abs as a kernel, not inside the implementation of the abs kernel.

Fixes https://github.com/tensorflow/tfjs/issues/843

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1353)
<!-- Reviewable:end -->
