### PR TITLE
Fix tf.pow() gradient to use power rule instead of dividing by x (which can be 0).

### DIFF
--- a/src/ops/arithmetic_test.ts
+++ b/src/ops/arithmetic_test.ts
@@ -670,6 +670,13 @@ describeWithFlags('pow', ALL_ENVS, () => {
     expectArraysClose(db, [3 * Math.pow(5, 2) * Math.log(5)]);
   });
 
+  it('gradients: x ^ 2 where x = 0', () => {
+    const f = (x: tf.Scalar) => x.pow(tf.scalar(2)).asScalar();
+    const g = tf.grad(f)(tf.scalar(0));
+
+    expectArraysClose(g, [0]);
+  });
+
   it('gradients: Scalar ^ Scalar fractional exponent', () => {
     const a = tf.scalar(4.0);
     const b = tf.scalar(1.5);

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -252,7 +252,8 @@ function pow_<T extends Tensor>(base: T|TensorLike, exp: Tensor|TensorLike): T {
   const grad = (dy: Tensor, saved: Tensor[]) => {
     const [y] = saved;
     const derBase = () => {
-      let res = dy.mul($exp.toFloat().mul(y.div($base)));
+      const expFloat = $exp.toFloat();
+      let res = dy.mul(expFloat.mul($base.pow(expFloat.sub(scalar(1)))));
       const reduceAxes = broadcast_util.getReductionAxes($base.shape, outShape);
       if (reduceAxes.length > 0) {
         res = res.sum(reduceAxes);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1376)
<!-- Reviewable:end -->
