### PR TITLE
Remove the global outer scope.

### DIFF
--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -649,3 +649,21 @@ describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
     expect(tf.memory().numTensors).toBe(0);
   });
 });
+
+// NOTE: This describe is purposefully not a describeWithFlags so that we test
+// tensor allocation where no scopes have been created. The backend here must be
+// set to CPU because we cannot allocate GPU tensors outside a
+// describeWithFlags because the default webgl backend and the test backends
+// share a WebGLContext. When backends get registered, global WebGL state is
+// initialized, which causes the two backends to step on each other and get in a
+// bad state.
+describe('Memory allocation outside a test scope', () => {
+  it('constructing a tensor works', () => {
+    tf.setBackend('cpu');
+    console.log(tf.ENV.getFeatures());
+    const a = tf.tensor1d([1, 2, 3]);
+    expectArraysClose(a, [1, 2, 3]);
+    a.dispose();
+    console.log(tf.ENV.getFeatures());
+  });
+});

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -660,10 +660,8 @@ describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
 describe('Memory allocation outside a test scope', () => {
   it('constructing a tensor works', () => {
     tf.setBackend('cpu');
-    console.log(tf.ENV.getFeatures());
     const a = tf.tensor1d([1, 2, 3]);
     expectArraysClose(a, [1, 2, 3]);
     a.dispose();
-    console.log(tf.ENV.getFeatures());
   });
 });

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -61,11 +61,6 @@ describeWithFlags(
     });
 
 describeWithFlags('WEBGL_PAGING_ENABLED', WEBGL_ENVS, testEnv => {
-  afterEach(() => {
-    ENV.reset();
-    ENV.setFeatures(testEnv.features);
-  });
-
   it('should be true if in a browser', () => {
     const features: Features = {'IS_BROWSER': true};
     const env = new Environment(features);


### PR DESCRIPTION
This causes a memory leak in backend_cpu and Node.js because we hold a pointer to all Tensors.

I verified with htop that memory usage does not explode linearly and that GC kicks in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1425)
<!-- Reviewable:end -->
