### PR TITLE
Don't upload small tensors as uniforms to packed op programs

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1840,7 +1840,7 @@ export class MathBackendWebGL implements KernelBackend {
       let texData = this.texData.get(input.dataId);
 
       if (texData.texture == null) {
-        if (!(!texData.isPacked && program.usesPackedTextures) &&
+        if (!program.usesPackedTextures &&
             util.sizeFromShape(input.shape) <=
                 ENV.get('WEBGL_SIZE_UPLOAD_UNIFORM')) {
           // Upload small tensors that live on the CPU as uniforms, not as


### PR DESCRIPTION
Trivial: modify the check to prevent upload to uniform when
texData.isPacked == true and program.usesPackedTextures == true.

BUG

#### Description
I got this reproduced from batchnorm tests with [packed binary PR](https://github.com/tensorflow/tfjs-core/pull/1423) on and [this modification of batchnormalization4D tests](https://gist.github.com/astojilj/15b2e02089e733f5512463aeff90a2e4).
This test would run existing batchnormTests with WEBGL_PACK flag on.
although texData.isPacked == true, and program.usesPackedTextures == true. the logic would still upload the tensor to uniform.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1429)
<!-- Reviewable:end -->
