### PR TITLE
Refine condition for expensive reshaping

### DIFF
--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -405,9 +405,14 @@ export function isReshapeFree(shape1: number[], shape2: number[]): boolean {
   }
 
   if (shape1.length !== shape2.length) {  // One of the shapes is a vector.
-    if (util.arraysEqual(
-            util.squeezeShape(shape1).newShape,
-            util.squeezeShape(shape2).newShape)) {
+    const shape1Cols = shape1.slice(-1)[0];
+    const shape2Cols = shape2.slice(-1)[0];
+    if (shape1Cols === shape2Cols) {
+      return true;
+    }
+
+    if (isEven(shape1Cols) && isEven(shape2Cols) &&
+        (shape1[0] === 1 || shape2[0] === 1)) {
       return true;
     }
   } else {
@@ -415,6 +420,7 @@ export function isReshapeFree(shape1: number[], shape2: number[]): boolean {
       if (isEven(shape1[1]) && isEven(shape2[1])) {
         return true;
       }
+
       if (shape1[1] === shape2[1]) {
         return true;
       }

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -135,8 +135,24 @@ describeWithFlags('isReshapeFree', WEBGL_ENVS, () => {
   it('is free when one shape is a vector and the final dimensions match',
      () => {
        const before = [9];
-       const after = [2, 1, 9];
+       const after = [1, 1, 9];
        expect(webgl_util.isReshapeFree(before, after)).toBe(true);
+     });
+
+  it('is free when one shape is a vector and the other has 1 row' +
+         'in every batch and the final dimensions are even',
+     () => {
+       const before = [10];
+       const after = [5, 1, 2];
+       expect(webgl_util.isReshapeFree(before, after)).toBe(true);
+     });
+
+  it('is not free when one shape is a vector and the final dimensions' +
+         'do not match and are not even',
+     () => {
+       const before = [18];
+       const after = [2, 1, 9];
+       expect(webgl_util.isReshapeFree(before, after)).toBe(false);
      });
 
   it('is free when the inner dimensions are divisible by 2', () => {


### PR DESCRIPTION
Accounts for the fact that if one shape is a vector and the other shape has a 1 in the rows slot and the columns are both even, the reshape is free.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1386)
<!-- Reviewable:end -->
