### PR TITLE
Add BrowerHTTPRequestSaveResult interface

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -24,7 +24,7 @@
 import {assert} from '../util';
 import {concatenateArrayBuffers, getModelArtifactsInfoForJSON} from './io_utils';
 import {IORouter, IORouterRegistry} from './router_registry';
-import {IOHandler, ModelArtifacts, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
+import {BrowserHTTPRequestSaveResult, IOHandler, ModelArtifacts, WeightsManifestConfig, WeightsManifestEntry} from './types';
 import {loadWeightsAsArrayBuffer} from './weights_loader';
 
 export class BrowserHTTPRequest implements IOHandler {
@@ -64,7 +64,8 @@ export class BrowserHTTPRequest implements IOHandler {
     this.requestInit = requestInit || {};
   }
 
-  async save(modelArtifacts: ModelArtifacts): Promise<SaveResult> {
+  async save(modelArtifacts: ModelArtifacts):
+      Promise<BrowserHTTPRequestSaveResult> {
     if (modelArtifacts.modelTopology instanceof ArrayBuffer) {
       throw new Error(
           'BrowserHTTPRequest.save() does not support saving model topology ' +

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -25,7 +25,7 @@ import {browserHTTPRequest} from './browser_http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, withSaveHandler} from './passthrough';
 import {IORouterRegistry} from './router_registry';
-import {IOHandler, LoadHandler, ModelArtifacts, ModelStoreManager, SaveConfig, SaveHandler, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
+import {BrowserHTTPRequestSaveResult, IOHandler, LoadHandler, ModelArtifacts, ModelStoreManager, SaveConfig, SaveHandler, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
 import {loadWeights, weightsLoaderFactory} from './weights_loader';
 
 const registerSaveRouter = IORouterRegistry.registerSaveRouter;
@@ -38,6 +38,7 @@ export {copyModel, listModels, moveModel, removeModel} from './model_management'
 export {
   browserFiles,
   browserHTTPRequest,
+  BrowserHTTPRequestSaveResult,
   concatenateArrayBuffers,
   decodeWeights,
   encodeWeights,

--- a/src/io/types.ts
+++ b/src/io/types.ts
@@ -111,15 +111,16 @@ export interface SaveResult {
   modelArtifactsInfo: ModelArtifactsInfo;
 
   /**
-   * HTTP responses from the server that handled the model-saving request (if
-   * any). This is applicable only to server-based saving routes.
-   */
-  responses?: Response[];
-
-  /**
    * Error messages and related data (if any).
    */
   errors?: Array<{}|string>;
+}
+
+export interface BrowserHTTPRequestSaveResult extends SaveResult {
+  /**
+   * HTTP responses from the server that handled the model-saving request.
+   */
+  responses: Response[];
 }
 
 export declare interface ModelArtifactsInfo {


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
This is pulled out of #1399 with a minor tweak.

The general idea being, different `IOHandler` implementations need to return extra information in `SaveResult`. `responses` was being special-cased as an optional key, but this gets ugly fast if you need to add more implementation-specific optional keys. Extending the interface for implementation-specific results feels like the right thing to do here.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
