### PR TITLE
improve the url parsing for weight file to allow suffix

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -222,12 +222,23 @@ export class BrowserHTTPRequest implements IOHandler {
   }
 }
 
+/**
+ * Extract the prefix and suffix of the url, where the prefix is the path before
+ * the last file, and suffix is the search params after the last file.
+ * ```
+ * const url = 'http://tfhub.dev/model/1/tensorflowjs_model.pb?tfjs-format=file'
+ * [prefix, suffix] = parseUrl(url)
+ * // prefix = 'http://tfhub.dev/model/1/'
+ * // suffix = '?tfjs-format=file'
+ * ```
+ * @param url the model url to be parsed.
+ */
 export function parseUrl(url: string): [string, string] {
-  const lastSlice = url.lastIndexOf('/');
+  const lastSlash = url.lastIndexOf('/');
   const lastSearchParam = url.lastIndexOf('?');
-  const prefix = url.substring(0, lastSlice);
+  const prefix = url.substring(0, lastSlash);
   const suffix =
-      lastSearchParam > lastSlice ? url.substring(lastSearchParam) : '';
+      lastSearchParam > lastSlash ? url.substring(lastSearchParam) : '';
   return [prefix + '/', suffix];
 }
 

--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -100,7 +100,7 @@ export class BrowserHTTPRequest implements IOHandler {
 
     const response = await fetch(this.path as string, init);
 
-    if (response.type === 'opaque' || response.ok) {
+    if (response.ok) {
       return {
         modelArtifactsInfo: getModelArtifactsInfoForJSON(modelArtifacts),
         responses: [response],
@@ -131,7 +131,7 @@ export class BrowserHTTPRequest implements IOHandler {
   private async loadBinaryTopology(): Promise<ArrayBuffer> {
     try {
       const response = await fetch(this.path[0], this.requestInit);
-      if (response.type !== 'opaque' && !response.ok) {
+      if (!response.ok) {
         throw new Error(
             `BrowserHTTPRequest.load() failed due to HTTP response: ${
                 response.statusText}`);
@@ -145,7 +145,7 @@ export class BrowserHTTPRequest implements IOHandler {
   protected async loadBinaryModel(): Promise<ModelArtifacts> {
     const graphPromise = this.loadBinaryTopology();
     const manifestPromise = await fetch(this.path[1], this.requestInit);
-    if (manifestPromise.type !== 'opaque' && !manifestPromise.ok) {
+    if (!manifestPromise.ok) {
       throw new Error(`BrowserHTTPRequest.load() failed due to HTTP response: ${
           manifestPromise.statusText}`);
     }
@@ -169,7 +169,7 @@ export class BrowserHTTPRequest implements IOHandler {
   protected async loadJSONModel(): Promise<ModelArtifacts> {
     const modelConfigRequest =
         await fetch(this.path as string, this.requestInit);
-    if (modelConfigRequest.type !== 'opaque' && !modelConfigRequest.ok) {
+    if (!modelConfigRequest.ok) {
       throw new Error(`BrowserHTTPRequest.load() failed due to HTTP response: ${
           modelConfigRequest.statusText}`);
     }

--- a/src/io/browser_http_test.ts
+++ b/src/io/browser_http_test.ts
@@ -23,7 +23,7 @@ import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {BROWSER_ENVS, CHROME_ENVS, NODE_ENVS} from '../test_util';
 
-import {BrowserHTTPRequest, httpRequestRouter} from './browser_http';
+import {BrowserHTTPRequest, httpRequestRouter, parseUrl} from './browser_http';
 
 // Test data.
 const modelTopology1: {} = {
@@ -398,7 +398,29 @@ describeWithFlags('browserHTTPRequest-save', CHROME_ENVS, () => {
   });
 });
 
+describeWithFlags('parseUrl', BROWSER_ENVS, () => {
+  it('should parse url with no suffix', () => {
+    const url = 'http://google.com/file';
+    const [prefix, suffix] = parseUrl(url);
+    expect(prefix).toEqual('http://google.com/');
+    expect(suffix).toEqual('');
+  });
+  it('should parse url with suffix', () => {
+    const url = 'http://google.com/file?param=1';
+    const [prefix, suffix] = parseUrl(url);
+    expect(prefix).toEqual('http://google.com/');
+    expect(suffix).toEqual('?param=1');
+  });
+  it('should parse url with multiple serach params', () => {
+    const url = 'http://google.com/a?x=1/file?param=1';
+    const [prefix, suffix] = parseUrl(url);
+    expect(prefix).toEqual('http://google.com/a?x=1/');
+    expect(suffix).toEqual('?param=1');
+  });
+});
+
 describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
+
   describe('JSON model', () => {
     let requestInits: RequestInit[];
 


### PR DESCRIPTION
#### Description
With TFHub, the model url follows following pattern
http://tfhub.dev/model/1/tensorflowjs.pb?tfjs-format=file
http://tfhub.dev/model/1/weights_manifest.json?tfjs-format=file
http://tfhub.dev/model/1/group1-shard1of1?tfjs-format=file

We need to parse both the prefix and suffix to order to properly load the weight files.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1387)
<!-- Reviewable:end -->
