### PR TITLE
reduce size of matrix in test

### DIFF
--- a/src/ops/linalg_ops_test.ts
+++ b/src/ops/linalg_ops_test.ts
@@ -85,7 +85,7 @@ describeWithFlags('gramSchmidt-tiny', ALL_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  fit('16x128', () => {
+  it('16x128', () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
     const xs = tf.randomUniform([16, 128]) as Tensor2D;

--- a/src/ops/linalg_ops_test.ts
+++ b/src/ops/linalg_ops_test.ts
@@ -85,12 +85,12 @@ describeWithFlags('gramSchmidt-tiny', ALL_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  it('32x512', () => {
+  fit('16x128', () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
-    const xs = tf.randomUniform([32, 512]) as Tensor2D;
+    const xs = tf.randomUniform([16, 128]) as Tensor2D;
     const y = tf.linalg.gramSchmidt(xs) as Tensor2D;
-    expectArraysClose(y.matMul(y.transpose()), tf.eye(32));
+    expectArraysClose(y.matMul(y.transpose()), tf.eye(16));
   });
 });
 


### PR DESCRIPTION
#### Description
Reduces size of matrix in test to enfasten.  2000ms -> 800ms 


---
<!-- Please do not delete this section -->
##### For repository owners only:

PERF: Slightly fastedr tests.

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1426)
<!-- Reviewable:end -->
