### PR TITLE
Add trendline to visualize model performance over time, call dataSync for every run

### DIFF
--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -40,8 +40,14 @@
       font-size: 10px;
     }
 
-    #trendline-container {
+    #trendline-container svg {
+      overflow: visible;
+      margin-top: 20px;
+    }
 
+    #trendline-container path {
+      fill: none;
+      stroke: #222;
     }
 
     #modal-msg {
@@ -56,8 +62,8 @@
     }
 
     .table {
-      margin-right: 20px;
-      margin-bottom: 20px;
+      margin-right: 30px;
+      margin-bottom: 30px;
       border: 1px solid #ccc;
       border-collapse: collapse;
       border-spacing: 0;
@@ -111,6 +117,7 @@
       </table>
       <div class="box" id="trendline-container">
         <div class="label"></div>
+        <svg><path></path></svg>
       </div>
     </div>
     <table class="table" id="kernels">
@@ -241,14 +248,24 @@
     async function measureAveragePredictTime() {
       document.querySelector("#trendline-container .label").textContent = `Inference times over ${state.numRuns} runs`;
       await showMsg(`Running predict ${state.numRuns} times`);
+      const chartHeight = 150;
+      const chartWidth = document.querySelector("#trendline-container").getBoundingClientRect().width;
       const times = [];
+
       let res;
       for (let i = 0; i < state.numRuns; i++) {
         const start = performance.now();
         res = awaitResult(predict(model));
         times.push(performance.now() - start);
       }
+
       const average = times.reduce((acc, curr) => acc + curr, 0) / times.length;
+      const max = times.reduce((acc, curr) => curr > acc ? curr : acc, 0);
+      const xIncrement = chartWidth / times.length;
+
+      document.querySelector("#trendline-container path")
+        .setAttribute("d", `M${times.map((d, i) => `${i * xIncrement},${chartHeight - (d / max) * chartHeight}`).join('L')}`);
+
       await showMsg(null);
       appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printTime(average));
     }

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -176,8 +176,8 @@
       // Place model loading code here.
       //////////////////////////////////
       return await tf.loadFrozenModel(
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
+        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
+        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);
@@ -256,13 +256,14 @@
     async function warmUpAndRecordTime() {
       await showMsg('Warming up');
       const start = performance.now();
-      let res;
-      if(isAsync) {
-        res = await predict(model);
-      } else {
-        res = predict(model);
+      let res = predict(model);
+      if(res instanceof Promise) {
+        res = await res;
       }
-      res.dataSync();
+
+      if(res instanceof tf.Tensor) {
+        res.dataSync();
+      }
 
       const elapsed = performance.now() - start;
       await showMsg(null);
@@ -277,7 +278,7 @@
       await showMsg('Loading the model');
       const start = performance.now();
       model = await load();
-      isAsync = model.executor.isControlFlowModel;
+      isAsync = model.executor && model.executor.isControlFlowModel;
 
       const elapsed = performance.now() - start;
       await showMsg(null);
@@ -295,13 +296,14 @@
       const times = [];
       for (let i = 0; i < state.numRuns; i++) {
         const start = performance.now();
-        let res;
-        if(isAsync) {
-          res = await predict(model);
-        } else {
-          res = predict(model);
+        let res = predict(model);
+        if(res instanceof Promise) {
+          res = await res;
         }
-        res.dataSync();
+
+        if(res instanceof tf.Tensor) {
+          res.dataSync();
+        }
 
         times.push(performance.now() - start);
       }
@@ -325,10 +327,13 @@
       const start = performance.now();
       let res;
       const data = await tf.profile(() => res = predict(model));
-      if(isAsync) {
+      if(res instanceof Promise) {
         res = await res;
       }
-      res.dataSync();
+
+      if(res instanceof tf.Tensor) {
+        res.dataSync();
+      }
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
@@ -364,13 +369,14 @@
           });
         }
       }
-      let res;
-      if(isAsync) {
+      let res = predict(model);
+      if(res instanceof Promise) {
         res = await predict(model);
-      } else {
-        res = predict(model);
       }
-      res.dataSync();
+
+      if(res instanceof tf.Tensor) {
+        res.dataSync();
+      }
 
       await showMsg(null);
       await sleep(10);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -209,16 +209,17 @@
       tbody.appendChild(tr);
     }
 
+    async function awaitResult(res) {
+      if (res instanceof Promise) {
+        return await res;
+      }
+      return await res.dataSync(); // res is a tensor
+    }
+
     async function warmUpAndRecordTime() {
       await showMsg('Warming up');
       const start = performance.now();
-      let res = predict(model);
-      if (res instanceof Promise) {
-        res = await res;
-      }
-      if (res instanceof tf.Tensor) {
-        await res.data();
-      }
+      let res = awaitResult(predict(model));
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, '1st inference', printElapsed(start));
@@ -245,12 +246,7 @@
       for (let i = 0; i < state.numRuns; i++) {
         res = predict(model);
       }
-      if (res instanceof Promise) {
-        res = await res;
-      }
-      if (res instanceof tf.Tensor) {
-        res.dataSync();
-      }
+      res = awaitResult(res);
       const elapsed = (performance.now() - start) / state.numRuns;
       await showMsg(null);
       appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printElapsed(elapsed));
@@ -261,12 +257,7 @@
       const start = performance.now();
       let res;
       const data = await tf.profile(() => res = predict(model));
-      if (res instanceof Promise) {
-        res = await res;
-      }
-      if (res instanceof tf.Tensor) {
-        await res.data();
-      }
+      res = awaitResult(res);
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
@@ -302,13 +293,7 @@
           });
         }
       }
-      let res = predict(model);
-      if (res instanceof Promise) {
-        res = await res;
-      }
-      if (res instanceof tf.Tensor) {
-        res.dataSync();
-      }
+      let res = awaitResult(predict(model));
       await showMsg(null);
       await sleep(10);
       kernels = kernels.sort((a, b) => b.time - a.time);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -18,6 +18,10 @@
       margin: 20px 100px;
     }
 
+    h2 {
+      margin-bottom: 30px;
+    }
+
     #container {
       display: flex;
       flex-direction: row;
@@ -25,8 +29,8 @@
     }
 
     .box {
-      margin-right: 20px;
-      margin-bottom: 20px;
+      margin-right: 30px;
+      margin-bottom: 30px;
     }
 
     .box pre {
@@ -106,8 +110,7 @@
         </tbody>
       </table>
       <div class="box" id="trendline-container">
-        <div></div>
-        trendline
+        <div class="label"></div>
       </div>
     </div>
     <table class="table" id="kernels">
@@ -148,7 +151,6 @@
     'use strict';
     const state = {
       numRuns: 50,
-
     };
     const modalDiv = document.getElementById('modal-msg');
     const timeTable = document.querySelector('#timings tbody');
@@ -236,6 +238,7 @@
     }
 
     async function measureAveragePredictTime() {
+      document.querySelector("#trendline-container .label").textContent = `Inference times over ${state.numRuns} runs`;
       await showMsg(`Running predict ${state.numRuns} times`);
       const start = performance.now();
       let res;

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -15,7 +15,7 @@
     }
 
     body {
-      margin: 30px 0 0 30px;
+      margin: 20px 100px;
     }
 
     #container {
@@ -34,6 +34,10 @@
       border: 1px solid #ccc;
       padding: 8px;
       font-size: 10px;
+    }
+
+    #trendline-container {
+
     }
 
     #modal-msg {
@@ -87,19 +91,24 @@
   <h2>TensorFlow.js Model Benchmark</h2>
   <div id="modal-msg"></div>
   <div id="container">
-    <div class="box">
-      <pre id="env"></pre>
+    <div id="stats">
+      <div class="box">
+        <pre id="env"></pre>
+      </div>
+      <table class="table" id="timings">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+      <div class="box" id="trendline-container">
+        trendline
+      </div>
     </div>
-    <table class="table" id="timings">
-      <thead>
-        <tr>
-          <th>Type</th>
-          <th>Value</th>
-        </tr>
-      </thead>
-      <tbody>
-      </tbody>
-    </table>
     <table class="table" id="kernels">
       <thead>
         <tr>
@@ -137,7 +146,7 @@
   <script>
     'use strict';
     const state = {
-      numRuns: 20,
+      numRuns: 50,
 
     };
     const modalDiv = document.getElementById('modal-msg');

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -22,6 +22,10 @@
       margin-bottom: 30px;
     }
 
+    #kernels {
+      max-width: 750px;
+    }
+
     #container {
       display: flex;
       flex-direction: row;

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -106,6 +106,7 @@
         </tbody>
       </table>
       <div class="box" id="trendline-container">
+        <div></div>
         trendline
       </div>
     </div>
@@ -178,6 +179,10 @@
       envDiv.innerHTML += `<br/>${JSON.stringify(tf.ENV.features, null, 2)}`;
     }
 
+    function printElapsed(elapsed) {
+      return elapsed.toFixed(1) + ' ms';
+    }
+
     function printMemory(bytes) {
       if (bytes < 1024) {
         return bytes + ' B';
@@ -214,7 +219,7 @@
       }
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, 'Warmup', elapsed.toFixed(1) + ' ms');
+      appendRow(timeTable, '1st inference', printElapsed(start));
     }
 
     function sleep(timeMs) {
@@ -227,7 +232,7 @@
       model = await load();
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, 'Model load', elapsed.toFixed(1) + ' ms');
+      appendRow(timeTable, 'Model load', printElapsed(elapsed));
     }
 
     async function measureAveragePredictTime() {
@@ -245,14 +250,24 @@
       }
       const elapsed = (performance.now() - start) / state.numRuns;
       await showMsg(null);
-      appendRow(timeTable, `Predict (${state.numRuns} runs)`, elapsed.toFixed(1) + ' ms');
+      appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printElapsed(elapsed));
     }
 
     async function profileMemory() {
       await showMsg('Profile memory');
-      const data = await tf.profile(() => predict(model));
+      const start = performance.now();
+      let res;
+      const data = await tf.profile(() => res = predict(model));
+      if (res instanceof Promise) {
+        res = await res;
+      }
+      if (res instanceof tf.Tensor) {
+        await res.data();
+      }
+      const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
+      appendRow(timeTable, '2nd inference', printElapsed(elapsed));
     }
 
     function showKernelTime(kernels) {

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -145,7 +145,7 @@
         <div class="label"></div>
         <div id="trendline">
           <div id="yMax"></div>
-          <div id="yMin">0ms</div>
+          <div id="yMin">0 ms</div>
           <svg><path></path></svg>
         </div>
       </div>

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -178,9 +178,6 @@
       return await tf.loadFrozenModel(
         'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
         'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
-      // return await tf.loadFrozenModel(
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);
@@ -199,11 +196,10 @@
     const state = {
       numRuns: 50,
     };
-    let isAsync = false;
     const modalDiv = document.getElementById('modal-msg');
     const timeTable = document.querySelector('#timings tbody');
     const envDiv = document.getElementById('env');
-    let model;
+    let model, isAsync;
 
     async function showMsg(message) {
       if (message != null) {
@@ -281,9 +277,8 @@
       await showMsg('Loading the model');
       const start = performance.now();
       model = await load();
-      if(model.executor.isControlFlowModel) {
-        isAsync = true;
-      }
+      isAsync = model.executor.isControlFlowModel;
+
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Model load', printTime(elapsed));

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -250,7 +250,7 @@
       if (res instanceof Promise) {
         return await res;
       }
-      return await res.dataSync(); // res is a tensor
+      return res.dataSync(); // res is a tensor
     }
 
     async function warmUpAndRecordTime() {

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -175,12 +175,12 @@
       //////////////////////////////////
       // Place model loading code here.
       //////////////////////////////////
-      return await tf.loadFrozenModel(
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
       // return await tf.loadFrozenModel(
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
+      return await tf.loadFrozenModel(
+        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
+        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);
@@ -264,7 +264,7 @@
       if(isAsync) {
         res = await predict(model);
       } else {
-        res = predict(model);
+        res = predict(model).dataSync();
       }
       const elapsed = performance.now() - start;
       await showMsg(null);
@@ -302,7 +302,7 @@
         if(isAsync) {
           res = await predict(model);
         } else {
-          res = predict(model);
+          res = predict(model).dataSync();
         }
         times.push(performance.now() - start);
       }
@@ -327,10 +327,11 @@
       let res;
       const data = await tf.profile(() => res = predict(model));
       if(isAsync) {
-        res = await res;
+        await res;
         // console.log("execute async");
         // res = await predict(model);
       } else {
+        res.dataSync();
         // res = execute(model);
       }
       const elapsed = performance.now() - start;
@@ -372,7 +373,7 @@
       if(isAsync) {
         res = await predict(model);
       } else {
-        res = predict(model);
+        res = predict(model).dataSync();
       }
       await showMsg(null);
       await sleep(10);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -178,6 +178,9 @@
       return await tf.loadFrozenModel(
         'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
         'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
+      // return await tf.loadFrozenModel(
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);
@@ -185,6 +188,9 @@
       //////////////////////////////////
       // Place model prediction code here.
       //////////////////////////////////
+      if(isAsync) {
+        return model.executeAsync(zeros);
+      }
       return model.predict(zeros);
     }
   </script>
@@ -193,6 +199,7 @@
     const state = {
       numRuns: 50,
     };
+    let isAsync = false;
     const modalDiv = document.getElementById('modal-msg');
     const timeTable = document.querySelector('#timings tbody');
     const envDiv = document.getElementById('env');
@@ -250,17 +257,15 @@
       tbody.appendChild(tr);
     }
 
-    async function awaitResult(res) {
-      if (res instanceof Promise) {
-        return await res;
-      }
-      return res.dataSync(); // res is a tensor
-    }
-
     async function warmUpAndRecordTime() {
       await showMsg('Warming up');
       const start = performance.now();
-      let res = awaitResult(predict(model));
+      let res;
+      if(isAsync) {
+        res = await predict(model);
+      } else {
+        res = predict(model);
+      }
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, '1st inference', printTime(start));
@@ -274,6 +279,9 @@
       await showMsg('Loading the model');
       const start = performance.now();
       model = await load();
+      if(model.executor.isControlFlowModel) {
+        isAsync = true;
+      }
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Model load', printTime(elapsed));
@@ -290,7 +298,12 @@
       const times = [];
       for (let i = 0; i < state.numRuns; i++) {
         const start = performance.now();
-        awaitResult(predict(model));
+        let res;
+        if(isAsync) {
+          res = await predict(model);
+        } else {
+          res = predict(model);
+        }
         times.push(performance.now() - start);
       }
 
@@ -313,7 +326,13 @@
       const start = performance.now();
       let res;
       const data = await tf.profile(() => res = predict(model));
-      res = awaitResult(res);
+      if(isAsync) {
+        res = await res;
+        // console.log("execute async");
+        // res = await predict(model);
+      } else {
+        // res = execute(model);
+      }
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
@@ -349,7 +368,12 @@
           });
         }
       }
-      let res = awaitResult(predict(model));
+      let res;
+      if(isAsync) {
+        res = await predict(model);
+      } else {
+        res = predict(model);
+      }
       await showMsg(null);
       await sleep(10);
       kernels = kernels.sort((a, b) => b.time - a.time);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -43,11 +43,38 @@
     #trendline-container svg {
       overflow: visible;
       margin-top: 20px;
+      border-bottom: 1px solid #ccc;
+      border-left: 1px solid #ccc;
+    }
+
+    #trendline-container .label {
+      font-size: 14px;
+      font-weight: bold;
     }
 
     #trendline-container path {
       fill: none;
       stroke: #222;
+    }
+
+    #trendline-container {
+      position: relative;
+    }
+
+    #trendline-container #yMax, #trendline-container #yMin {
+      position: absolute;
+      right: calc(100% + 6px);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    #trendline-container #yMin {
+      bottom: 0;
+    }
+
+    #trendline-container #yMax {
+      top: 20px;
+      transform: translateY(100%);
     }
 
     #modal-msg {
@@ -117,6 +144,8 @@
       </table>
       <div class="box" id="trendline-container">
         <div class="label"></div>
+        <div id="yMax"></div>
+        <div id="yMin">0ms</div>
         <svg><path></path></svg>
       </div>
     </div>
@@ -250,12 +279,13 @@
       await showMsg(`Running predict ${state.numRuns} times`);
       const chartHeight = 150;
       const chartWidth = document.querySelector("#trendline-container").getBoundingClientRect().width;
-      const times = [];
+      document.querySelector("#trendline-container svg").setAttribute("width", chartWidth);
+      document.querySelector("#trendline-container svg").setAttribute("height", chartHeight);
 
-      let res;
+      const times = [];
       for (let i = 0; i < state.numRuns; i++) {
         const start = performance.now();
-        res = awaitResult(predict(model));
+        awaitResult(predict(model));
         times.push(performance.now() - start);
       }
 
@@ -263,6 +293,7 @@
       const max = times.reduce((acc, curr) => curr > acc ? curr : acc, 0);
       const xIncrement = chartWidth / times.length;
 
+      document.querySelector("#trendline-container #yMax").textContent = printTime(max);
       document.querySelector("#trendline-container path")
         .setAttribute("d", `M${times.map((d, i) => `${i * xIncrement},${chartHeight - (d / max) * chartHeight}`).join('L')}`);
 

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -175,12 +175,12 @@
       //////////////////////////////////
       // Place model loading code here.
       //////////////////////////////////
-      // return await tf.loadFrozenModel(
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
-      //   'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
       return await tf.loadFrozenModel(
-        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
-        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
+        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
+        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
+      // return await tf.loadFrozenModel(
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
+      //   'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);
@@ -264,8 +264,10 @@
       if(isAsync) {
         res = await predict(model);
       } else {
-        res = predict(model).dataSync();
+        res = predict(model);
       }
+      res.dataSync();
+
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, '1st inference', printTime(start));
@@ -302,8 +304,10 @@
         if(isAsync) {
           res = await predict(model);
         } else {
-          res = predict(model).dataSync();
+          res = predict(model);
         }
+        res.dataSync();
+
         times.push(performance.now() - start);
       }
 
@@ -327,13 +331,9 @@
       let res;
       const data = await tf.profile(() => res = predict(model));
       if(isAsync) {
-        await res;
-        // console.log("execute async");
-        // res = await predict(model);
-      } else {
-        res.dataSync();
-        // res = execute(model);
+        res = await res;
       }
+      res.dataSync();
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
@@ -373,8 +373,10 @@
       if(isAsync) {
         res = await predict(model);
       } else {
-        res = predict(model).dataSync();
+        res = predict(model);
       }
+      res.dataSync();
+
       await showMsg(null);
       await sleep(10);
       kernels = kernels.sort((a, b) => b.time - a.time);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -176,8 +176,8 @@
       // Place model loading code here.
       //////////////////////////////////
       return await tf.loadFrozenModel(
-        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/tensorflowjs_model.pb',
-        'https://storage.googleapis.com/tfjs-models/savedmodel/coco-ssd-mobilenet_v1/weights_manifest.json');
+        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
+        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -42,7 +42,6 @@
 
     #trendline-container svg {
       overflow: visible;
-      margin-top: 20px;
       border-bottom: 1px solid #ccc;
       border-left: 1px solid #ccc;
     }
@@ -57,24 +56,24 @@
       stroke: #222;
     }
 
-    #trendline-container {
+    #trendline {
       position: relative;
+      margin-top: 20px;
     }
 
-    #trendline-container #yMax, #trendline-container #yMin {
+    #trendline #yMax, #trendline #yMin {
       position: absolute;
       right: calc(100% + 6px);
       font-size: 11px;
       white-space: nowrap;
     }
 
-    #trendline-container #yMin {
+    #trendline #yMin {
       bottom: 0;
     }
 
-    #trendline-container #yMax {
-      top: 20px;
-      transform: translateY(100%);
+    #trendline #yMax {
+      top: 0;
     }
 
     #modal-msg {
@@ -144,9 +143,11 @@
       </table>
       <div class="box" id="trendline-container">
         <div class="label"></div>
-        <div id="yMax"></div>
-        <div id="yMin">0ms</div>
-        <svg><path></path></svg>
+        <div id="trendline">
+          <div id="yMax"></div>
+          <div id="yMin">0ms</div>
+          <svg><path></path></svg>
+        </div>
       </div>
     </div>
     <table class="table" id="kernels">
@@ -290,7 +291,8 @@
       }
 
       const average = times.reduce((acc, curr) => acc + curr, 0) / times.length;
-      const max = times.reduce((acc, curr) => curr > acc ? curr : acc, 0);
+      const max = Math.max(...times);
+      const min = Math.min(...times);
       const xIncrement = chartWidth / times.length;
 
       document.querySelector("#trendline-container #yMax").textContent = printTime(max);
@@ -299,6 +301,7 @@
 
       await showMsg(null);
       appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printTime(average));
+      appendRow(timeTable, 'Best time', printTime(min));
     }
 
     async function profileMemory() {

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -181,7 +181,7 @@
       envDiv.innerHTML += `<br/>${JSON.stringify(tf.ENV.features, null, 2)}`;
     }
 
-    function printElapsed(elapsed) {
+    function printTime(elapsed) {
       return elapsed.toFixed(1) + ' ms';
     }
 
@@ -222,7 +222,7 @@
       let res = awaitResult(predict(model));
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, '1st inference', printElapsed(start));
+      appendRow(timeTable, '1st inference', printTime(start));
     }
 
     function sleep(timeMs) {
@@ -235,21 +235,22 @@
       model = await load();
       const elapsed = performance.now() - start;
       await showMsg(null);
-      appendRow(timeTable, 'Model load', printElapsed(elapsed));
+      appendRow(timeTable, 'Model load', printTime(elapsed));
     }
 
     async function measureAveragePredictTime() {
       document.querySelector("#trendline-container .label").textContent = `Inference times over ${state.numRuns} runs`;
       await showMsg(`Running predict ${state.numRuns} times`);
-      const start = performance.now();
+      const times = [];
       let res;
       for (let i = 0; i < state.numRuns; i++) {
-        res = predict(model);
+        const start = performance.now();
+        res = awaitResult(predict(model));
+        times.push(performance.now() - start);
       }
-      res = awaitResult(res);
-      const elapsed = (performance.now() - start) / state.numRuns;
+      const average = times.reduce((acc, curr) => acc + curr, 0) / times.length;
       await showMsg(null);
-      appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printElapsed(elapsed));
+      appendRow(timeTable, `Subsequent average (${state.numRuns} runs)`, printTime(average));
     }
 
     async function profileMemory() {
@@ -261,7 +262,7 @@
       const elapsed = performance.now() - start;
       await showMsg(null);
       appendRow(timeTable, 'Peak memory', printMemory(data.peakBytes));
-      appendRow(timeTable, '2nd inference', printElapsed(elapsed));
+      appendRow(timeTable, '2nd inference', printTime(elapsed));
     }
 
     function showKernelTime(kernels) {

--- a/integration_tests/benchmarks/benchmark.html
+++ b/integration_tests/benchmarks/benchmark.html
@@ -185,7 +185,7 @@
       //////////////////////////////////
       // Place model prediction code here.
       //////////////////////////////////
-      if(isAsync) {
+      if (isAsync) {
         return model.executeAsync(zeros);
       }
       return model.predict(zeros);
@@ -257,11 +257,11 @@
       await showMsg('Warming up');
       const start = performance.now();
       let res = predict(model);
-      if(res instanceof Promise) {
+      if (res instanceof Promise) {
         res = await res;
       }
 
-      if(res instanceof tf.Tensor) {
+      if (res instanceof tf.Tensor) {
         res.dataSync();
       }
 
@@ -278,7 +278,7 @@
       await showMsg('Loading the model');
       const start = performance.now();
       model = await load();
-      isAsync = model.executor && model.executor.isControlFlowModel;
+      isAsync = model.executor != null && model.executor.isControlFlowModel;
 
       const elapsed = performance.now() - start;
       await showMsg(null);
@@ -297,11 +297,11 @@
       for (let i = 0; i < state.numRuns; i++) {
         const start = performance.now();
         let res = predict(model);
-        if(res instanceof Promise) {
+        if (res instanceof Promise) {
           res = await res;
         }
 
-        if(res instanceof tf.Tensor) {
+        if (res instanceof tf.Tensor) {
           res.dataSync();
         }
 
@@ -327,11 +327,11 @@
       const start = performance.now();
       let res;
       const data = await tf.profile(() => res = predict(model));
-      if(res instanceof Promise) {
+      if (res instanceof Promise) {
         res = await res;
       }
 
-      if(res instanceof tf.Tensor) {
+      if (res instanceof tf.Tensor) {
         res.dataSync();
       }
       const elapsed = performance.now() - start;
@@ -371,7 +371,7 @@
       }
       let res = predict(model);
       if(res instanceof Promise) {
-        res = await predict(model);
+        res = await res;
       }
 
       if(res instanceof tf.Tensor) {


### PR DESCRIPTION
Related issue: https://github.com/tensorflow/tfjs/issues/713

### Changes
- Added a trendline to visualize the speed of each inference so we can get a more granular sense of model performance. This is helpful in the case that, for example, an optimization introduces overhead for the first several inferences, but leads to better model performance in the long run. Average prediction time itself can vary significantly depending on `numRuns`.
- Changed `measureAveragePredictTime` to call `dataSync` for every run, rather than only once at the end. 

Here's what the trendline looks like for MobileNet v2:
<img width="399" alt="screen shot 2018-11-15 at 10 37 13 am" src="https://user-images.githubusercontent.com/5700011/48563635-c1f29480-e8c2-11e8-8aee-6b882a6a4078.png">
As you can see it takes about 10 runs to stabilize. The average inference time is 23ms, best inference time is 20ms, worst inference time is 36 ms.

DEV, BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1396)
<!-- Reviewable:end -->
