### PR TITLE
Fix pool() when dilation > 1

### DIFF
--- a/src/ops/pool.ts
+++ b/src/ops/pool.ts
@@ -441,7 +441,7 @@ function avgPoolBackprop<T extends Tensor3D|Tensor4D>(
 
 // Helper function to compute crops and paddings for pool with dilation > 1.
 // tslint:disable-next-line:max-line-length
-// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L1037
+// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/array_ops.py#L2184
 function requiredSpaceToBatchPaddings(
     inputShape: [number, number], blockShape: [number, number],
     basePadding: number[][]) {
@@ -457,7 +457,7 @@ function requiredSpaceToBatchPaddings(
 
 // Helper function to compute base paddings for pool with dilation > 1.
 // tslint:disable-next-line:max-line-length
-// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L1037
+// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L524
 function withSpaceToBatchBasePaddings(
     filterShape: [number, number], dilation: [number, number]) {
   // Spatial dimensions of the filters and the upsampled filters in which we

--- a/src/ops/pool.ts
+++ b/src/ops/pool.ts
@@ -20,6 +20,7 @@ import {Tensor, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
+import {batchToSpaceND, spaceToBatchND} from './array_ops';
 import * as conv_util from './conv_util';
 import {op} from './operation';
 
@@ -243,7 +244,7 @@ function avgPool_<T extends Tensor3D|Tensor4D>(
  *    - For more info, see this guide:
  *     [https://www.tensorflow.org/api_guides/python/nn#Convolution](
  *         https://www.tensorflow.org/api_guides/python/nn#Convolution)
- * @param dilationRate The dilation rates: `[dilationHeight, dilationWidth]`
+ * @param dilations The dilation rates: `[dilationHeight, dilationWidth]`
  *     in which we sample input values across the height and width dimensions
  *     in dilated pooling. Defaults to `[1, 1]`. If `dilationRate` is a single
  *     number, then `dilationHeight == dilationWidth`. If it is greater than
@@ -254,19 +255,62 @@ function avgPool_<T extends Tensor3D|Tensor4D>(
 /** @doc {heading: 'Operations', subheading: 'Convolution'} */
 function pool_<T extends Tensor3D|Tensor4D>(
     input: T|TensorLike, windowShape: [number, number]|number,
-    poolingType: 'avg'|'max', padding: 'valid'|'same'|number,
-    dilationRate?: [number, number]|number, strides?: [number, number]|number) {
-  if (dilationRate == null) {
-    dilationRate = 1;
+    poolingType: 'avg'|'max', pad: 'valid'|'same'|number,
+    dilations?: [number, number]|number, strides?: [number, number]|number) {
+  if (dilations == null) {
+    dilations = [1, 1];
   }
   if (strides == null) {
     strides = 1;
   }
-  if (poolingType === 'avg') {
-    return avgPoolImpl_(input, windowShape, strides, dilationRate, padding);
-  } else {
-    return maxPoolImpl_(input, windowShape, strides, dilationRate, padding);
+  if (pad === 0) {
+    pad = 'valid';
   }
+  const $x = convertToTensor(input, 'x', 'maxPool');
+  let x4D = $x as Tensor4D;
+  let reshapedTo4D = false;
+  if ($x.rank === 3) {
+    reshapedTo4D = true;
+    x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
+  }
+  util.assert(
+      conv_util.eitherStridesOrDilationsAreOne(strides, dilations),
+      'Error in pool: Either strides or dilations must be 1. ' +
+          `Got strides ${strides} and dilations '${dilations}'`);
+  const convInfo = conv_util.computePool2DInfo(
+      x4D.shape, windowShape, strides, dilations, pad);
+  const dilation: [number, number] =
+      [convInfo.dilationHeight, convInfo.dilationWidth];
+
+  // The following implementation does batchToSpace(pool(spaceToBatch(x)))
+  // whenever dilation > 1 since the TF kernels do not support dilation > 1.
+  // tslint:disable-next-line:max-line-length
+  // https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L1037
+
+  let basePadding: number[][];
+  if (pad === 'same') {
+    basePadding = withSpaceToBatchBasePaddings(
+        [convInfo.filterHeight, convInfo.filterWidth], dilation);
+  } else {
+    basePadding = [[0, 0], [0, 0]];
+  }
+  const isDilationOne = dilation[0] === 1 && dilation[1] === 1;
+  const [adjustedPadding, adjustedCrops] = requiredSpaceToBatchPaddings(
+      [convInfo.inHeight, convInfo.inWidth], dilation, basePadding);
+  const convertedPad = isDilationOne ? pad : 'valid';
+  const convertedX =
+      isDilationOne ? x4D : spaceToBatchND(x4D, dilation, adjustedPadding);
+  const forwardOp = poolingType === 'avg' ?
+      () => avgPoolImpl_(
+          convertedX, windowShape, strides, 1 /* dilation */, convertedPad) :
+      () => maxPoolImpl_(
+          convertedX, windowShape, strides, 1 /* dilation */, convertedPad);
+  const y = forwardOp();
+  const res = isDilationOne ? y : batchToSpaceND(y, dilation, adjustedCrops);
+  if (reshapedTo4D) {
+    return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
+  }
+  return res as T;
 }
 
 /**
@@ -393,6 +437,43 @@ function avgPoolBackprop<T extends Tensor3D|Tensor4D>(
     return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
   }
   return res as T;
+}
+
+// Helper function to compute crops and paddings for pool with dilation > 1.
+// tslint:disable-next-line:max-line-length
+// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L1037
+function requiredSpaceToBatchPaddings(
+    inputShape: [number, number], blockShape: [number, number],
+    basePadding: number[][]) {
+  const padStart = basePadding.map(b => b[0]);
+  const origPadEnd = basePadding.map(b => b[1]);
+  const fullInputShape = inputShape.concat(padStart, origPadEnd);
+  const padEndExtra = blockShape.map((b, i) => (b - fullInputShape[i] % b) % b);
+  const padEnd = origPadEnd.map((s, i) => s + padEndExtra[i]);
+  const paddings = blockShape.map((_, i) => [padStart[i], padEnd[i]]);
+  const crops = blockShape.map((_, i) => [0, padEndExtra[i]]);
+  return [paddings, crops];
+}
+
+// Helper function to compute base paddings for pool with dilation > 1.
+// tslint:disable-next-line:max-line-length
+// https://github.com/tensorflow/tensorflow/blob/50f6bb67dc98c9b74630b6047aae7a4f8a40fd02/tensorflow/python/ops/nn_ops.py#L1037
+function withSpaceToBatchBasePaddings(
+    filterShape: [number, number], dilation: [number, number]) {
+  // Spatial dimensions of the filters and the upsampled filters in which we
+  // introduce (rate - 1) zeros between consecutive filter values.
+  const dilatedFilterShape = filterShape.map((s, i) => {
+    return s + (s - 1) * (dilation[i] - 1);
+  });
+  const padExtraShape = dilatedFilterShape.map(s => s - 1);
+
+  // When padding is odd, we pad more at end, following the same
+  // convention as conv2d.
+  const padExtraStart = padExtraShape.map(s => Math.floor(s / 2));
+  const padExtraEnd = padExtraShape.map((s, i) => s - padExtraStart[i]);
+  return padExtraShape.map((_, i) => {
+    return [padExtraStart[i], padExtraEnd[i]];
+  });
 }
 
 export const maxPool = op({maxPool_});


### PR DESCRIPTION
TF C Pool kernels do not support dilation > 1. Instead, a Python code uses the following transformation:
`batchToSpace(pool(spaceToBatch(x,...), dilation=1), ...)` to transform `dilation>1` into `dilation=1`. This PR ports that Python code to tfjs-core, which fixes https://github.com/tensorflow/tfjs/issues/847

Tested that all pool tests with dilation > 1 pass with tfjs-node by linking tfjs-core@master.

BUG
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1367)
<!-- Reviewable:end -->
