### PR TITLE
Update version to 0.13.10 and improve publish-npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-core",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Hardware-accelerated JavaScript library for machine intelligence",
   "private": false,
   "main": "dist/index.js",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -28,6 +28,7 @@ set -e
 
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 ORIGIN=`git config --get remote.origin.url`
+CHANGES=`git status --porcelain`
 
 if [ "$BRANCH" != "master" ]; then
   echo "Error: Switch to the master branch before publishing."
@@ -37,6 +38,13 @@ fi
 if ! [[ "$ORIGIN" =~ tensorflow/tfjs-core ]]; then
   echo "Error: Switch to the main repo (tensorflow/tfjs-core) before publishing."
   exit
+fi
+
+if [ ! -z "$CHANGES" ];
+then
+    echo "Make sure the master branch is clean. Found changes:"
+    echo $CHANGES
+    exit 1
 fi
 
 yarn build-npm

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.13.9';
+const version = '0.13.10';
 export {version};


### PR DESCRIPTION
Turns out we released 0.13.9 in a bad state where there was logging statements in the master branch right before `publish-npm` was called -- search for "logFnCall" in https://unpkg.com/@tensorflow/tfjs-core@0.13.9/dist/tf-core.js

Update the version to 0.13.10 and improve the publish-npm script to fail whenever the master branch is not clean.

BUG, DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1380)
<!-- Reviewable:end -->
