### PR TITLE
Add support for storing models in sessionStorage

### DIFF
--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-// Importing local_storage and indexed_db is necessary for the routers to be
+// Importing browser_storage and indexed_db is necessary for the routers to be
 // registered.
 import './indexed_db';
-import './local_storage';
+import './browser_storage';
 
 import {browserFiles} from './browser_files';
 import {browserHTTPRequest} from './browser_http';

--- a/src/io/local_storage_test.ts
+++ b/src/io/local_storage_test.ts
@@ -18,8 +18,10 @@
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {BROWSER_ENVS} from '../test_util';
+
 import {arrayBufferToBase64String, base64StringToArrayBuffer} from './io_utils';
-import {browserLocalStorage, BrowserLocalStorage, BrowserLocalStorageManager, localStorageRouter, purgeLocalStorageArtifacts} from './local_storage';
+import {browserLocalStorage, BrowserStorage, BrowserStorageManager, browserStorageRouter, purgeLocalStorageArtifacts} from './browser_storage';
+import {BrowserStorageType} from './types';
 
 describeWithFlags('LocalStorage', BROWSER_ENVS, () => {
   // Test data.
@@ -299,16 +301,15 @@ describeWithFlags('LocalStorage', BROWSER_ENVS, () => {
   });
 
   it('router', () => {
-    expect(
-        localStorageRouter('localstorage://bar') instanceof BrowserLocalStorage)
+    expect(browserStorageRouter('localstorage://bar') instanceof BrowserStorage)
         .toEqual(true);
-    expect(localStorageRouter('indexeddb://bar')).toBeNull();
-    expect(localStorageRouter('qux')).toBeNull();
+    expect(browserStorageRouter('indexeddb://bar')).toBeNull();
+    expect(browserStorageRouter('qux')).toBeNull();
   });
 
   it('Manager: List models: 0 result', done => {
     // Before any model is saved, listModels should return empty result.
-    new BrowserLocalStorageManager()
+    new BrowserStorageManager(BrowserStorageType.local)
         .listModels()
         .then(out => {
           expect(out).toEqual({});
@@ -322,7 +323,7 @@ describeWithFlags('LocalStorage', BROWSER_ENVS, () => {
     handler.save(artifacts1)
         .then(saveResult => {
           // After successful saving, there should be one model.
-          new BrowserLocalStorageManager()
+          new BrowserStorageManager(BrowserStorageType.local)
               .listModels()
               .then(out => {
                 expect(Object.keys(out).length).toEqual(1);
@@ -352,7 +353,7 @@ describeWithFlags('LocalStorage', BROWSER_ENVS, () => {
           handler2.save(artifacts1)
               .then(saveResult2 => {
                 // After successful saving, there should be two models.
-                new BrowserLocalStorageManager()
+                new BrowserStorageManager(BrowserStorageType.local)
                     .listModels()
                     .then(out => {
                       expect(Object.keys(out).length).toEqual(2);
@@ -401,7 +402,8 @@ describeWithFlags('LocalStorage', BROWSER_ENVS, () => {
               .then(saveResult2 => {
                 // After successful saving, delete the first save, and then
                 // `listModel` should give only one result.
-                const manager = new BrowserLocalStorageManager();
+                const manager =
+                    new BrowserStorageManager(BrowserStorageType.local);
 
                 manager.removeModel('QuxModel')
                     .then(deletedInfo => {

--- a/src/io/model_management_test.ts
+++ b/src/io/model_management_test.ts
@@ -19,7 +19,7 @@ import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {CHROME_ENVS} from '../test_util';
 import {deleteDatabase} from './indexed_db';
-import {purgeLocalStorageArtifacts} from './local_storage';
+import {purgeLocalStorageArtifacts} from './browser_storage';
 
 // Disabled for non-Chrome browsers due to:
 // https://github.com/tensorflow/tfjs/issues/427

--- a/src/io/types.ts
+++ b/src/io/types.ts
@@ -239,3 +239,8 @@ export interface ModelStoreManager {
    */
   removeModel(path: string): Promise<ModelArtifactsInfo>;
 }
+
+export enum BrowserStorageType {
+  local = 'local',
+  session = 'session'
+}


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
I have a use case where I need to store models temporarily for a session, and `sessionStorage` fits this bill perfectly, but currently this isn't a supported storage handler. Since both `localStorage` and `sessionStorage` are implementations of `Storage`, the implementation for `localStorage` should already support `sessionStorage` as well.

This PR turns the current `BrowserLocalStorage` class into the more generic `BrowserStorage` which can handle either type.

@caisq, thoughts? I realize this needs test coverage but I'm not sure the best way to avoid duplicating the entire `local_storage_test.ts` file.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1406)
<!-- Reviewable:end -->
