### PR TITLE
Add docs for tf.io.browserFiles() and tf.io.browserDownloads()

### DIFF
--- a/src/io/browser_files.ts
+++ b/src/io/browser_files.ts
@@ -280,6 +280,7 @@ IORouterRegistry.registerSaveRouter(browserDownloadsRouter);
  * @param config Additional configuration for triggering downloads.
  * @returns An instance of `DownloadTrigger` `IOHandler`.
  */
+/** @doc {heading: 'Models', subheading: 'Loading', namespace: 'io'} */
 export function browserDownloads(fileNamePrefix = 'model'): IOHandler {
   return new BrowserDownloads(fileNamePrefix);
 }
@@ -317,6 +318,7 @@ export function browserDownloads(fileNamePrefix = 'model'): IOHandler {
  *     topology will be loaded from the JSON file above.
  * @returns An instance of `Files` `IOHandler`.
  */
+/** @doc {heading: 'Models', subheading: 'Loading', namespace: 'io'} */
 export function browserFiles(files: File[]): IOHandler {
   return new BrowserFiles(files);
 }


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->

This PR adds JSDoc marks to the methods `tf.io.browserFiles()` and `tf.io.browserDownloads()` to make sure that they get compiled into the web documentation. Note that these methods already had docstrings, they just weren't marked for the web docs.

I wasn't quite sure under what subheading they would fit best, so I went with `Model / Loading` which seemed to be the most relevant existing subheading. If you think it'd be better to move them elsewhere, let me know!

Closes https://github.com/tensorflow/tfjs/issues/839.


#### Demo

Here's what the two methods look like on the docs page, developing locally:

![browserdownloads](https://user-images.githubusercontent.com/14170650/47814237-82a14100-dd23-11e8-89e0-fe69a206863f.png)
![browserfiles](https://user-images.githubusercontent.com/14170650/47814238-846b0480-dd23-11e8-84ba-629f8cc20096.png)


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1368)
<!-- Reviewable:end -->
