### PR TITLE
Fix outdated references to DownloadTrigger class

### DIFF
--- a/src/io/browser_files.ts
+++ b/src/io/browser_files.ts
@@ -42,7 +42,7 @@ export class BrowserDownloads implements IOHandler {
       // TODO(cais): Provide info on what IOHandlers are available under the
       //   current environment.
       throw new Error(
-          'triggerDownloads() cannot proceed because the current environment ' +
+          'browserDownloads() cannot proceed because the current environment ' +
           'is not a browser.');
     }
 
@@ -64,7 +64,7 @@ export class BrowserDownloads implements IOHandler {
 
     if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
       throw new Error(
-          'DownloadTrigger.save() does not support saving model topology ' +
+          'BrowserDownloads.save() does not support saving model topology ' +
           'in binary formats yet.');
     } else {
       const weightsManifest: WeightsManifestConfig = [{
@@ -273,7 +273,7 @@ IORouterRegistry.registerSaveRouter(browserDownloadsRouter);
  *      file and binary weights file will be named 'foo.json' and
  *      'foo.weights.bin', respectively.
  * @param config Additional configuration for triggering downloads.
- * @returns An instance of `DownloadTrigger` `IOHandler`.
+ * @returns An instance of `BrowserDownloads` `IOHandler`.
  */
 /** @doc {heading: 'Models', subheading: 'Loading', namespace: 'io'} */
 export function browserDownloads(fileNamePrefix = 'model'): IOHandler {


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
Cleans up a few outdated references to `DownloadTrigger`. It looks like [the classes were renamed](https://github.com/tensorflow/tfjs-core/pull/1012#issuecomment-386328618) during #1012 and these references were missed.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1397)
<!-- Reviewable:end -->
