### PR TITLE
Implement packed clipping op.

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -311,6 +311,10 @@ export class Environment {
       return true;
     } else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
       return false;
+    } else if (feature === 'WEBGL_PACK_CLIP') {
+      return false;
+    } else if (feature === 'WEBGL_PACK_DEPTHWISECONV') {
+      return false;
     } else if (feature === 'WEBGL_LAZILY_UNPACK') {
       return false;
     } else if (feature === 'WEBGL_CONV_IM2COL') {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -309,16 +309,16 @@ export class Environment {
       return isChrome();
     } else if (feature === 'WEBGL_CPU_FORWARD') {
       return true;
+    } else if (feature === 'WEBGL_PACK') {
+      return false;
     } else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
-      return false;
+      return this.get('WEBGL_PACK');
     } else if (feature === 'WEBGL_PACK_CLIP') {
-      return false;
-    } else if (feature === 'WEBGL_PACK_DEPTHWISECONV') {
-      return false;
+      return this.get('WEBGL_PACK');
     } else if (feature === 'WEBGL_LAZILY_UNPACK') {
-      return false;
+      return this.get('WEBGL_PACK');
     } else if (feature === 'WEBGL_CONV_IM2COL') {
-      return false;
+      return this.get('WEBGL_PACK');
     } else if (feature === 'WEBGL_PAGING_ENABLED') {
       return this.get('IS_BROWSER') && !this.get('PROD');
     } else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -28,6 +28,8 @@ export interface Features {
   'WEBGL_LAZILY_UNPACK'?: boolean;
   // Whether the WebGL backend will sometimes forward ops to the CPU.
   'WEBGL_CPU_FORWARD'?: boolean;
+  // Whether to turn all packing related flags on.
+  'WEBGL_PACK'?: boolean;
   // Whether we will pack the batchnormalization op.
   'WEBGL_PACK_BATCHNORMALIZATION'?: boolean;
   // Whether we will pack the clipping op.
@@ -91,6 +93,7 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'IS_BROWSER', type: Type.BOOLEAN},
   {name: 'WEBGL_LAZILY_UNPACK', type: Type.BOOLEAN},
   {name: 'WEBGL_CPU_FORWARD', type: Type.BOOLEAN},
+  {name: 'WEBGL_PACK', type: Type.BOOLEAN},
   {name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN},
   {name: 'WEBGL_PACK_CLIP', type: Type.BOOLEAN},
   {name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN},

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -30,6 +30,8 @@ export interface Features {
   'WEBGL_CPU_FORWARD'?: boolean;
   // Whether we will pack the batchnormalization op.
   'WEBGL_PACK_BATCHNORMALIZATION'?: boolean;
+  // Whether we will pack the clipping op.
+  'WEBGL_PACK_CLIP'?: boolean;
   // Whether we will use the im2col algorithm to speed up convolutions.
   'WEBGL_CONV_IM2COL'?: boolean;
   // Whether we will perform memory paging.
@@ -90,6 +92,7 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'WEBGL_LAZILY_UNPACK', type: Type.BOOLEAN},
   {name: 'WEBGL_CPU_FORWARD', type: Type.BOOLEAN},
   {name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN},
+  {name: 'WEBGL_PACK_CLIP', type: Type.BOOLEAN},
   {name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN},
   {name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER},
   {name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN},

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1821,8 +1821,11 @@ export class MathBackendWebGL implements KernelBackend {
         // Upload small tensors that live on the CPU as uniforms, not as
         // textures. Do this only when the environment supports 32bit floats due
         // to problems when comparing 16bit floats with 32bit floats.
-        if (util.sizeFromShape(input.shape) <=
-            ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
+        // TODO(https://github.com/tensorflow/tfjs/issues/821): Make it possible
+        // for packed shaders to sample from uniforms.
+        if (!(!texData.isPacked && program.usesPackedTextures) &&
+            util.sizeFromShape(input.shape) <=
+                ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
           return {
             shape: input.shape,
             texData: null,

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -51,6 +51,7 @@ import {BinaryOpComplexProgram} from './webgl/binaryop_complex_gpu';
 import * as binaryop_gpu from './webgl/binaryop_gpu';
 import {BinaryOpProgram} from './webgl/binaryop_gpu';
 import {ClipProgram} from './webgl/clip_gpu';
+import {ClipPackedProgram} from './webgl/clip_packed_gpu';
 import {ComplexAbsProgram} from './webgl/complex_abs_gpu';
 import {ConcatProgram} from './webgl/concat_gpu';
 import {Conv2DDerFilterProgram, Conv2DDerInputProgram} from './webgl/conv_backprop_gpu';

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1331,7 +1331,12 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   clip<T extends Tensor>(x: T, min: number, max: number): T {
-    const program = new ClipProgram(x.shape, min, max);
+    let program;
+    if (ENV.get('WEBGL_PACK_CLIP')) {
+      program = new ClipPackedProgram(x.shape, min, max);
+    } else {
+      program = new ClipProgram(x.shape, min, max);
+    }
     return this.compileAndRun(program, [x]) as T;
   }
 

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -18,7 +18,7 @@
 import {GPGPUProgram} from './gpgpu_math';
 import {getCoordsDataType} from './shader_compiler';
 
-export class ClipProgram implements GPGPUProgram {
+export class ClipPackedProgram implements GPGPUProgram {
   variableNames = ['A'];
   usesPackedTextures = true;
   userCode: string;
@@ -45,7 +45,7 @@ export class ClipProgram implements GPGPUProgram {
 const dims = ['rc.x', 'rc.y', 'rc.z', 'rc.w'];
 
 function getSourceCoords(rank: number): string {
-  if(rank === 1) {
+  if (rank === 1) {
     return 'rc';
   }
 

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -36,6 +36,20 @@ export class ClipPackedProgram implements GPGPUProgram {
         ${dtype} rc = getOutputCoords();
         vec4 value = getA(${sourceCoords});
 
+        if(hasNaN(value)) {
+          setOutput(vec4(
+            isNaN(value.x) ? value.x : clamp(value.x, float(${min}), float(${
+        max})),
+            isNaN(value.y) ? value.y : clamp(value.y, float(${min}), float(${
+        max})),
+            isNaN(value.z) ? value.z : clamp(value.z, float(${min}), float(${
+        max})),
+            isNaN(value.w) ? value.w : clamp(value.w, float(${min}), float(${
+        max}))
+          ));
+          return;
+        }
+
         setOutput(clamp(value, vec4(${min}), vec4(${max})));
       }
     `;

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -29,17 +29,8 @@ export class ClipPackedProgram implements GPGPUProgram {
       void main() {
         vec4 value = getAAtOutCoords();
 
-        if(hasNaN(value)) {
-          setOutput(vec4(
-            isNaN(value.x) ? value.x : clamp(value.x, float(${min}), float(${
-        max})),
-            isNaN(value.y) ? value.y : clamp(value.y, float(${min}), float(${
-        max})),
-            isNaN(value.z) ? value.z : clamp(value.z, float(${min}), float(${
-        max})),
-            isNaN(value.w) ? value.w : clamp(value.w, float(${min}), float(${
-        max}))
-          ));
+        if (hasNaN(value)) {
+          setOutput(value);
           return;
         }
 

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {GPGPUProgram} from './gpgpu_math';
+import {getCoordsDataType} from './shader_compiler';
+
+export class ClipProgram implements GPGPUProgram {
+  variableNames = ['A'];
+  usesPackedTextures = true;
+  userCode: string;
+  outputShape: number[];
+
+  constructor(aShape: number[], min: number, max: number) {
+    this.outputShape = aShape;
+    const rank = aShape.length;
+
+    const dtype = getCoordsDataType(rank);
+    const sourceCoords = getSourceCoords(rank);
+
+    this.userCode = `
+      void main() {
+        ${dtype} rc = getOutputCoords();
+        vec4 value = getA(${sourceCoords});
+
+        setOutput(clamp(value, vec4(${min}), vec4(${max})));
+      }
+    `;
+  }
+}
+
+const dims = ['rc.x', 'rc.y', 'rc.z', 'rc.w'];
+
+function getSourceCoords(rank: number): string {
+  if(rank === 1) {
+    return 'rc';
+  }
+
+  let coords = '';
+  for (let i = 0; i < rank; i++) {
+    coords += dims[i];
+    if (i < rank - 1) {
+      coords += ',';
+    }
+  }
+  return coords;
+}

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -16,7 +16,6 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
-import {getCoordsDataType} from './shader_compiler';
 
 export class ClipPackedProgram implements GPGPUProgram {
   variableNames = ['A'];
@@ -26,15 +25,9 @@ export class ClipPackedProgram implements GPGPUProgram {
 
   constructor(aShape: number[], min: number, max: number) {
     this.outputShape = aShape;
-    const rank = aShape.length;
-
-    const dtype = getCoordsDataType(rank);
-    const sourceCoords = getSourceCoords(rank);
-
     this.userCode = `
       void main() {
-        ${dtype} rc = getOutputCoords();
-        vec4 value = getA(${sourceCoords});
+        vec4 value = getAAtOutCoords();
 
         if(hasNaN(value)) {
           setOutput(vec4(
@@ -54,21 +47,4 @@ export class ClipPackedProgram implements GPGPUProgram {
       }
     `;
   }
-}
-
-const dims = ['rc.x', 'rc.y', 'rc.z', 'rc.w'];
-
-function getSourceCoords(rank: number): string {
-  if (rank === 1) {
-    return 'rc';
-  }
-
-  let coords = '';
-  for (let i = 0; i < rank; i++) {
-    coords += dims[i];
-    if (i < rank - 1) {
-      coords += ',';
-    }
-  }
-  return coords;
 }

--- a/src/kernels/webgl/pack_gpu.ts
+++ b/src/kernels/webgl/pack_gpu.ts
@@ -36,7 +36,7 @@ export class PackProgram implements GPGPUProgram {
     if (rank === 0) {
       this.userCode = `
         void main() {
-          setOutput(vec4(A, 0., 0., 0.));
+          setOutput(vec4(getA(), 0., 0., 0.));
         }
       `;
     } else {

--- a/src/kernels/webgl/pack_gpu.ts
+++ b/src/kernels/webgl/pack_gpu.ts
@@ -33,28 +33,36 @@ export class PackProgram implements GPGPUProgram {
     this.outputShape = outputShape;
     const rank = outputShape.length;
 
-    const channels = getChannels('rc', rank);
-    const dtype = getCoordsDataType(rank);
-    const outOfBoundsCondition =
-        getOutOfBoundsCondition(rank, outputShape, channels);
-    const setup = getSetup(
-        rank, outputShape[outputShape.length - 1],
-        outputShape[outputShape.length - 2], channels);
-    const output = getOutput(outputShape, channels);
-
-    this.userCode = `
-      void main() {
-        ${dtype} rc = getOutputCoords();
-
-        if(${outOfBoundsCondition}) {
-          gl_FragColor = vec4(0);
-        } else {
-          ${setup}
-
-          setOutput(vec4(${output}));
+    if (rank === 0) {
+      this.userCode = `
+        void main() {
+          setOutput(vec4(A, 0., 0., 0.));
         }
-      }
-    `;
+      `;
+    } else {
+      const channels = getChannels('rc', rank);
+      const dtype = getCoordsDataType(rank);
+      const outOfBoundsCondition =
+          getOutOfBoundsCondition(rank, outputShape, channels);
+      const setup = getSetup(
+          rank, outputShape[outputShape.length - 1],
+          outputShape[outputShape.length - 2], channels);
+      const output = getOutput(outputShape, channels);
+
+      this.userCode = `
+        void main() {
+          ${dtype} rc = getOutputCoords();
+
+          if(${outOfBoundsCondition}) {
+            setOutput(vec4(0));
+          } else {
+            ${setup}
+
+            setOutput(vec4(${output}));
+          }
+        }
+      `;
+    }
   }
 }
 

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -1308,22 +1308,8 @@ function getPackedSamplerAtOutputCoords(
       inputInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape);
   const inRank = inputInfo.shapeInfo.logicalShape.length;
   const outRank = outShapeInfo.logicalShape.length;
-  const doBroadcast =
-      supportsBroadcasting && ((outRank > inRank) || broadcastDims.length > 0);
-  const broadcastOverOuter =
-      broadcast_util.broadcastDimsAreOuter(broadcastDims);
-
-  if (doBroadcast && !broadcastOverOuter) {
+  if (broadcastDims.length) {
     throw Error('Packed broadcast sampling is not implemented yet.');
-  }
-
-  const inSize = util.sizeFromShape(packedTexShape);
-  let broadcastSnippet = '';
-  if (doBroadcast && broadcastOverOuter) {
-    broadcastSnippet = `
-        int mainPart = index / ${inSize};
-        index -= mainPart * ${inSize};
-      `;
   }
 
   const inTexShape = inputInfo.shapeInfo.texShape;
@@ -1361,8 +1347,6 @@ function getPackedSamplerAtOutputCoords(
       ivec2 resTexRC = ivec2(resultUV.yx *
                              vec2(${packedTexShape[0]}, ${packedTexShape[1]}));
       int index = resTexRC.x * ${packedTexShape[1]} + resTexRC.y;
-
-      ${broadcastSnippet}
 
       int texR = index / ${texNumC};
       int texC = index - texR * ${texNumC};

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -331,7 +331,7 @@ const SHADER_PREFIX = `
   };
 
   bool isNaN(float val) {
-    return false;
+    return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
   }
 
   bool hasNaN(vec4 values) {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -331,9 +331,12 @@ const SHADER_PREFIX = `
   }
 
   bool hasNaN(vec4 values) {
-    vec4 v1 = values * values;
-    vec4 v2 = values * values;
-    return any(notEqual(v1, v2));
+    return any(bvec4(
+      (values.x < 1.0 || 0.0 < values.x || values.x == 0.0) ? false : true,
+      (values.y < 1.0 || 0.0 < values.y || values.y == 0.0) ? false : true,
+      (values.z < 1.0 || 0.0 < values.z || values.z == 0.0) ? false : true,
+      (values.w < 1.0 || 0.0 < values.w || values.w == 0.0) ? false : true
+    ));
   }
 
   float getNaN(vec4 values) {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -1281,7 +1281,7 @@ function getPackedSamplerAtOutputCoords(
       broadcast_util.broadcastDimsAreOuter(broadcastDims);
 
   if (doBroadcast && !broadcastOverOuter) {
-    throw Error('not implemented yet');
+    throw Error('Packed broadcast sampling is not implemented yet.');
   }
 
   const inSize = util.sizeFromShape(packedTexShape);

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -332,10 +332,10 @@ if (ENV.get('PROD')) {
 
     bool hasNaN(vec4 values) {
       return any(bvec4(
-        (values.x < 1.0 || 0.0 < values.x || values.x == 0.0) ? false : true,
-        (values.y < 1.0 || 0.0 < values.y || values.y == 0.0) ? false : true,
-        (values.z < 1.0 || 0.0 < values.z || values.z == 0.0) ? false : true,
-        (values.w < 1.0 || 0.0 < values.w || values.w == 0.0) ? false : true
+        isNaN(values.x),
+        isNaN(values.y),
+        isNaN(values.z),
+        isNaN(values.w)
       ));
     }
   `;

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -124,7 +124,7 @@ function getInputSamplingSnippet(
     inInfo: InputInfo, outShapeInfo: ShapeInfo, broadcast: boolean,
     usesPackedTextures = false): string {
   let res = getSamplerFlat(inInfo);
-  if (inInfo.shapeInfo.isPacked) {
+  if (usesPackedTextures) {
     res += getPackedSamplerFromInInfo(inInfo);
   } else {
     res += getSamplerFromInInfo(inInfo);

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -122,12 +122,13 @@ function getInputSamplingSnippet(
     res += getSamplerFromInInfo(inInfo);
   }
 
-  // If input and output have matching logical shapes, add
-  // getTexNameAtOutCoord() method that samples the input
+  // If input and output have the same packed status and have matching logical
+  // shapes, add getTexNameAtOutCoord() method that samples the input
   // textureSampler using the output coordinates.
-  if (broadcast ||
-      util.arraysEqual(
-          inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
+  if (inInfo.shapeInfo.isPacked === outShapeInfo.isPacked &&
+      (broadcast ||
+       util.arraysEqual(
+           inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape))) {
     if (inInfo.shapeInfo.isPacked) {
       res += getPackedSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     } else {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -321,9 +321,9 @@ if (ENV.get('PROD')) {
     }
   `;
 } else {
-  /*
-  Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false : true'
-  does not work on iOS 12
+  /**
+   * Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false : true'
+   * does not work on iOS 12
    */
   NAN_CHECKS = `
     bool isNaN(float val) {

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -130,13 +130,12 @@ function getInputSamplingSnippet(
     res += getSamplerFromInInfo(inInfo);
   }
 
-  // If input and output have the same packed status and have matching logical
-  // shapes, add getTexNameAtOutCoord() method that samples the input
-  // textureSampler using the output coordinates.
-  if (usesPackedTextures === outShapeInfo.isPacked &&
-      (broadcast ||
-       util.arraysEqual(
-           inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape))) {
+  // If input and output have matching logical shapes, add
+  // getTexNameAtOutCoord() method that samples the input textureSampler using
+  // the output coordinates.
+  if (broadcast ||
+      util.arraysEqual(
+          inInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape)) {
     if (usesPackedTextures) {
       res += getPackedSamplerAtOutputCoords(inInfo, outShapeInfo, broadcast);
     } else {

--- a/src/kernels/webgl/unpack_gpu.ts
+++ b/src/kernels/webgl/unpack_gpu.ts
@@ -34,7 +34,7 @@ export class UnpackProgram implements GPGPUProgram {
     const dtype = getCoordsDataType(rank);
     const sourceCoords = getSourceCoords(rank, channels);
     const innerDims = channels.slice(-2);
-    const coords = rank === 1 ? 'rc' : `vec2(${innerDims.join(',')})`;
+    const coords = rank <= 1 ? 'rc' : `vec2(${innerDims.join(',')})`;
 
     this.userCode = `
       void main() {

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2421,7 +2421,7 @@ describeWithFlags('packed clip', WEBGL_ENVS, () => {
     tf.ENV.set('WEBGL_PACK_CLIP', webglPackedClipSavedFlag);
   });
 
-  fit('should not leak memory', () => {
+  it('should not leak memory', () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2]);
     const min = -1;
     const max = 50;

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2446,6 +2446,16 @@ describeWithFlags('packed clip', WEBGL_ENVS, () => {
     expectArraysClose(result, [3, -1, 0, 50, -1, 2]);
   });
 
+  fit('should work for scalars', () => {
+    const a = tf.scalar(-4);
+    const min = -1;
+    const max = 50;
+
+    const result = tf.clipByValue(a, min, max);
+
+    expectArraysClose(result, [min]);
+  });
+
   it('derivative: 1D tensor with max or min value', () => {
     const min = -1;
     const max = 2;

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2446,7 +2446,7 @@ describeWithFlags('packed clip', WEBGL_ENVS, () => {
     expectArraysClose(result, [3, -1, 0, 50, -1, 2]);
   });
 
-  fit('should work for scalars', () => {
+  it('should work for scalars', () => {
     const a = tf.scalar(-4);
     const min = -1;
     const max = 50;


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tfjs/issues/803

### Changes
- Added `ClipPackedProgram` that implements clipping for packed textures
- Added ENV flag `WEBGL_PACK_CLIP`, defaults to `false`
- Added ENV flag `WEBGL_PACK`, defaults to `false`, that turns all packing-related flags on or off
- Turn off NaN checking if `PROD` flag is on
- Support scalar sampling in packed ops
- Partially support packed `get${Var}AtOutCoords` and broadcasting - broadcasting only occurs when the innermost dimensions are the same and the vector to be broadcast is rank 0 or 1. 

PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1412)
<!-- Reviewable:end -->
