### PR TITLE
allow user to specify the path prefix for weight files

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -186,7 +186,7 @@ export class BrowserHTTPRequest implements IOHandler {
   private async loadWeights(weightsManifest: WeightsManifestConfig):
       Promise<[WeightsManifestEntry[], ArrayBuffer]> {
     let pathPrefix = this.weightPathPrefix;
-    if (!pathPrefix) {
+    if (pathPrefix == null) {
       const weightPath = Array.isArray(this.path) ? this.path[1] : this.path;
 
       pathPrefix = weightPath.substring(0, weightPath.lastIndexOf('/'));
@@ -194,17 +194,17 @@ export class BrowserHTTPRequest implements IOHandler {
         pathPrefix = pathPrefix + '/';
       }
     }
+    const weightSpecs = [];
+    for (const entry of weightsManifest) {
+      weightSpecs.push(...entry.weights);
+    }
+
     const fetchURLs: string[] = [];
     weightsManifest.forEach(weightsGroup => {
       weightsGroup.paths.forEach(path => {
         fetchURLs.push(pathPrefix + path);
       });
     });
-
-    const weightSpecs = [];
-    for (const entry of weightsManifest) {
-      weightSpecs.push(...entry.weights);
-    }
 
     return [
       weightSpecs,

--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -35,7 +35,9 @@ export class BrowserHTTPRequest implements IOHandler {
 
   static readonly URL_SCHEME_REGEX = /^https?:\/\//;
 
-  constructor(path: string|string[], requestInit?: RequestInit) {
+  constructor(
+      path: string|string[], requestInit?: RequestInit,
+      private readonly weightPathPrefix?: string) {
     if (typeof fetch === 'undefined') {
       throw new Error(
           // tslint:disable-next-line:max-line-length
@@ -183,16 +185,14 @@ export class BrowserHTTPRequest implements IOHandler {
 
   private async loadWeights(weightsManifest: WeightsManifestConfig):
       Promise<[WeightsManifestEntry[], ArrayBuffer]> {
-    const weightPath = Array.isArray(this.path) ? this.path[1] : this.path;
+    let pathPrefix = this.weightPathPrefix;
+    if (!pathPrefix) {
+      const weightPath = Array.isArray(this.path) ? this.path[1] : this.path;
 
-    const weightSpecs = [];
-    for (const entry of weightsManifest) {
-      weightSpecs.push(...entry.weights);
-    }
-
-    let pathPrefix = weightPath.substring(0, weightPath.lastIndexOf('/'));
-    if (!pathPrefix.endsWith('/')) {
-      pathPrefix = pathPrefix + '/';
+      pathPrefix = weightPath.substring(0, weightPath.lastIndexOf('/'));
+      if (!pathPrefix.endsWith('/')) {
+        pathPrefix = pathPrefix + '/';
+      }
     }
     const fetchURLs: string[] = [];
     weightsManifest.forEach(weightsGroup => {
@@ -200,6 +200,12 @@ export class BrowserHTTPRequest implements IOHandler {
         fetchURLs.push(pathPrefix + path);
       });
     });
+
+    const weightSpecs = [];
+    for (const entry of weightsManifest) {
+      weightSpecs.push(...entry.weights);
+    }
+
     return [
       weightSpecs,
       concatenateArrayBuffers(
@@ -369,9 +375,12 @@ IORouterRegistry.registerLoadRouter(httpRequestRouter);
  * topology (filename: 'model.json') and the weights of the model (filename:
  * 'model.weights.bin') will be appended to the body. If `requestInit` has a
  * `body`, an Error will be thrown.
+ * @param weightPathPrefix Optional, this specifies the path prefix for weight
+ * files, by default this is calculated from the path param.
  * @returns An instance of `IOHandler`.
  */
 export function browserHTTPRequest(
-    path: string|string[], requestInit?: RequestInit): IOHandler {
-  return new BrowserHTTPRequest(path, requestInit);
+    path: string|string[], requestInit?: RequestInit,
+    weightPathPrefix?: string): IOHandler {
+  return new BrowserHTTPRequest(path, requestInit, weightPathPrefix);
 }


### PR DESCRIPTION
This is required by integration with TF-Hub, where the weight files path prefix cannot be directly calculated from the manifest file url.
This way, the FrozenModel class can specify the weight file path directly.

#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1369)
<!-- Reviewable:end -->
