### PR TITLE
Add BrowserFiles.save method to save model to File objects

### DIFF
--- a/src/io/browser_files_test.ts
+++ b/src/io/browser_files_test.ts
@@ -801,4 +801,12 @@ describeWithFlags('browserFiles', BROWSER_ENVS, () => {
     expect(() => tf.io.browserFiles(null)).toThrowError(/at least 1 file/);
     expect(() => tf.io.browserFiles([])).toThrowError(/at least 1 file/);
   });
+
+  it('Save to files', async () => {
+    const saveResult = await tf.io.BrowserFiles.save(artifacts1);
+
+    expect(saveResult.files.length).toEqual(2);
+    expect(saveResult.files[0].name).toEqual('model.json');
+    expect(saveResult.files[1].name).toEqual('model.weights.bin');
+  });
 });

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -20,7 +20,7 @@
 import './indexed_db';
 import './local_storage';
 
-import {browserFiles} from './browser_files';
+import {BrowserFiles, browserFiles} from './browser_files';
 import {browserHTTPRequest} from './browser_http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, withSaveHandler} from './passthrough';
@@ -36,6 +36,7 @@ const getLoadHandlers = IORouterRegistry.getLoadHandlers;
 export {copyModel, listModels, moveModel, removeModel} from './model_management';
 
 export {
+  BrowserFiles,
   browserFiles,
   browserHTTPRequest,
   concatenateArrayBuffers,

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -20,7 +20,7 @@ import {Tensor} from '../tensor';
 import {NamedTensorMap} from '../tensor_types';
 import {TypedArray} from '../types';
 import {sizeFromShape} from '../util';
-import {DTYPE_VALUE_SIZE_MAP, ModelArtifacts, ModelArtifactsInfo, WeightsManifestEntry} from './types';
+import {DTYPE_VALUE_SIZE_MAP, ModelArtifacts, ModelArtifactsInfo, WeightsManifestConfig, WeightsManifestEntry} from './types';
 
 /**
  * Encode a map from names to weight values as an ArrayBuffer, along with an
@@ -296,4 +296,30 @@ export function getModelArtifactsInfoForJSON(modelArtifacts: ModelArtifacts):
         0 :
         modelArtifacts.weightData.byteLength,
   };
+}
+
+/**
+ * Get ModelArtifacts as File objects.
+ * @param modelArtifacts
+ * @returns Model artifact Files
+ */
+export function getModelArtifactsAsFiles(
+    modelArtifacts: ModelArtifacts, modelTopologyFileName: string,
+    weightDataFileName: string): File[] {
+  const weightsManifest: WeightsManifestConfig = [
+    {paths: ['./' + weightDataFileName], weights: modelArtifacts.weightSpecs}
+  ];
+  const modelTopologyAndWeightManifest = {
+    modelTopology: modelArtifacts.modelTopology,
+    weightsManifest
+  };
+
+  return [
+    new File(
+        [JSON.stringify(modelTopologyAndWeightManifest)], modelTopologyFileName,
+        {type: 'application/json'}),
+    new File(
+        [modelArtifacts.weightData], weightDataFileName,
+        {type: 'application/octet-stream'})
+  ];
 }

--- a/src/io/types.ts
+++ b/src/io/types.ts
@@ -111,15 +111,29 @@ export interface SaveResult {
   modelArtifactsInfo: ModelArtifactsInfo;
 
   /**
-   * HTTP responses from the server that handled the model-saving request (if
-   * any). This is applicable only to server-based saving routes.
-   */
-  responses?: Response[];
-
-  /**
    * Error messages and related data (if any).
    */
   errors?: Array<{}|string>;
+}
+
+/**
+ * Result of a saving to browser HTTP operation.
+ */
+export interface BrowserHTTPRequestSaveResult extends SaveResult {
+  /**
+   * HTTP responses from the server that handled the model-saving request.
+   */
+  responses: Response[];
+}
+
+/**
+ * Result of a saving to browser files operation.
+ */
+export interface BrowserFilesSaveResult extends SaveResult {
+  /**
+   * Model artifacts as files.
+   */
+  files: File[];
 }
 
 export declare interface ModelArtifactsInfo {


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
I don't love the way this implementation panned out (so very open to suggestions), but it was the simplest way I could add this functionality with minimal changes.

Goal is to provide a way to save the model as `File` objects rather than triggering a browser download, allowing for further control. For example, I have metadata about the model (author, description, etc) that I'd like to download as well. Downloading a bunch of different files begins to be a bad user experience, so I bundle them into a ZIP file first and then download the single ZIP file. With this PR it becomes:

```javascript
const { files } = await model.save(tf.io.BrowserFiles)

// Add files to ZIP, trigger download of ZIP
```

There's several changes in this PR I thought I'd highlight individually:
* Factor out common code for creating `File` objects from `ModelArtifacts` into `getModelArtifactsAsFiles` util function
* Refactor `SaveResult` to use sub-interfaces for handling the different return values for different `IOHandler` implementations
* Add `BrowserFiles.save` method and expose `BrowserFiles` class so that it can be used with `model.save`. Note that this implementation of `save` is a *static* method as the constructor of `BrowserFiles` expects files for loading.

It's the last change I don't love, however I wasn't able to come up with a cleaner implementation. It could possibly be implemented as an entirely different `IOHandler` which implements the save functionality and registers a new scheme (`browser-files://`?), but that seemed to be straying from the existing implementation.

Thoughts and suggestions welcome.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1399)
<!-- Reviewable:end -->
