### PR TITLE
WIP Change KernelBackend from an interface to a class

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -83,231 +83,496 @@ export interface BackendTimer {
  * methods, this can be done gradually (throw an error for unimplemented
  * methods).
  */
-export interface KernelBackend extends TensorStorage, BackendTimer {
+export class KernelBackend implements TensorStorage, BackendTimer {
+  time(f: () => void): Promise<BackendTimingInfo> {
+    throw new Error('Not yet implemented.');
+  }
+  read(dataId: object): Promise<Float32Array|Int32Array|Uint8Array> {
+    throw new Error('Not yet implemented.');
+  }
+  readSync(dataId: object): Float32Array|Int32Array|Uint8Array {
+    throw new Error('Not yet implemented.');
+  }
+  disposeData(dataId: object): void {
+    throw new Error('Not yet implemented.');
+  }
+  write(dataId: object, values: Float32Array|Int32Array|Uint8Array): void {
+    throw new Error('Not yet implemented.');
+  }
+  fromPixels(
+      pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
+      numChannels: number): Tensor<Rank.R3> {
+    throw new Error('Not yet implemented.');
+  }
+  register(
+      dataId: object, shape: number[],
+      dtype: 'float32'|'int32'|'bool'|'complex64'): void {
+    throw new Error('Not yet implemented.');
+  }
+  memory(): {unreliable: boolean;} {
+    throw new Error('Not yet implemented.');
+  }
   /** Returns the highest precision for floats in bits (e.g. 16 or 32) */
-  floatPrecision(): number;
+  floatPrecision(): number {
+    throw new Error('Not yet implemented');
+  }
 
   batchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean,
-      transposeB: boolean): Tensor3D;
+      transposeB: boolean): Tensor3D {
+    throw new Error('Not yet implemented');
+  }
 
-  slice<T extends Tensor>(x: T, begin: number[], size: number[]): T;
+  slice<T extends Tensor>(x: T, begin: number[], size: number[]): T {
+    throw new Error('Not yet implemented');
+  }
   stridedSlice<T extends Tensor>(
       x: T, begin: number[], end: number[], strides: number[],
       beginMask: number, endMask: number, ellipsisMask: number,
-      newAxisMask: number, shrinkAxisMask: number): T;
-  reverse<T extends Tensor>(a: T, axis: number[]): T;
+      newAxisMask: number, shrinkAxisMask: number): T {
+    throw new Error('Not yet implemented');
+  }
+  reverse<T extends Tensor>(a: T, axis: number[]): T {
+    throw new Error('Not yet implemented');
+  }
 
-  concat(tensors: Tensor[], axis: number): Tensor;
+  concat(tensors: Tensor[], axis: number): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  neg<T extends Tensor>(a: T): T;
+  neg<T extends Tensor>(a: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  add(a: Tensor, b: Tensor): Tensor;
-  addN<T extends Tensor>(tensors: T[]): T;
-  subtract(a: Tensor, b: Tensor): Tensor;
-  multiply(a: Tensor, b: Tensor): Tensor;
-  realDivide(a: Tensor, b: Tensor): Tensor;
-  floorDiv(a: Tensor, b: Tensor): Tensor;
+  add(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  addN<T extends Tensor>(tensors: T[]): T {
+    throw new Error('Not yet implemented');
+  }
+  subtract(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  multiply(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  realDivide(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  floorDiv(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  sum(x: Tensor, axes: number[]): Tensor;
-  prod(x: Tensor, axes: number[]): Tensor;
+  sum(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  prod(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
   unsortedSegmentSum<T extends Tensor>(
-      x: T, segmentIds: Tensor1D, numSegments: number): Tensor;
+      x: T, segmentIds: Tensor1D, numSegments: number): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  argMin(x: Tensor, axis: number): Tensor;
-  argMax(x: Tensor, axis: number): Tensor;
+  argMin(x: Tensor, axis: number): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  argMax(x: Tensor, axis: number): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  equal(a: Tensor, b: Tensor): Tensor;
-  notEqual(a: Tensor, b: Tensor): Tensor;
+  equal(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  notEqual(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  less(a: Tensor, b: Tensor): Tensor;
-  lessEqual(a: Tensor, b: Tensor): Tensor;
+  less(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  lessEqual(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  greater(a: Tensor, b: Tensor): Tensor;
-  greaterEqual(a: Tensor, b: Tensor): Tensor;
+  greater(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  greaterEqual(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  logicalNot<T extends Tensor>(a: T): T;
-  logicalAnd(a: Tensor, b: Tensor): Tensor;
-  logicalOr(a: Tensor, b: Tensor): Tensor;
+  logicalNot<T extends Tensor>(a: T): T {
+    throw new Error('Not yet implemented');
+  }
+  logicalAnd(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  logicalOr(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  where(condition: Tensor): Tensor2D;
-  select(condition: Tensor, a: Tensor, b: Tensor): Tensor;
+  where(condition: Tensor): Tensor2D {
+    throw new Error('Not yet implemented');
+  }
+  select(condition: Tensor, a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  topk<T extends Tensor>(x: T, k: number, sorted: boolean): [T, T];
+  topk<T extends Tensor>(x: T, k: number, sorted: boolean): [T, T] {
+    throw new Error('Not yet implemented');
+  }
 
-  min(x: Tensor, axes: number[]): Tensor;
-  minimum(a: Tensor, b: Tensor): Tensor;
+  min(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  minimum(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  mod(a: Tensor, b: Tensor): Tensor;
+  mod(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  max(x: Tensor, axes: number[]): Tensor;
-  maximum(a: Tensor, b: Tensor): Tensor;
+  max(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  maximum(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  all(x: Tensor, axes: number[]): Tensor;
-  any(x: Tensor, axes: number[]): Tensor;
+  all(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
+  any(x: Tensor, axes: number[]): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  squaredDifference(a: Tensor, b: Tensor): Tensor;
+  squaredDifference(a: Tensor, b: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
-  ceil<T extends Tensor>(x: T): T;
-  floor<T extends Tensor>(x: T): T;
-  round<T extends Tensor>(x: T): T;
+  ceil<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  floor<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  round<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  sign<T extends Tensor>(x: T): T;
+  sign<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  pow<T extends Tensor>(a: T, b: Tensor): T;
-  exp<T extends Tensor>(x: T): T;
-  expm1<T extends Tensor>(x: T): T;
-  log<T extends Tensor>(x: T): T;
-  log1p<T extends Tensor>(x: T): T;
-  sqrt<T extends Tensor>(x: T): T;
-  rsqrt<T extends Tensor>(x: T): T;
+  pow<T extends Tensor>(a: T, b: Tensor): T {
+    throw new Error('Not yet implemented');
+  }
+  exp<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  expm1<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  log<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  log1p<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  sqrt<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  rsqrt<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  square<T extends Tensor>(x: T): T;
-  reciprocal<T extends Tensor>(x: T): T;
+  square<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  reciprocal<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  relu<T extends Tensor>(x: T): T;
-  elu<T extends Tensor>(x: T): T;
-  eluDer<T extends Tensor>(dy: T, y: T): T;
-  selu<T extends Tensor>(x: T): T;
-  int<T extends Tensor>(x: T): T;
+  relu<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  elu<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  eluDer<T extends Tensor>(dy: T, y: T): T {
+    throw new Error('Not yet implemented');
+  }
+  selu<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  int<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  clip<T extends Tensor>(x: T, min: number, max: number): T;
+  clip<T extends Tensor>(x: T, min: number, max: number): T {
+    throw new Error('Not yet implemented');
+  }
 
-  abs<T extends Tensor>(x: T): T;
-  complexAbs<T extends Tensor>(x: T): T;
+  abs<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  complexAbs<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  sigmoid<T extends Tensor>(x: T): T;
+  sigmoid<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  softplus<T extends Tensor>(x: T): T;
+  softplus<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  sin<T extends Tensor>(x: T): T;
-  cos<T extends Tensor>(x: T): T;
-  tan<T extends Tensor>(x: T): T;
+  sin<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  cos<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  tan<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  asin<T extends Tensor>(x: T): T;
-  acos<T extends Tensor>(x: T): T;
-  atan<T extends Tensor>(x: T): T;
-  atan2<T extends Tensor>(a: T, b: T): T;
+  asin<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  acos<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  atan<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  atan2<T extends Tensor>(a: T, b: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  sinh<T extends Tensor>(x: T): T;
-  cosh<T extends Tensor>(x: T): T;
-  tanh<T extends Tensor>(x: T): T;
+  sinh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  cosh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  tanh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  asinh<T extends Tensor>(x: T): T;
-  acosh<T extends Tensor>(x: T): T;
-  atanh<T extends Tensor>(x: T): T;
+  asinh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  acosh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  atanh<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  erf<T extends Tensor>(x: T): T;
+  erf<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
 
-  step<T extends Tensor>(x: T, alpha: number): T;
+  step<T extends Tensor>(x: T, alpha: number): T {
+    throw new Error('Not yet implemented');
+  }
 
-  conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
+  conv2d(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
   conv2dDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D;
-  conv2dDerFilter(x: Tensor4D, dY: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
+  conv2dDerFilter(x: Tensor4D, dY: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   depthwiseConv2D(input: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
   depthwiseConv2DDerInput(dy: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
   depthwiseConv2DDerFilter(x: Tensor4D, dY: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
-  maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
+  maxPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
   maxPoolBackprop(dy: Tensor4D, x: Tensor4D, y: Tensor4D, convInfo: Conv2DInfo):
-      Tensor4D;
-  avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
-  avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
+  avgPool(x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
+  avgPoolBackprop(dy: Tensor4D, x: Tensor4D, convInfo: Conv2DInfo): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   reshape<T extends Tensor, R extends Rank>(x: T, shape: ShapeMap[R]):
-      Tensor<R>;
-  cast<T extends Tensor>(x: T, dtype: DataType): T;
+      Tensor<R> {
+    throw new Error('Not yet implemented');
+  }
+  cast<T extends Tensor>(x: T, dtype: DataType): T {
+    throw new Error('Not yet implemented');
+  }
 
-  tile<T extends Tensor>(x: T, reps: number[]): T;
+  tile<T extends Tensor>(x: T, reps: number[]): T {
+    throw new Error('Not yet implemented');
+  }
 
   pad<T extends Tensor>(
-      x: T, paddings: Array<[number, number]>, constantValue: number): T;
+      x: T, paddings: Array<[number, number]>, constantValue: number): T {
+    throw new Error('Not yet implemented');
+  }
 
-  transpose<T extends Tensor>(x: T, perm: number[]): T;
+  transpose<T extends Tensor>(x: T, perm: number[]): T {
+    throw new Error('Not yet implemented');
+  }
 
-  gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T;
+  gather<T extends Tensor>(x: T, indices: Tensor1D, axis: number): T {
+    throw new Error('Not yet implemented');
+  }
 
-  gatherND(x: Tensor, indices: Tensor): Tensor;
+  gatherND(x: Tensor, indices: Tensor): Tensor {
+    throw new Error('Not yet implemented');
+  }
 
   scatterND<R extends Rank>(
-      indices: Tensor, updates: Tensor, shape: ShapeMap[R]): Tensor<R>;
+      indices: Tensor, updates: Tensor, shape: ShapeMap[R]): Tensor<R> {
+    throw new Error('Not yet implemented');
+  }
 
   batchToSpaceND<T extends Tensor>(
-      x: T, blockShape: number[], crops: number[][]): T;
+      x: T, blockShape: number[], crops: number[][]): T {
+    throw new Error('Not yet implemented');
+  }
 
   spaceToBatchND<T extends Tensor>(
-      x: T, blockShape: number[], paddings: number[][]): T;
+      x: T, blockShape: number[], paddings: number[][]): T {
+    throw new Error('Not yet implemented');
+  }
 
   resizeBilinear(
       x: Tensor4D, newHeight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D;
+      alignCorners: boolean): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   resizeBilinearBackprop(dy: Tensor4D, x: Tensor4D, alignCorners: boolean):
-      Tensor4D;
+      Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   resizeNearestNeighbor(
       x: Tensor4D, newHEight: number, newWidth: number,
-      alignCorners: boolean): Tensor4D;
+      alignCorners: boolean): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   resizeNearestNeighborBackprop(
-      dy: Tensor4D, x: Tensor4D, alignCorners: boolean): Tensor4D;
+      dy: Tensor4D, x: Tensor4D, alignCorners: boolean): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   batchNormalization(
       x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
       varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
-      offset?: Tensor4D|Tensor1D): Tensor4D;
+      offset?: Tensor4D|Tensor1D): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   localResponseNormalization4D(
       x: Tensor4D, radius: number, bias: number, alpha: number,
-      beta: number): Tensor4D;
+      beta: number): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   LRNGrad(
       dy: Tensor4D, inputImage: Tensor4D, outputImage: Tensor4D, radius: number,
-      bias: number, alpha: number, beta: number): Tensor4D;
+      bias: number, alpha: number, beta: number): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   multinomial(
       logits: Tensor2D, normalized: boolean, numSamples: number,
-      seed: number): Tensor2D;
+      seed: number): Tensor2D {
+    throw new Error('Not yet implemented');
+  }
 
   oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):
-      Tensor2D;
+      Tensor2D {
+    throw new Error('Not yet implemented');
+  }
 
-  cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean): Tensor;
+  cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
+      Tensor {
+    throw new Error('Not yet implemented');
+  }
 
   nonMaxSuppression(
       boxes: Tensor2D, scores: Tensor1D, maxOutputSize: number,
-      iouThreshold: number, scoreThreshold?: number): Tensor1D;
+      iouThreshold: number, scoreThreshold?: number): Tensor1D {
+    throw new Error('Not yet implemented');
+  }
 
-  fft(x: Tensor2D): Tensor2D;
-  ifft(x: Tensor2D): Tensor2D;
-  complex<T extends Tensor>(real: T, imag: T): T;
-  real<T extends Tensor>(input: T): T;
-  imag<T extends Tensor>(input: T): T;
+  fft(x: Tensor2D): Tensor2D {
+    throw new Error('Not yet implemented');
+  }
+  ifft(x: Tensor2D): Tensor2D {
+    throw new Error('Not yet implemented');
+  }
+  complex<T extends Tensor>(real: T, imag: T): T {
+    throw new Error('Not yet implemented');
+  }
+  real<T extends Tensor>(input: T): T {
+    throw new Error('Not yet implemented');
+  }
+  imag<T extends Tensor>(input: T): T {
+    throw new Error('Not yet implemented');
+  }
 
   cropAndResize(
       image: Tensor4D, boxes: Tensor2D, boxIndex: Tensor1D,
       cropSize: [number, number], method: 'bilinear'|'nearest',
-      extrapolationValue: number): Tensor4D;
+      extrapolationValue: number): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
-  depthToSpace(x: Tensor4D, blockSize: number, dataFormat: string): Tensor4D;
+  depthToSpace(x: Tensor4D, blockSize: number, dataFormat: string): Tensor4D {
+    throw new Error('Not yet implemented');
+  }
 
   // Aligns with the "SplitV" kernel in TensorFlow.
-  split<T extends Tensor>(value: T, sizeSplits: number[], axis: number): T[];
+  split<T extends Tensor>(value: T, sizeSplits: number[], axis: number): T[] {
+    throw new Error('Not yet implemented');
+  }
 
   sparseToDense<R extends Rank>(
       sparseIndices: Tensor, sparseValues: Tensor, outputShape: ShapeMap[R],
-      defaultValue: Scalar): Tensor<R>;
+      defaultValue: Scalar): Tensor<R> {
+    throw new Error('Not yet implemented');
+  }
   /**
    * Sets the data mover for this backend. Backends should use the mover to
    * move data from other backends to this backend.
    */
-  setDataMover(dataMover: DataMover): void;
+  setDataMover(dataMover: DataMover): void {
+    throw new Error('Not yet implemented');
+  }
 
-  dispose(): void;
+  dispose(): void {
+    throw new Error('Not yet implemented');
+  }
 }


### PR DESCRIPTION
This allows all Backends to not break whenever we add a new method in core. Instead all backends get a default "Not implemented" implementation.

This allows us to run Travis nightly on `tfjs-node` and get a log with all the failing unit tests without being prematurely terminated by a compiler build error.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1355)
<!-- Reviewable:end -->
