### PR TITLE
WebGL backend should hand off kernel execution to CPU if inputs are small and on the CPU

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -645,10 +645,6 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   multiply(a: Tensor, b: Tensor): Tensor {
-    if (this.shouldExecuteOnCPU([a, b])) {
-      return this.cpuBackend.multiply(a, b);
-    }
-
     if (a.dtype === 'complex64') {
       const aData = this.texData.get(a.dataId);
       const bData = this.texData.get(b.dataId);
@@ -671,6 +667,10 @@ export class MathBackendWebGL implements KernelBackend {
       real.dispose();
       imag.dispose();
       return complex;
+    }
+
+    if (this.shouldExecuteOnCPU([a, b])) {
+      return this.cpuBackend.multiply(a, b);
     }
 
     const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
@@ -1173,12 +1173,12 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   subtract(a: Tensor, b: Tensor): Tensor {
-    if (this.shouldExecuteOnCPU([a, b])) {
-      return this.cpuBackend.subtract(a, b);
-    }
-
     if (a.dtype === 'complex64' && b.dtype === 'complex64') {
       return this.complexSeparableBinaryOp(a, b, binaryop_gpu.SUB);
+    }
+
+    if (this.shouldExecuteOnCPU([a, b])) {
+      return this.cpuBackend.subtract(a, b);
     }
 
     const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tfjs/issues/826

### Changes
- Added a `shouldExecuteOnCPU` method to the `MathBackendWebGL` that checks whether inputs are on the CPU and within a size threshold
- Singled out certain ops (`stridedSlice`, `slice`, `concat`, `min`, `max`, `subtract`, `multiply`, `greater`, `less`) for passing kernel execution to the CPU if conditions are met. These are the ops that get called most frequently in COCO SSD with tiny inputs. 

This PR is not productionized (no tests or environment flag) - I wasn't sure whether we wanted to just experiment with the approach first.

### COCO SSD benchmark

on `master`: 277ms
on `webgl_cpu_handoff`: 184ms *(+50.5%)*

These are prediction times across 20 runs.

#### Note

I think there's a better way to write this so we don't have to repeat the checking logic in so many places. If we just create an array of kernel names we want to apply this treatment to, then we could loop through them and forward to the CPU using *arguments*. And if we could get a list of all the kernels then we could apply the treatment across the webGL backend. But it might require some TypeScript overrides...

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
