### PR TITLE
confusionMatrix: Address args and return types inconsistency with py tf

### DIFF
--- a/src/ops/confusion_matrix.ts
+++ b/src/ops/confusion_matrix.ts
@@ -46,7 +46,7 @@ import {op} from './operation';
  * @param numClasses Number of all classes, as an integer.
  *   Its value must be larger than the largest element in `labels` and
  *   `predictions`.
- * @returns The confusion matrix as a 2D tensor. The value at
+ * @returns The confusion matrix as a int32-type 2D tensor. The value at
  *   row `r` and column `c` is the number of times examples of actual class
  *   `r` were predicted as class `c`.
  */
@@ -80,9 +80,9 @@ export function confusionMatrix_(
   // TODO(cais): In the future, if oneHot supports tensors inputs for
   //   `numClasses`, `confusionMatrix` can make `numClasses` optional.
 
-  const oneHotLabels = oneHot($labels, numClasses);
-  const oneHotPredictions = oneHot($predictions, numClasses);
-  return oneHotLabels.transpose().matMul(oneHotPredictions);
+  const oneHotLabels = oneHot($labels.asType('int32'), numClasses);
+  const oneHotPredictions = oneHot($predictions.asType('int32'), numClasses);
+  return oneHotLabels.transpose().matMul(oneHotPredictions).asType('int32');
 }
 
 export const confusionMatrix = op({confusionMatrix_});

--- a/src/ops/confusion_matrix_test.ts
+++ b/src/ops/confusion_matrix_test.ts
@@ -42,7 +42,17 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const predictions = tf.tensor1d([0, 2, 2, 1, 0], 'int32');
     const numClasses = 3;
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
-    expectArraysEqual(out, tf.tensor2d([[2, 0, 0], [0, 1, 1], [0, 0, 1]]));
+    expectArraysEqual(
+        out, tf.tensor2d([[2, 0, 0], [0, 1, 1], [0, 0, 1]], [3, 3], 'int32'));
+  });
+
+  it('float32 arguments are accepted', () => {
+    const labels = tf.tensor1d([0, 1, 2, 1, 0], 'float32');
+    const predictions = tf.tensor1d([0, 2, 2, 1, 0], 'float32');
+    const numClasses = 3;
+    const out = tf.math.confusionMatrix(labels, predictions, numClasses);
+    expectArraysEqual(
+        out, tf.tensor2d([[2, 0, 0], [0, 1, 1], [0, 0, 1]], [3, 3], 'int32'));
   });
 
   // Reference (Python) TensorFlow code:
@@ -65,7 +75,9 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
     expectArraysEqual(
         out,
-        tf.tensor2d([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]]));
+        tf.tensor2d(
+            [[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]], [4, 4],
+            'int32'));
   });
 
   it('4x4 all cases present in predictions, but not labels', () => {
@@ -75,7 +87,9 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
     expectArraysEqual(
         out,
-        tf.tensor2d([[2, 2, 0, 0], [0, 0, 0, 0], [0, 0, 2, 2], [0, 0, 0, 0]]));
+        tf.tensor2d(
+            [[2, 2, 0, 0], [0, 0, 0, 0], [0, 0, 2, 2], [0, 0, 0, 0]], [4, 4],
+            'int32'));
   });
 
   it('Plain arrays as inputs', () => {
@@ -85,7 +99,9 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
     expectArraysEqual(
         out,
-        tf.tensor2d([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]]));
+        tf.tensor2d(
+            [[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]], [4, 4],
+            'int32'));
   });
 
   it('Int32Arrays as inputs', () => {
@@ -95,7 +111,9 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
     expectArraysEqual(
         out,
-        tf.tensor2d([[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]]));
+        tf.tensor2d(
+            [[2, 0, 0, 0], [2, 0, 0, 0], [0, 0, 2, 0], [0, 0, 2, 0]], [4, 4],
+            'int32'));
   });
 
   // Reference (Python) TensorFlow code:
@@ -116,10 +134,14 @@ describeWithFlags('confusionMatrix', ALL_ENVS, () => {
     const predictions = tf.tensor1d([4, 0], 'int32');
     const numClasses = 5;
     const out = tf.math.confusionMatrix(labels, predictions, numClasses);
-    expectArraysEqual(out, tf.tensor2d([
-      [0, 0, 0, 0, 1], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0],
-      [1, 0, 0, 0, 0]
-    ]));
+    expectArraysEqual(
+        out,
+        tf.tensor2d(
+            [
+              [0, 0, 0, 0, 1], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0],
+              [0, 0, 0, 0, 0], [1, 0, 0, 0, 0]
+            ],
+            [5, 5], 'int32'));
   });
 
   it('Invalid numClasses leads to Error', () => {


### PR DESCRIPTION
- Make sure the returned tensor is int32
- Make sure that float32 args are accepted

Fixes: https://github.com/tensorflow/tfjs/issues/846

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1359)
<!-- Reviewable:end -->
