### PR TITLE
Annotate class names of optimizers for closure compiler

### DIFF
--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -25,6 +25,7 @@ import {Optimizer} from './optimizer';
 
 /** @doclink Optimizer */
 export class AdadeltaOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'AdadeltaOptimizer';
   private c: Scalar;
   private epsilonScalar: Scalar;

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -25,6 +25,7 @@ import {Optimizer} from './optimizer';
 
 /** @doclink Optimizer */
 export class AdagradOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'AdagradOptimizer';
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/adam_optimizer.ts
+++ b/src/optimizers/adam_optimizer.ts
@@ -24,6 +24,7 @@ import {NamedVariableMap} from '../tensor_types';
 import {Optimizer} from './optimizer';
 
 export class AdamOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'AdamOptimizer';
   private c: Scalar;
   private epsScalar: Scalar;

--- a/src/optimizers/adamax_optimizer.ts
+++ b/src/optimizers/adamax_optimizer.ts
@@ -24,6 +24,7 @@ import {NamedVariableMap} from '../tensor_types';
 import {Optimizer} from './optimizer';
 
 export class AdamaxOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'AdamaxOptimizer';
   private c: Scalar;
   private epsScalar: Scalar;

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -25,6 +25,7 @@ import {SGDOptimizer} from './sgd_optimizer';
 
 /** @doclink Optimizer */
 export class MomentumOptimizer extends SGDOptimizer {
+  /** @nocollapse */
   static className = 'MomentumOptimizer';
   private m: Scalar;
   private accumulations: NamedVariableMap;

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -25,6 +25,7 @@ import {Optimizer} from './optimizer';
 
 /** @doclink Optimizer */
 export class RMSPropOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'RMSPropOptimizer';
   private c: Scalar;
   private epsilonScalar: Scalar;

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -25,6 +25,7 @@ import {Optimizer} from './optimizer';
 
 /** @doclink Optimizer */
 export class SGDOptimizer extends Optimizer {
+  /** @nocollapse */
   static className = 'SGDOptimizer';
   protected c: Scalar;
 


### PR DESCRIPTION
Annotate class names of optimizers so closure compiler doesn't rename

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1415)
<!-- Reviewable:end -->
