### PR TITLE
getTexureShapeFromLogicalShape should return even numbers for packed …

### DIFF
--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -375,7 +375,14 @@ export function getTextureShapeFromLogicalShape(
       logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
     return [logShape[0], logShape[1] * logShape[2] * logShape[3]];
   } else {
-    return util.sizeToSquarishShape(size);
+    const texShape = util.sizeToSquarishShape(size);
+    if (isPacked) {
+      // Ensure that packed texture has even width and height, even it could
+      // exceed maxTexSize - e.g. 6x12 shape is sizeToSquarishShape-ed to 8x9.
+      texShape[0] = util.nearestLargerEven(texShape[0]);
+      texShape[1] = util.nearestLargerEven(texShape[1]);
+    }
+    return texShape;
   }
 }
 

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -111,6 +111,19 @@ describeWithFlags('getTextureShapeFromLogicalShape packed', WEBGL_ENVS, () => {
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', max);
     expect(texShape).toEqual([4, 6]);
   });
+
+  it('squarified texture shapes have even number of rows and columns', () => {
+    const isPacked = true;
+    const max = tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+
+    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 5);
+    const logicalShape = [6, 12];
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(logicalShape, isPacked);
+
+    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', max);
+    expect(texShape).toEqual([8, 10]);
+  });
 });
 
 describeWithFlags('isReshapeFree', WEBGL_ENVS, () => {


### PR DESCRIPTION
…texures

#### Description
Ensure that even width and height is returned, even though it could exceed
maxTexSize - e.g. 6x12 shape is sizeToSquarishShape-ed to 8x9.

BUG

<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1420)
<!-- Reviewable:end -->
