### PR TITLE
Support different glsl version for webgl1.0 and 2.0

### DIFF
--- a/src/kernels/webgl/encode_float_gpu.ts
+++ b/src/kernels/webgl/encode_float_gpu.ts
@@ -16,6 +16,7 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {getGlslDifferences} from './glsl_version';
 
 export class EncodeFloatProgram implements GPGPUProgram {
   variableNames = ['A'];
@@ -23,6 +24,7 @@ export class EncodeFloatProgram implements GPGPUProgram {
   outputShape: number[];
 
   constructor(outputShape: number[]) {
+    const glsl = getGlslDifferences();
     this.outputShape = outputShape;
     this.userCode = `
       const float FLOAT_MAX = 1.70141184e38;
@@ -66,7 +68,7 @@ export class EncodeFloatProgram implements GPGPUProgram {
 
       void main() {
         float x = getAAtOutCoords();
-        gl_FragColor = encode_float(x);
+        ${glsl.output} = encode_float(x);
       }
     `;
   }

--- a/src/kernels/webgl/encode_float_gpu.ts
+++ b/src/kernels/webgl/encode_float_gpu.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {GPGPUProgram} from './gpgpu_math';
 import {getGlslDifferences} from './glsl_version';
+import {GPGPUProgram} from './gpgpu_math';
 
 export class EncodeFloatProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/from_pixels_gpu.ts
+++ b/src/kernels/webgl/from_pixels_gpu.ts
@@ -16,6 +16,7 @@
  */
 
 import {GPGPUProgram} from './gpgpu_math';
+import {getGlslDifferences} from './glsl_version';
 
 export class FromPixelsProgram implements GPGPUProgram {
   variableNames = ['A'];
@@ -23,6 +24,7 @@ export class FromPixelsProgram implements GPGPUProgram {
   outputShape: number[];
 
   constructor(outputShape: number[]) {
+    const glsl = getGlslDifferences();
     const [height, width, ] = outputShape;
     this.outputShape = outputShape;
     this.userCode = `
@@ -33,7 +35,7 @@ export class FromPixelsProgram implements GPGPUProgram {
         int depth = coords[2];
         vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${width}.0, ${height}.0);
 
-        vec4 values = texture2D(A, uv);
+        vec4 values = ${glsl.texture2D}(A, uv);
         float value;
         if (depth == 0) {
           value = values.r;

--- a/src/kernels/webgl/from_pixels_gpu.ts
+++ b/src/kernels/webgl/from_pixels_gpu.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {GPGPUProgram} from './gpgpu_math';
 import {getGlslDifferences} from './glsl_version';
+import {GPGPUProgram} from './gpgpu_math';
 
 export class FromPixelsProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -46,7 +46,7 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture';
     output = 'outputColor';
     defineOutput = 'out vec4 outputColor;';
-    defineRound = '';
+    defineRound = '#define round(x) int(round(x))';
   } else {
     version = '';
     attribute = 'attribute';

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -46,7 +46,7 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture';
     output = 'outputColor';
     defineOutput = 'out vec4 outputColor;';
-    defineRound = '#define round(x) int(round(x))';
+    defineRound = '#define round(value) int(floor((value) + 0.5))';
   } else {
     version = '';
     attribute = 'attribute';

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../../environment';
+
+export type GLSL = {
+  version: string,
+  attribute: string,
+  varyingVs: string,
+  varyingFs: string,
+  texture2D: string,
+  output: string,
+  defineOutput: string,
+  defineRound: string
+};
+
+export function getGlslDifferences(): GLSL {
+  let version: string;
+  let attribute: string;
+  let varyingVs: string;
+  let varyingFs: string;
+  let texture2D: string;
+  let output: string;
+  let defineOutput: string;
+  let defineRound: string;
+
+  if (ENV.get('WEBGL_VERSION') === 2) {
+    version = '#version 300 es';
+    attribute = 'in';
+    varyingVs = 'out';
+    varyingFs = 'in';
+    texture2D = 'texture';
+    output = 'outputColor';
+    defineOutput = 'out vec4 outputColor;';
+    defineRound = '';
+  } else {
+    version = '';
+    attribute = 'attribute';
+    varyingVs = 'varying';
+    varyingFs = 'varying';
+    texture2D = 'texture2D';
+    output = 'gl_FragColor';
+    defineOutput = '';
+    defineRound = `
+      int round(float value) {
+        return int(floor(value + 0.5));
+      }
+    `;
+  }
+
+  return {
+    version,
+    attribute,
+    varyingVs,
+    varyingFs,
+    texture2D,
+    output,
+    defineOutput,
+    defineRound
+  };
+}

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -18,6 +18,7 @@
 import {describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose, expectNumbersClose} from '../../test_util';
 import {binSearchLastTrue, GPGPUContext} from './gpgpu_context';
+import {getGlslDifferences} from './glsl_version';
 import * as tex_util from './tex_util';
 
 const DOWNLOAD_FLOAT_ENVS = {
@@ -205,8 +206,10 @@ describeWithFlags(
       beforeEach(() => {
         gpgpu = new GPGPUContext();
         gpgpu.enableAutomaticDebugValidation(true);
-        const src =
-            'precision highp float; void main(){gl_FragColor = vec4(2,0,0,0);}';
+        const glsl = getGlslDifferences();
+        const src =`
+          precision highp float; void main(){${glsl.output} = vec4(2,0,0,0);}
+        `;
         program = gpgpu.createProgram(src);
         output = gpgpu.createFloat32MatrixTexture(4, 4);
         gpgpu.uploadMatrixToTexture(output, 4, 4, new Float32Array(16));

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -17,8 +17,8 @@
 
 import {describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose, expectNumbersClose} from '../../test_util';
-import {binSearchLastTrue, GPGPUContext} from './gpgpu_context';
 import {getGlslDifferences} from './glsl_version';
+import {binSearchLastTrue, GPGPUContext} from './gpgpu_context';
 import * as tex_util from './tex_util';
 
 const DOWNLOAD_FLOAT_ENVS = {
@@ -207,7 +207,7 @@ describeWithFlags(
         gpgpu = new GPGPUContext();
         gpgpu.enableAutomaticDebugValidation(true);
         const glsl = getGlslDifferences();
-        const src =`
+        const src = `
           precision highp float; void main(){${glsl.output} = vec4(2,0,0,0);}
         `;
         program = gpgpu.createProgram(src);

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -207,8 +207,12 @@ describeWithFlags(
         gpgpu = new GPGPUContext();
         gpgpu.enableAutomaticDebugValidation(true);
         const glsl = getGlslDifferences();
-        const src = `
-          precision highp float; void main(){${glsl.output} = vec4(2,0,0,0);}
+        const src = `${glsl.version}
+          precision highp float;
+          ${glsl.defineOutput}
+          void main() {
+            ${glsl.output} = vec4(2,0,0,0);
+          }
         `;
         program = gpgpu.createProgram(src);
         output = gpgpu.createFloat32MatrixTexture(4, 4);
@@ -297,7 +301,11 @@ describeWithFlags('GPGPUContext', DOWNLOAD_FLOAT_ENVS, () => {
   });
 
   it('throws an error if validation is on and framebuffer incomplete', () => {
-    const src = `precision highp float; void main() {}`;
+    const glsl = getGlslDifferences();
+    const src = `${glsl.version}
+      precision highp float;
+      void main() {}
+    `;
     const program = gpgpu.createProgram(src);
     const result = gpgpu.createFloat32MatrixTexture(1, 1);
     gpgpu.setOutputMatrixTexture(result, 1, 1);

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -16,9 +16,8 @@
  */
 
 import {ENV} from '../../environment';
-import {getGlslDifferences} from './glsl_version';
 import * as util from '../../util';
-
+import {getGlslDifferences} from './glsl_version';
 import * as tex_util from './tex_util';
 import * as webgl_util from './webgl_util';
 

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -16,6 +16,7 @@
  */
 
 import {ENV} from '../../environment';
+import {getGlslDifferences} from './glsl_version';
 import * as util from '../../util';
 
 import * as tex_util from './tex_util';
@@ -37,11 +38,12 @@ export interface TextureConfig {
 }
 
 export function createVertexShader(gl: WebGLRenderingContext): WebGLShader {
-  const vertexShaderSource = `
+  const glsl = getGlslDifferences();
+  const vertexShaderSource = `${glsl.version}
     precision highp float;
-    attribute vec3 clipSpacePos;
-    attribute vec2 uv;
-    varying vec2 resultUV;
+    ${glsl.attribute} vec3 clipSpacePos;
+    ${glsl.attribute} vec2 uv;
+    ${glsl.varyingVs} vec2 resultUV;
 
     void main() {
       gl_Position = vec4(clipSpacePos, 1);

--- a/src/kernels/webgl/im2col_gpu.ts
+++ b/src/kernels/webgl/im2col_gpu.ts
@@ -17,6 +17,7 @@
 
 import {Conv2DInfo} from '../../ops/conv_util';
 import {GPGPUProgram} from './gpgpu_math';
+import {getGlslDifferences} from './glsl_version';
 
 export class Im2ColProgram implements GPGPUProgram {
   variableNames = ['A'];
@@ -39,6 +40,7 @@ export class Im2ColProgram implements GPGPUProgram {
     } = convInfo;
     const {left, top} = padInfo;
     const itemsPerBlockRow = inChannels * filterWidth;
+    const glsl = getGlslDifferences();
 
     this.userCode = `
       void main() {
@@ -72,7 +74,7 @@ export class Im2ColProgram implements GPGPUProgram {
           }
         }
 
-        gl_FragColor = result;
+        ${glsl.output} = result;
       }
     `;
   }

--- a/src/kernels/webgl/im2col_gpu.ts
+++ b/src/kernels/webgl/im2col_gpu.ts
@@ -16,8 +16,8 @@
  */
 
 import {Conv2DInfo} from '../../ops/conv_util';
-import {GPGPUProgram} from './gpgpu_math';
 import {getGlslDifferences} from './glsl_version';
+import {GPGPUProgram} from './gpgpu_math';
 
 export class Im2ColProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/segment_gpu.ts
+++ b/src/kernels/webgl/segment_gpu.ts
@@ -38,7 +38,7 @@ export class SegmentOpProgram implements GPGPUProgram {
     const windowSizeVec4Remainder = windowSize % 4;
 
     const updateSnippet = `
-        sumValue += dot(values, filter);
+        sumValue += dot(values, segFilter);
     `;
 
     let checkValueOutOfBounds = '';
@@ -91,7 +91,7 @@ export class SegmentOpProgram implements GPGPUProgram {
             getValue(batch, inIdx + 3)
           );
 
-          vec4 filter = vec4(
+          vec4 segFilter = vec4(
             int(getSegmentIdAtIndex(inIdx)) == currentSeg ? 1 : 0,
             int(getSegmentIdAtIndex(inIdx + 1)) == currentSeg ? 1 : 0,
             int(getSegmentIdAtIndex(inIdx + 2)) == currentSeg ? 1 : 0,
@@ -112,7 +112,7 @@ export class SegmentOpProgram implements GPGPUProgram {
 
           int inIdxSeg = int(getSegmentIdAtIndex(inIdx));
 
-          vec4 filter = vec4(
+          vec4 segFilter = vec4(
             int(getSegmentIdAtIndex(inIdx)) == currentSeg ? 1 : 0,
             0,
             0,
@@ -128,7 +128,7 @@ export class SegmentOpProgram implements GPGPUProgram {
             initializationValue
           );
 
-          vec4 filter = vec4(
+          vec4 segFilter = vec4(
             int(getSegmentIdAtIndex(inIdx)) == currentSeg ? 1 : 0,
             int(getSegmentIdAtIndex(inIdx + 1)) == currentSeg ? 1 : 0,
               0,
@@ -144,7 +144,7 @@ export class SegmentOpProgram implements GPGPUProgram {
             initializationValue
           );
 
-          vec4 filter = vec4(
+          vec4 segFilter = vec4(
             int(getSegmentIdAtIndex(inIdx)) == currentSeg ? 1 : 0,
             int(getSegmentIdAtIndex(inIdx + 1)) == currentSeg ? 1 : 0,
             int(getSegmentIdAtIndex(inIdx + 2)) == currentSeg ? 1 : 0,

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -17,6 +17,7 @@
 
 import {ENV} from '../../environment';
 import {getBroadcastDims} from '../../ops/broadcast_util';
+import {getGlslDifferences, GLSL} from './glsl_version';
 import * as util from '../../util';
 import * as shader_util from './shader_compiler_util';
 import * as tex_util from './tex_util';
@@ -50,18 +51,20 @@ export function makeShader(
           .map(x => getInputSamplingSnippet(x, outputShape, usesPackedTextures))
           .join('\n');
   const outTexShape = outputShape.texShape;
+  const glsl = getGlslDifferences();
+  const floatTextureSampleSnippet = getFloatTextureSampleSnippet(glsl);
   let outputSamplingSnippet: string;
   let floatTextureSetOutputSnippet: string;
-  let shaderPrefix = SHADER_PREFIX;
+  let shaderPrefix = getShaderPrefix(glsl);
 
   if (outputShape.isPacked) {
     outputSamplingSnippet =
         getPackedOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
-    floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_RGBA_SNIPPET;
+    floatTextureSetOutputSnippet = getFloatTextureSetRGBASnippet(glsl);
   } else {
     outputSamplingSnippet =
         getOutputSamplingSnippet(outputShape.logicalShape, outTexShape);
-    floatTextureSetOutputSnippet = FLOAT_TEXTURE_SET_R_SNIPPET;
+    floatTextureSetOutputSnippet = getFloatTextureSetRSnippet(glsl);
   }
 
   if (usesPackedTextures) {
@@ -69,7 +72,7 @@ export function makeShader(
   }
 
   const source = [
-    shaderPrefix, FLOAT_TEXTURE_SAMPLE_SNIPPET, floatTextureSetOutputSnippet,
+    shaderPrefix, floatTextureSampleSnippet, floatTextureSetOutputSnippet,
     inputPrefixSnippet, outputSamplingSnippet, inputSamplingSnippet, userCode
   ].join('\n');
   return source;
@@ -194,6 +197,123 @@ function getOutputSamplingSnippet(
   }
 }
 
+function getFloatTextureSampleSnippet(glsl: GLSL): string {
+  return `
+    float sampleTexture(sampler2D textureSampler, vec2 uv) {
+      return ${glsl.texture2D}(textureSampler, uv).r;
+    }
+  `;
+}
+
+function getFloatTextureSetRSnippet(glsl: GLSL): string {
+  return `
+    void setOutput(float val) {
+      ${glsl.output} = vec4(val, 0, 0, 0);
+    }
+  `;
+}
+
+function getFloatTextureSetRGBASnippet(glsl: GLSL): string {
+  return `
+    void setOutput(vec4 val) {
+      ${glsl.output} = val;
+    }
+  `;
+}
+
+function getShaderPrefix(glsl: GLSL): string {
+  let NAN_CHECKS = '';
+  if (ENV.get('PROD')) {
+    NAN_CHECKS = `
+      bool isNaN(float val) {
+        return false;
+      }
+
+      bool hasNaN(vec4 values) {
+        return false;
+      }
+    `;
+  } else {
+    /**
+     * Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false :
+     * true' does not work on iOS 12
+     */
+    NAN_CHECKS = `
+      bool isNaN(float val) {
+        return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
+      }
+
+      bool hasNaN(vec4 values) {
+        return any(bvec4(
+          isNaN(values.x),
+          isNaN(values.y),
+          isNaN(values.z),
+          isNaN(values.w)
+        ));
+      }
+    `;
+  }
+
+  const SHADER_PREFIX = `${glsl.version}
+    precision highp float;
+    precision highp int;
+    precision highp sampler2D;
+    ${glsl.varyingFs} vec2 resultUV;
+    ${glsl.defineOutput}
+    const vec2 halfCR = vec2(0.5, 0.5);
+
+    struct ivec5
+    {
+      int x;
+      int y;
+      int z;
+      int w;
+      int u;
+    };
+
+    struct ivec6
+    {
+      int x;
+      int y;
+      int z;
+      int w;
+      int u;
+      int v;
+    };
+
+    ${NAN_CHECKS}
+
+    float getNaN(vec4 values) {
+      return dot(vec4(1), values);
+    }
+
+    ${glsl.defineRound}
+
+    int imod(int x, int y) {
+      return x - y * (x / y);
+    }
+
+    //Based on the work of Dave Hoskins
+    //https://www.shadertoy.com/view/4djSRW
+    #define HASHSCALE1 443.8975
+    float random(float seed){
+      vec2 p = resultUV * seed;
+      vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);
+      p3 += dot(p3, p3.yzx + 19.19);
+      return fract((p3.x + p3.y) * p3.z);
+    }
+
+    ${SAMPLE_1D_SNIPPET}
+    ${SAMPLE_2D_SNIPPET}
+    ${SAMPLE_3D_SNIPPET}
+    ${SAMPLE_4D_SNIPPET}
+    ${SAMPLE_5D_SNIPPET}
+    ${SAMPLE_6D_SNIPPET}
+  `;
+
+  return SHADER_PREFIX;
+}
+
 const SAMPLE_1D_SNIPPET = `
 vec2 UVfrom1D(int texNumR, int texNumC, int index) {
   int texR = index / texNumC;
@@ -288,113 +408,6 @@ vec2 UVfrom6D(int texNumR, int texNumC, int stride0,
   int texC = index - texR * texNumC;
   return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
 }
-`;
-
-const FLOAT_TEXTURE_SAMPLE_SNIPPET = `
-  float sampleTexture(sampler2D textureSampler, vec2 uv) {
-    return texture2D(textureSampler, uv).r;
-  }
-`;
-
-const FLOAT_TEXTURE_SET_R_SNIPPET = `
-  void setOutput(float val) {
-    gl_FragColor = vec4(val, 0, 0, 0);
-  }
-`;
-
-const FLOAT_TEXTURE_SET_RGBA_SNIPPET = `
-  void setOutput(vec4 val) {
-    gl_FragColor = val;
-  }
-`;
-
-let NAN_CHECKS = '';
-if (ENV.get('PROD')) {
-  NAN_CHECKS = `
-    bool isNaN(float val) {
-      return false;
-    }
-
-    bool hasNaN(vec4 values) {
-      return false;
-    }
-  `;
-} else {
-  /**
-   * Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false : true'
-   * does not work on iOS 12
-   */
-  NAN_CHECKS = `
-    bool isNaN(float val) {
-      return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
-    }
-
-    bool hasNaN(vec4 values) {
-      return any(bvec4(
-        isNaN(values.x),
-        isNaN(values.y),
-        isNaN(values.z),
-        isNaN(values.w)
-      ));
-    }
-  `;
-}
-
-const SHADER_PREFIX = `
-  precision highp float;
-  precision highp int;
-  varying vec2 resultUV;
-  const vec2 halfCR = vec2(0.5, 0.5);
-
-  struct ivec5
-  {
-    int x;
-    int y;
-    int z;
-    int w;
-    int u;
-  };
-
-  struct ivec6
-  {
-    int x;
-    int y;
-    int z;
-    int w;
-    int u;
-    int v;
-  };
-
-  ${NAN_CHECKS}
-
-  float getNaN(vec4 values) {
-    return dot(vec4(1), values);
-  }
-
-  int round(float value) {
-    return int(floor(value + 0.5));
-  }
-
-  int imod(int x, int y) {
-    return x - y * (x / y);
-  }
-
-  //Based on the work of Dave Hoskins
-  //https://www.shadertoy.com/view/4djSRW
-  #define HASHSCALE1 443.8975
-  float random(float seed){
-    vec2 p = resultUV * seed;
-    vec3 p3  = fract(vec3(p.xyx) * HASHSCALE1);
-    p3 += dot(p3, p3.yzx + 19.19);
-    return fract((p3.x + p3.y) * p3.z);
-  }
-
-  ${SAMPLE_1D_SNIPPET}
-  ${SAMPLE_2D_SNIPPET}
-  ${SAMPLE_3D_SNIPPET}
-  ${SAMPLE_4D_SNIPPET}
-  ${SAMPLE_5D_SNIPPET}
-  ${SAMPLE_6D_SNIPPET}
 `;
 
 const SHADER_PACKED_PREFIX = `
@@ -683,9 +696,10 @@ function getOutput2DCoords(
 function getPackedSamplerScalar(inputInfo: InputInfo): string {
   const texName = inputInfo.name;
   const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
+  const glsl = getGlslDifferences();
   return `
     vec4 ${funcName}() {
-      return texture2D(${texName}, halfCR);
+      return ${glsl.texture2D}(${texName}, halfCR);
     }
   `;
 }
@@ -709,12 +723,13 @@ function getPackedSampler1D(inputInfo: InputInfo): string {
   const texShape = inputInfo.shapeInfo.texShape;
   const packedTexShape =
       [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+  const glsl = getGlslDifferences();
 
   return `
     vec4 ${funcName}(int index) {
       vec2 uv = packedUVfrom1D(
         ${packedTexShape[0]}, ${packedTexShape[1]}, index);
-      return texture2D(${texName}, uv);
+      return ${glsl.texture2D}(${texName}, uv);
     }
   `;
 }
@@ -775,12 +790,13 @@ function getPackedSampler2D(inputInfo: InputInfo): string {
 
   const texNumR = texShape[0];
   const texNumC = texShape[1];
+  const glsl = getGlslDifferences();
   if (texShape != null && util.arraysEqual(shape, texShape)) {
     return `
       vec4 ${funcName}(int row, int col) {
         vec2 uv = (vec2(col, row) + halfCR) / vec2(${texNumC}.0, ${texNumR}.0);
 
-        return texture2D(${texName}, uv);
+        return ${glsl.texture2D}(${texName}, uv);
       }
     `;
   }
@@ -793,7 +809,7 @@ function getPackedSampler2D(inputInfo: InputInfo): string {
     vec4 ${funcName}(int row, int col) {
       vec2 uv = packedUVfrom2D(${valuesPerRow}, ${packedTexShape[0]}, ${
       packedTexShape[1]}, row, col);
-      return texture2D(${texName}, uv);
+      return ${glsl.texture2D}(${texName}, uv);
     }
   `;
 }
@@ -894,12 +910,13 @@ function getPackedSampler3D(inputInfo: InputInfo): string {
 
   const valuesPerRow = Math.ceil(shape[2] / 2);
   const texelsInBatch = valuesPerRow * Math.ceil(shape[1] / 2);
+  const glsl = getGlslDifferences();
 
   return `
     vec4 ${funcName}(int b, int row, int col) {
       vec2 uv = packedUVfrom3D(
         ${texNumR}, ${texNumC}, ${texelsInBatch}, ${valuesPerRow}, b, row, col);
-      return texture2D(${texName}, uv);
+      return ${glsl.texture2D}(${texName}, uv);
     }
   `;
 }
@@ -985,13 +1002,14 @@ function getPackedSampler4D(inputInfo: InputInfo): string {
   const valuesPerRow = Math.ceil(shape[3] / 2);
   const texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
   const texelsInBatch2 = texelsInBatch * shape[1];
+  const glsl = getGlslDifferences();
 
   return `
     vec4 ${funcName}(int b2, int b, int row, int col) {
       vec2 uv = packedUVfrom4D(
         ${texNumR}, ${texNumC}, ${texelsInBatch2},
         ${texelsInBatch}, ${valuesPerRow}, b2, b, row, col);
-      return texture2D(${texName}, uv);
+      return ${glsl.texture2D}(${texName}, uv);
     }
   `;
 }
@@ -1267,30 +1285,32 @@ function getPackedSamplerAtOutputCoords(
   const inTexShape = inputInfo.shapeInfo.texShape;
   const packedInTexShape = [...tex_util.getPackedMatrixTextureShapeWidthHeight(
       inTexShape[1], inTexShape[0])];
+  const glsl = getGlslDifferences();
+
   if (util.arraysEqual(inTexShape, outTexShape)) {
     return `
       vec4 ${funcName}() {
-        return texture2D(${texName}, resultUV);
+        return ${glsl.texture2D}(${texName}, resultUV);
       }
     `;
   }
 
-  let output = `return texture2D(${texName}, uv)`;
+  let output = `return ${glsl.texture2D}(${texName}, uv)`;
 
   if (inRank === 1 && outRank > 1) {
     output = `
-      vec4 sample = texture2D(${texName}, uv);
+      vec4 sample = ${glsl.texture2D}(${texName}, uv);
       return vec4(sample.xy, sample.xy);
     `;
   } else if (inRank === 0 && outRank > 0) {
     if (outRank === 1) {
       output = `
-        vec4 sample = texture2D(${texName}, uv);
+        vec4 sample = ${glsl.texture2D}(${texName}, uv);
         return vec4(sample.x, sample.x, 0., 0.);
       `;
     } else {
       output = `
-        vec4 sample = texture2D(${texName}, uv);
+        vec4 sample = ${glsl.texture2D}(${texName}, uv);
         return vec4(sample.x);
       `;
     }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -1299,19 +1299,19 @@ function getPackedSamplerAtOutputCoords(
 
   if (inRank === 1 && outRank > 1) {
     output = `
-      vec4 sample = ${glsl.texture2D}(${texName}, uv);
-      return vec4(sample.xy, sample.xy);
+      vec4 values = ${glsl.texture2D}(${texName}, uv);
+      return vec4(values.xy, values.xy);
     `;
   } else if (inRank === 0 && outRank > 0) {
     if (outRank === 1) {
       output = `
-        vec4 sample = ${glsl.texture2D}(${texName}, uv);
-        return vec4(sample.x, sample.x, 0., 0.);
+        vec4 values = ${glsl.texture2D}(${texName}, uv);
+        return vec4(values.x, values.x, 0., 0.);
       `;
     } else {
       output = `
-        vec4 sample = ${glsl.texture2D}(${texName}, uv);
-        return vec4(sample.x);
+        vec4 values = ${glsl.texture2D}(${texName}, uv);
+        return vec4(values.x);
       `;
     }
   }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -17,8 +17,8 @@
 
 import {ENV} from '../../environment';
 import {getBroadcastDims} from '../../ops/broadcast_util';
-import {getGlslDifferences, GLSL} from './glsl_version';
 import * as util from '../../util';
+import {getGlslDifferences, GLSL} from './glsl_version';
 import * as shader_util from './shader_compiler_util';
 import * as tex_util from './tex_util';
 


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
I found that upgrading GLSL to es 300 can improve the accuracy on Android devices with webgl 2.0 backend.
These commits support glsl es 300 for webgl2 while keeping es100 for webgl 1.0.

FEATURE Add GLSL ES 300 for webgl2
PERFORMANCE Improve float precision on mobile to 32-bits

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1421)
<!-- Reviewable:end -->
