### PR TITLE
Properly decode data from packed textures when calling async read.

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1813,10 +1813,7 @@ export class MathBackendWebGL implements KernelBackend {
 
       let texData = this.texData.get(input.dataId);
 
-      if (texData.texture == null &&
-          !(!texData.isPacked && program.usesPackedTextures) &&
-          util.sizeFromShape(input.shape) <=
-              ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
+      if (texData.texture == null) {
         // Upload small tensors that live on the CPU as uniforms, not as
         // textures. Do this only when the environment supports 32bit floats due
         // to problems when comparing 16bit floats with 32bit floats.
@@ -1829,15 +1826,12 @@ export class MathBackendWebGL implements KernelBackend {
           uniformValues: this.readSync(input.dataId) as TypedArray
         };
 
-        // TODO(annyuan): Revive this block once uploading to packed textures is
-        // fixed.
-
         // This ensures that if a packed program's inputs have not yet been
         // uploaded to the GPU, they get uploaded as packed right off the bat.
-        // if (program.usesPackedTextures) {
-        // texData.isPacked = true;
-        // texData.shape = input.shape;
-        //}
+        if (program.usesPackedTextures) {
+          texData.isPacked = true;
+          texData.shape = input.shape;
+        }
       } else if (!!texData.isPacked !== !!program.usesPackedTextures) {
         let preProcessProgram: UnpackProgram|PackProgram;
         let processedInput: Tensor;

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -108,6 +108,12 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expectArraysClose(await a.data(), new Float32Array([1, 2, 3, 4, 5, 6]));
   });
 
+  it('Tensor.data() packed CPU --> GPU', async () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [3, 2]);
+    tf.matMul(a, tf.tensor2d([1, 2], [2, 1]));
+    expectArraysClose(await a.data(), new Float32Array([1, 2, 3, 4, 5, 6]));
+  });
+
   it('Scalar basic methods', () => {
     const a = tf.scalar(5);
     expectNumbersClose(a.get(), 5);


### PR DESCRIPTION
### Changes

- Add check for `isPacked` bit on textures and call appropriate decoder in `async read`
- Revive logic for lazy uploading removed by https://github.com/tensorflow/tfjs-core/pull/1417
- Add unit test

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
