### PR TITLE
Made tf.abs underflow-safe on CPU & GPU and added test for it.

### DIFF
--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -1122,7 +1122,7 @@ export class MathBackendCPU implements KernelBackend {
     for (let i = 0; i < x.size; ++i) {
       const real = values[i * 2];
       const imag = values[i * 2 + 1];
-      resultValues[i] = Math.sqrt(real * real + imag * imag);
+      resultValues[i] = Math.hypot(real, imag);
     }
     return Tensor.make(x.shape, {values: resultValues}) as T;
   }

--- a/src/kernels/webgl/complex_abs_gpu.ts
+++ b/src/kernels/webgl/complex_abs_gpu.ts
@@ -26,15 +26,15 @@ export class ComplexAbsProgram implements GPGPUProgram {
     this.outputShape = shape;
     this.userCode = `
       void main() {
-        float re = abs( getRealAtOutCoords() );
-        float im = abs( getImagAtOutCoords() );
-        float mx = max(re,im);
+        float re = abs(getRealAtOutCoords());
+        float im = abs(getImagAtOutCoords());
+        float mx = max(re, im);
 
         // sadly the length function in glsl is not underflow-safe
-        // (at least not on Integl GPUs). So the safe solution is
+        // (at least not on Intel GPUs). So the safe solution is
         // to ensure underflow-safety in all cases.
         setOutput(
-          mx * length(  vec2(1, min(re,im)/mx)  )
+          mx * length(vec2(1, min(re, im)/mx))
         );
       }
     `;

--- a/src/kernels/webgl/complex_abs_gpu.ts
+++ b/src/kernels/webgl/complex_abs_gpu.ts
@@ -34,7 +34,7 @@ export class ComplexAbsProgram implements GPGPUProgram {
         // (at least not on Intel GPUs). So the safe solution is
         // to ensure underflow-safety in all cases.
         setOutput(
-          mx * length(vec2(1, min(re, im)/mx))
+          mx == 0.0 ? 0.0 : mx * length(vec2(1, min(re, im)/mx))
         );
       }
     `;

--- a/src/kernels/webgl/complex_abs_gpu.ts
+++ b/src/kernels/webgl/complex_abs_gpu.ts
@@ -26,11 +26,16 @@ export class ComplexAbsProgram implements GPGPUProgram {
     this.outputShape = shape;
     this.userCode = `
       void main() {
-        float real = getRealAtOutCoords();
-        float imag = getImagAtOutCoords();
-        vec2 v = vec2(real, imag);
+        float re = abs( getRealAtOutCoords() );
+        float im = abs( getImagAtOutCoords() );
+        float mx = max(re,im);
 
-        setOutput(sqrt(dot(v, v)));
+        // sadly the length function in glsl is not underflow-safe
+        // (at least not on Integl GPUs). So the safe solution is
+        // to ensure underflow-safety in all cases.
+        setOutput(
+          mx * length(  vec2(1, min(re,im)/mx)  )
+        );
       }
     `;
   }

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -175,25 +175,26 @@ describeWithFlags('abs', ALL_ENVS, () => {
     let small;
     switch(floatBits) {
       case 32: small = 1e-30; break;
-      case 16: small = 1e-5;  break;
+      case 16: small = 1e-4;  break;
       default: throw new Error(
         `Test not implemented for ENV.engine.floatPrecision()=${floatBits}.`
       );
     }
 
     const a = tf.complex(
-       [small,     0, small],
-       [small, small,     0]
+       [small,     0, small, 0],
+       [small, small,     0, 0]
     );
     const result = tf.abs(a);
     expectArraysClose(
       result,
       [Math.hypot(small, small),
        Math.hypot(    0, small),
-       Math.hypot(small,     0)], 
+       Math.hypot(small,     0),
+       Math.hypot(    0,     0)], 
       /*tolerance=*/small/100
     );
-    expect(result.shape).toEqual([3]);
+    expect(result.shape).toEqual([4]);
   });
 
   it('propagates NaNs', () => {

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -170,14 +170,14 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('is underflow-safe for complex64', () => {
     const a = tf.complex(
-       /*re=*/[ 1e-30, 0     ],
-       /*im=*/[ 1e-30, 1e-30 ]
+       [1e-30, 0    ],
+       [1e-30, 1e-30]
     );
     const result = tf.abs(a);
     expectArraysClose(
       result,
-      [ Math.hypot(1e-30, 1e-30),
-        Math.hypot(0,     1e-30) ], 
+      [Math.hypot(1e-30, 1e-30),
+       Math.hypot(0,     1e-30)], 
       /*tolerance=*/1e-32
     );
     expect(result.shape).toEqual([2]);

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -19,6 +19,7 @@ import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose, expectNumbersClose} from '../test_util';
 import * as util from '../util';
+import {ENV} from '../environment';
 
 import * as selu_util from './selu_util';
 
@@ -169,18 +170,30 @@ describeWithFlags('abs', ALL_ENVS, () => {
   });
 
   it('is underflow-safe for complex64', () => {
+
+    const floatBits = ENV.backend.floatPrecision();
+    let small;
+    switch(floatBits) {
+      case 32: small = 1e-30; break;
+      case 16: small = 1e-5;  break;
+      default: throw new Error(
+        `Test not implemented for ENV.engine.floatPrecision()=${floatBits}.`
+      );
+    }
+
     const a = tf.complex(
-       [1e-30, 0    ],
-       [1e-30, 1e-30]
+       [small,     0, small],
+       [small, small,     0]
     );
     const result = tf.abs(a);
     expectArraysClose(
       result,
-      [Math.hypot(1e-30, 1e-30),
-       Math.hypot(0,     1e-30)], 
-      /*tolerance=*/1e-32
+      [Math.hypot(small, small),
+       Math.hypot(    0, small),
+       Math.hypot(small,     0)], 
+      /*tolerance=*/small/100
     );
-    expect(result.shape).toEqual([2]);
+    expect(result.shape).toEqual([3]);
   });
 
   it('propagates NaNs', () => {

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -168,6 +168,21 @@ describeWithFlags('abs', ALL_ENVS, () => {
     expect(result.shape).toEqual([2, 2, 2]);
   });
 
+  it('is underflow-safe for complex64', () => {
+    const a = tf.complex(
+       /*re=*/[ 1e-30, 0     ],
+       /*im=*/[ 1e-30, 1e-30 ]
+    );
+    const result = tf.abs(a);
+    expectArraysClose(
+      result,
+      [ Math.hypot(1e-30, 1e-30),
+        Math.hypot(0,     1e-30) ], 
+      /*tolerance=*/1e-32
+    );
+    expect(result.shape).toEqual([2]);
+  });
+
   it('propagates NaNs', () => {
     const a = tf.tensor1d([1, -2, 0, 3, -0.1, NaN]);
     const result = tf.abs(a);


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
Fixes part of [#895](https://github.com/tensorflow/tfjs/issues/895). The CPU backend now uses `Math.hypot` and the WebGL backend uses `length` albeit with some workaround to ensure underflow-safety (which is otherwise not given, at least on Intel GPUs).

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1391)
<!-- Reviewable:end -->
