### PR TITLE
Make IS_NODE check more failure-proof

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -303,6 +303,7 @@ export class Environment {
       return typeof window !== 'undefined';
     } else if (feature === 'IS_NODE') {
       return (typeof process !== 'undefined') &&
+          (typeof process.versions !== 'undefined') &&
           (typeof process.versions.node !== 'undefined');
     } else if (feature === 'IS_CHROME') {
       return isChrome();


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
The [`node-libs-browser`](https://github.com/webpack/node-libs-browser) project (from Webpack) mocks the `process` object, but leaves `process.versions` undefined. This causes the `IS_NODE` check to throw an error.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1400)
<!-- Reviewable:end -->
