### PR TITLE
Disable uniform uploads when testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: '10'
+node_js:
+  - '8'
+  - '10'
 script:
   - if [ "$TO_TEST" = "regular" ]; then yarn test-benchmark && yarn test-travis; fi
   - if [ "$TO_TEST" = "integration" ]; then yarn test-integration; fi
@@ -16,3 +18,7 @@ notifications:
     on_success: never
     on_failure: always
     on_pull_requests: false
+matrix:
+  exclude:
+  - node_js: '8'
+    env: TO_TEST=integration

--- a/integration_tests/benchmarks/benchmark_travis.sh
+++ b/integration_tests/benchmarks/benchmark_travis.sh
@@ -14,8 +14,12 @@
 # limitations under the License.
 # =============================================================================
 
+set -e
+
 if [ "$TRAVIS_EVENT_TYPE" = cron ] && [[ $(node -v) = *v10* ]]
 then
+  yarn
+  yarn lint
   karma start --firebaseKey $FIREBASE_KEY --travis \
     --singleRun --reporters='dots,karma-typescript,BrowserStack' \
     --hostname='bs-local.com' --browsers=bs_chrome_mac

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "coverage": "KARMA_COVERAGE=1 karma start --browsers='Chrome' --singleRun",
     "test": "karma start",
     "run-browserstack": "karma start --singleRun --reporters='dots,karma-typescript,BrowserStack' --hostname='bs-local.com'",
-    "test-benchmark": "cd integration_tests/benchmarks && yarn && yarn lint && yarn benchmark-travis && cd ../../",
+    "test-benchmark": "cd integration_tests/benchmarks && yarn benchmark-travis && cd ../../",
     "test-node": "ts-node src/test_node.ts",
     "test-integration": "./scripts/test-integration.sh",
     "test-travis": "./scripts/test-travis.sh"

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -18,11 +18,10 @@ set -e
 
 yarn build
 yarn lint
+# Test in node (headless environment).
+yarn test-node
 
 if [[ $(node -v) = *v10* ]]; then
-  # Test in node (headless environment).
-  yarn test-node
-
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
   yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -25,15 +25,16 @@ if [[ $(node -v) = *v10* ]]; then
 
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false}'
+  yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.
-npm-run-all -p -c --aggregate-output \
-  "run-browserstack --browsers=bs_safari_mac --features '{\"HAS_WEBGL\": false}' --backend cpu" \
-  "run-browserstack --browsers=bs_ios_11 --backend webgl --features '{\"WEBGL_CPU_FORWARD\": false}'" \
-  "run-browserstack --browsers=bs_ios_11 --features '{\"HAS_WEBGL\": false}' --backend cpu" \
-  "run-browserstack --browsers=bs_firefox_mac" \
-  "run-browserstack --browsers=bs_chrome_mac" \
-  "run-browserstack --browsers=bs_chrome_mac --features '{\"WEBGL_CPU_FORWARD\": true}' --backend webgl"
+  npm-run-all -p -c --aggregate-output \
+    "run-browserstack --browsers=bs_safari_mac --features '{\"HAS_WEBGL\": false}' --backend cpu" \
+    "run-browserstack --browsers=bs_ios_11 --backend webgl --features {\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}" \
+    "run-browserstack --browsers=bs_ios_11 --features '{\"HAS_WEBGL\": false}' --backend cpu" \
+    "run-browserstack --browsers=bs_firefox_mac" \
+    "run-browserstack --browsers=bs_chrome_mac" \
+    "run-browserstack --browsers=bs_chrome_mac --backend webgl --features '{\"WEBGL_CPU_FORWARD\": true}'" \
+    "run-browserstack --browsers=bs_chrome_mac --backend webgl --features '{\"WEBGL_CPU_FORWARD\": false}'"
 fi

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -31,7 +31,7 @@ if [[ $(node -v) = *v10* ]]; then
   # already downloaded binary.
   npm-run-all -p -c --aggregate-output \
     "run-browserstack --browsers=bs_safari_mac --features '{\"HAS_WEBGL\": false}' --backend cpu" \
-    "run-browserstack --browsers=bs_ios_11 --backend webgl --features {\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}" \
+    "run-browserstack --browsers=bs_ios_11 --backend webgl --features '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
     "run-browserstack --browsers=bs_ios_11 --features '{\"HAS_WEBGL\": false}' --backend cpu" \
     "run-browserstack --browsers=bs_firefox_mac" \
     "run-browserstack --browsers=bs_chrome_mac" \

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -23,7 +23,7 @@ import {DataId, setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
-const EPSILON_FLOAT16 = 1e-3;
+const EPSILON_FLOAT16 = 1e-4;
 const TEST_EPSILON_FLOAT16 = 1e-1;
 
 const EPSILON_FLOAT32 = 1e-7;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -23,10 +23,10 @@ import {DataId, setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
-const EPSILON_FLOAT16 = 1e-4;
+export const EPSILON_FLOAT16 = 1e-4;
 const TEST_EPSILON_FLOAT16 = 1e-1;
 
-const EPSILON_FLOAT32 = 1e-7;
+export const EPSILON_FLOAT32 = 1e-7;
 const TEST_EPSILON_FLOAT32 = 1e-3;
 
 export class Environment {

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as device_util from './device_util';
-import {ENV, Environment} from './environment';
+import {ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
 import {Features, getQueryParams} from './environment_util';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
@@ -160,7 +160,8 @@ describeWithFlags('max texture size', WEBGL_ENVS, () => {
 
 describeWithFlags('epsilon', {}, () => {
   it('Epsilon is a function of float precision', () => {
-    const epsilonValue = ENV.backend.floatPrecision() === 32 ? 1e-7 : 1e-3;
+    const epsilonValue =
+        ENV.backend.floatPrecision() === 32 ? EPSILON_FLOAT32 : EPSILON_FLOAT16;
     expect(ENV.get('EPSILON')).toBe(epsilonValue);
   });
 

--- a/src/jasmine_util.ts
+++ b/src/jasmine_util.ts
@@ -95,12 +95,20 @@ export let TEST_ENVS: TestEnv[] = [
   {
     name: 'test-webgl1',
     factory: () => new MathBackendWebGL(),
-    features: {'WEBGL_VERSION': 1, 'WEBGL_CPU_FORWARD': false}
+    features: {
+      'WEBGL_VERSION': 1,
+      'WEBGL_CPU_FORWARD': false,
+      'WEBGL_SIZE_UPLOAD_UNIFORM': 0,
+    }
   },
   {
     name: 'test-webgl2',
     factory: () => new MathBackendWebGL(),
-    features: {'WEBGL_VERSION': 2, 'WEBGL_CPU_FORWARD': false}
+    features: {
+      'WEBGL_VERSION': 2,
+      'WEBGL_CPU_FORWARD': false,
+      'WEBGL_SIZE_UPLOAD_UNIFORM': 0,
+    }
   },
   {
     name: 'test-cpu',

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -183,8 +183,12 @@ describeWithFlags('Custom window size', WEBGL_ENVS, () => {
 });
 
 // Run only for environments that have 32bit floating point support.
-const FLOAT32_WEBGL_ENVS =
-    Object.assign({'WEBGL_RENDER_FLOAT32_ENABLED': true}, WEBGL_ENVS);
+const FLOAT32_WEBGL_ENVS = Object.assign(
+    {
+      'WEBGL_RENDER_FLOAT32_ENABLED': true,
+      'WEBGL_SIZE_UPLOAD_UNIFORM': SIZE_UPLOAD_UNIFORM
+    },
+    WEBGL_ENVS);
 describeWithFlags('upload tensors as uniforms', FLOAT32_WEBGL_ENVS, () => {
   it('small tensor gets uploaded as scalar', () => {
     let m = tf.memory() as WebGLMemoryInfo;

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2464,10 +2464,10 @@ describeWithFlags('clip', ALL_ENVS, () => {
 
   it('clip(x, eps, 1-eps) never returns 0 or 1', () => {
     const min = tf.ENV.get('EPSILON');
-    const max = 1 - min;
+    const max = 0.5;
     const res = tf.clipByValue([0, 1], min, max).dataSync();
     expect(res[0]).toBeGreaterThan(0);
-    expect(res[1]).toBeLessThan(1);
+    expect(res[1]).toBeCloseTo(max);
   });
 });
 


### PR DESCRIPTION
- Disable uniform uploads when testing on travis.
- Change the default epsilon for 16bit float devices to 1e-4 instead of 1e-3 and change the clip test to stop testing `1-epsilon < 1` since the IEEE 754 buckets around 1 are different than around 0.
- Bring back node 8 testing since the LTS is for another 14 months. And test cpu backend in both node envs.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1393)
<!-- Reviewable:end -->
