### PR TITLE
Remove gradMode from public API as it is confusing users.

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -183,8 +183,8 @@ export class Environment {
    */
   /** @doc {heading: 'Performance', subheading: 'Memory'} */
   static tidy<T extends TensorContainer>(
-      nameOrFn: string|ScopeFn<T>, fn?: ScopeFn<T>, gradMode = false): T {
-    return ENV.engine.tidy(nameOrFn, fn, gradMode);
+      nameOrFn: string|ScopeFn<T>, fn?: ScopeFn<T>): T {
+    return ENV.engine.tidy(nameOrFn, fn);
   }
 
   /**


### PR DESCRIPTION
Internally we call engine.tidy() which has gradMode so we don't need it on the public tidy.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1414)
<!-- Reviewable:end -->
