### PR TITLE
Speedup matmul when the matrices are vectors

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -605,11 +605,12 @@ export class MathBackendWebGL implements KernelBackend {
 
     // Since the matrices are vectors, it is faster to call mul().sum()
     // because sum() is O(sqrt(N)) due to divide-and-conquer.
-    if (firstDim === 1 && secondDim === 1 &&
+    if ((firstDim === 1 || secondDim === 1) &&
         sharedDim > reduce_util.PARALLELIZE_THRESHOLD) {
-      const a2D = a.as2D(batch, -1);
-      const b2D = b.as2D(batch, -1);
-      return this.multiply(a2D, b2D).sum(1 /* axis */).as3D(batch, 1, 1);
+      const a3D = secondDim === 1 ? a : a.as3D(batch, sharedDim, 1);
+      const axis = secondDim === 1 ? 2 : 1;
+      const b3D = secondDim === 1 ? b.as3D(batch, 1, sharedDim) : b;
+      return this.multiply(a3D, b3D).sum(axis, true /* keepDims */);
     }
 
     // TODO(https://github.com/tensorflow/tfjs/issues/693): Support 3D tensors

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -600,8 +600,19 @@ export class MathBackendWebGL implements KernelBackend {
     const outerShapeA = transposeA ? a.shape[2] : a.shape[1];
     const outerShapeB = transposeB ? b.shape[1] : b.shape[2];
 
+    const [batch, firstDim, ] = a.shape;
+    const [, , secondDim] = b.shape;
+
+    if (firstDim === 1 && secondDim === 1) {
+      const a2D = a.as2D(batch, -1);
+      const b2D = b.as2D(batch, -1);
+      // Since the matrices are vectors, it is faster to call mul().sum()
+      // because sum() is O(sqrt(N)) due to divide-and-conquer.
+      return this.multiply(a2D, b2D).sum(1 /* axis */).as3D(batch, 1, 1);
+    }
+
     // TODO(https://github.com/tensorflow/tfjs/issues/693): Support 3D tensors
-    if (a.shape[0] === 1 && b.shape[0] === 1) {
+    if (batch === 1) {
       const aSqueezed = a.as2D(a.shape[1], a.shape[2]);
       const bSqueezed = b.as2D(b.shape[1], b.shape[2]);
 

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -296,7 +296,32 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     const a = tf.ones([batch, 1, sharedDim]);
     const b = tf.ones([batch, sharedDim, 1]);
     const result = tf.matMul(a, b);
+    expect(result.shape).toEqual([batch, 1, 1]);
     expectArraysClose(result, [sharedDim, sharedDim, sharedDim]);
+  });
+
+  it('batched matmul with matrix x vector', () => {
+    const batch = 3;
+    const sharedDim = 10000;
+    const a = tf.ones([batch, 2, sharedDim]);
+    const b = tf.ones([batch, sharedDim, 1]);
+    const result = tf.matMul(a, b);
+    expect(result.shape).toEqual([batch, 2, 1]);
+    expectArraysClose(
+        result,
+        [sharedDim, sharedDim, sharedDim, sharedDim, sharedDim, sharedDim]);
+  });
+
+  it('batched matmul with vector x matrix', () => {
+    const batch = 3;
+    const sharedDim = 10000;
+    const a = tf.ones([batch, 1, sharedDim]);
+    const b = tf.ones([batch, sharedDim, 2]);
+    const result = tf.matMul(a, b);
+    expect(result.shape).toEqual([batch, 1, 2]);
+    expectArraysClose(
+        result,
+        [sharedDim, sharedDim, sharedDim, sharedDim, sharedDim, sharedDim]);
   });
 
   it('Matrix * vector propagates NaNs', () => {

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -290,7 +290,7 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     expectArraysClose(result, expected);
   });
 
-  it('matmul forwards to dot product', () => {
+  it('batched matmul with the matrices being vectors', () => {
     const batch = 3;
     const sharedDim = 10;
     const a = tf.ones([batch, 1, sharedDim]);

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -290,6 +290,15 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     expectArraysClose(result, expected);
   });
 
+  it('matmul forwards to dot product', () => {
+    const batch = 3;
+    const sharedDim = 10;
+    const a = tf.ones([batch, 1, sharedDim]);
+    const b = tf.ones([batch, sharedDim, 1]);
+    const result = tf.matMul(a, b);
+    expectArraysClose(result, [10, 10, 10]);
+  });
+
   it('Matrix * vector propagates NaNs', () => {
     const matrix = tf.tensor2d([1, 2, 3, 4], [2, 2]);
     const v = tf.tensor1d([2, NaN]);

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -293,35 +293,31 @@ describeWithFlags('matmul', ALL_ENVS, () => {
   it('batched matmul with the matrices being vectors', () => {
     const batch = 3;
     const sharedDim = 10000;
-    const a = tf.ones([batch, 1, sharedDim]);
-    const b = tf.ones([batch, sharedDim, 1]);
+    const a = tf.fill([batch, 1, sharedDim], 0.1);
+    const b = tf.fill([batch, sharedDim, 1], 0.1);
     const result = tf.matMul(a, b);
     expect(result.shape).toEqual([batch, 1, 1]);
-    expectArraysClose(result, [sharedDim, sharedDim, sharedDim]);
+    expectArraysClose(result, [100, 100, 100]);
   });
 
   it('batched matmul with matrix x vector', () => {
     const batch = 3;
     const sharedDim = 10000;
-    const a = tf.ones([batch, 2, sharedDim]);
-    const b = tf.ones([batch, sharedDim, 1]);
+    const a = tf.fill([batch, 2, sharedDim], 0.1);
+    const b = tf.fill([batch, sharedDim, 1], 0.1);
     const result = tf.matMul(a, b);
     expect(result.shape).toEqual([batch, 2, 1]);
-    expectArraysClose(
-        result,
-        [sharedDim, sharedDim, sharedDim, sharedDim, sharedDim, sharedDim]);
+    expectArraysClose(result, [100, 100, 100, 100, 100, 100]);
   });
 
   it('batched matmul with vector x matrix', () => {
     const batch = 3;
     const sharedDim = 10000;
-    const a = tf.ones([batch, 1, sharedDim]);
-    const b = tf.ones([batch, sharedDim, 2]);
+    const a = tf.fill([batch, 1, sharedDim], 0.1);
+    const b = tf.fill([batch, sharedDim, 2], 0.1);
     const result = tf.matMul(a, b);
     expect(result.shape).toEqual([batch, 1, 2]);
-    expectArraysClose(
-        result,
-        [sharedDim, sharedDim, sharedDim, sharedDim, sharedDim, sharedDim]);
+    expectArraysClose(result, [100, 100, 100, 100, 100, 100]);
   });
 
   it('Matrix * vector propagates NaNs', () => {

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -292,11 +292,11 @@ describeWithFlags('matmul', ALL_ENVS, () => {
 
   it('batched matmul with the matrices being vectors', () => {
     const batch = 3;
-    const sharedDim = 10;
+    const sharedDim = 10000;
     const a = tf.ones([batch, 1, sharedDim]);
     const b = tf.ones([batch, sharedDim, 1]);
     const result = tf.matMul(a, b);
-    expectArraysClose(result, [10, 10, 10]);
+    expectArraysClose(result, [sharedDim, sharedDim, sharedDim]);
   });
 
   it('Matrix * vector propagates NaNs', () => {


### PR DESCRIPTION
In the WebGL backend, we can parallelize dot products by calling `tf.mul(x,y).sum()` -- this is due to the fact that the WebGL's sum() uses divide-and-conquer and is O(sqrt(N)).

Have matmul() in WebGL call `tf.mul(x, y).sum()` when we have matrix x vector, vector x matrix, or vector x vector and the shared dimension is longer than 1000 (see benchmark below).

Fixes https://github.com/tensorflow/tfjs/issues/881

Benchmark of `[1,K]x[K,1]` for different `K`s:
=== OLD ===
LOG: 'K = 1, Took 0.72 ms'
LOG: 'K = 10, Took 0.67 ms'
LOG: 'K = 100, Took 0.59 ms'
LOG: 'K = 1000, Took 0.64 ms' --- slower after K>1000.
LOG: 'K = 10000, Took 1.18 ms'
LOG: 'K = 100000, Took 10.66 ms'
LOG: 'K = 1000000, Took 110.90 ms'

=== NEW ===
LOG: 'K = 1, Took 0.62 ms'
LOG: 'K = 10, Took 0.62 ms'
LOG: 'K = 100, Took 0.67 ms'
LOG: 'K = 1000, Took 0.67 ms' --- faster after K>1000.
LOG: 'K = 10000, Took 1.12 ms'
LOG: 'K = 100000, Took 0.88 ms'
LOG: 'K = 1000000, Took 0.94 ms'

Benchmarked mobilenet, coco-ssd, and posenet --  no perf impact there.

PERF 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1379)
<!-- Reviewable:end -->
