### PR TITLE
Allow squeeze to use negative index

### DIFF
--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -1372,6 +1372,16 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(() => a.squeeze([-3, -2])).toThrowError();
   });
 
+  it('squeeze axis out of range', () => {
+    const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
+    expect(() => a.squeeze([10, 11])).toThrowError();
+  });
+
+  it('squeeze negative axis out of range', () => {
+    const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
+    expect(() => a.squeeze([-13, -12])).toThrowError();
+  });
+
   it('squeeze throws when passed a non-tensor', () => {
     expect(() => tf.squeeze({} as tf.Tensor))
         .toThrowError(/Argument 'x' passed to 'squeeze' must be a Tensor/);

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -1362,6 +1362,12 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.shape).toEqual([3, 1]);
   });
 
+  it('squeeze with multiple negative axis', () => {
+    const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
+    const b = a.squeeze([-1, -2]);
+    expect(b.shape).toEqual([3]);
+  });
+
   it('squeeze wrong axis', () => {
     const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
     expect(() => a.squeeze([0, 1])).toThrowError();

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -1356,16 +1356,27 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.shape).toEqual([3, 1]);
   });
 
+  it('squeeze with negative axis', () => {
+    const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
+    const b = a.squeeze([-1]);
+    expect(b.shape).toEqual([3, 1]);
+  });
+
   it('squeeze wrong axis', () => {
     const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
     expect(() => a.squeeze([0, 1])).toThrowError();
+  });
+
+  it('squeeze wrong negative axis', () => {
+    const a = tf.tensor3d([4, 2, 1], [3, 1, 1], 'bool');
+    expect(() => a.squeeze([-3, -2])).toThrowError();
   });
 
   it('squeeze throws when passed a non-tensor', () => {
     expect(() => tf.squeeze({} as tf.Tensor))
         .toThrowError(/Argument 'x' passed to 'squeeze' must be a Tensor/);
   });
-
+  
   it('squeeze accepts a tensor-like object', () => {
     const res = tf.squeeze([[[4]], [[2]], [[1]]] /* shape is [3, 1, 1] */);
     expect(res.shape).toEqual([3]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -279,7 +279,8 @@ export function squeezeShape(shape: number[], axis?: number[]):
     for (let i = 0; i < axis.length; ++i) {
       if (axis[i] < -shape.length || axis[i] >= shape.length) {
         throw new Error(
-          `Can't squeeze axis ${axis[i]} since its not in [-${shape.length}, ${shape.length}) for shape ${shape}`); // tslint:disable-line
+          `Can't squeeze axis ${axis[i]} since its not in ` +
+          `[-${shape.length}, ${shape.length}) for shape ${shape}`);
       } 
       if (axis[i] < 0) {
         axis[i] = shape.length + axis[i];

--- a/src/util.ts
+++ b/src/util.ts
@@ -275,6 +275,14 @@ export function squeezeShape(shape: number[], axis?: number[]):
     {newShape: number[], keptDims: number[]} {
   const newShape: number[] = [];
   const keptDims: number[] = [];
+  if (axis != null) {
+    for (let i = 0; i < axis.length; ++i) {
+      if (axis[i] < 0){
+        axis[i] = shape.length + axis[i];
+      }
+    }
+    axis.sort();
+  }
   let j = 0;
   for (let i = 0; i < shape.length; ++i) {
     if (axis != null) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -277,7 +277,11 @@ export function squeezeShape(shape: number[], axis?: number[]):
   const keptDims: number[] = [];
   if (axis != null) {
     for (let i = 0; i < axis.length; ++i) {
-      if (axis[i] < 0){
+      if (axis[i] < -shape.length || axis[i] >= shape.length) {
+        throw new Error(
+          `Can't squeeze axis ${axis[i]} since its not in [-${shape.length}, ${shape.length}) for shape ${shape}`); // tslint:disable-line
+      } 
+      if (axis[i] < 0) {
         axis[i] = shape.length + axis[i];
       }
     }

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -262,8 +262,16 @@ describe('util.squeezeShape', () => {
       expect(newShape).toEqual([1, 1, 4]);
       expect(keptDims).toEqual([0, 3, 4]);
     });
+    it('should only reduce dimensions specified by negative axis', () => {
+      const {newShape, keptDims} = util.squeezeShape([1, 1, 1, 1, 4], [-2, -3]);
+      expect(newShape).toEqual([1, 1, 4]);
+      expect(keptDims).toEqual([0, 1, 4]);
+    });
     it('throws error when specified axis is not squeezable', () => {
       expect(() => util.squeezeShape([1, 1, 2, 1, 4], [1, 2])).toThrowError();
+    });
+    it('throws error when specified negative axis is not squeezable', () => {
+      expect(() => util.squeezeShape([1, 1, 2, 1, 4], [-1, -2])).toThrowError();
     });
   });
 });

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -273,6 +273,14 @@ describe('util.squeezeShape', () => {
     it('throws error when specified negative axis is not squeezable', () => {
       expect(() => util.squeezeShape([1, 1, 2, 1, 4], [-1, -2])).toThrowError();
     });
+    it('throws error when specified axis is out of range', () => {
+      expect(
+        () => util.squeezeShape([1, 1, 2, 1, 4], [11, 22])).toThrowError();
+    });
+    it('throws error when specified negative axis is out of range', () => {
+      expect(
+        () => util.squeezeShape([1, 1, 2, 1, 4], [-11, -22])).toThrowError();
+    });
   });
 });
 


### PR DESCRIPTION
Issue in focus: tensorflow/tfjs#940

#### Description

`squeeze()` didn't support the use of negative index which is supported in tensorflow for Python. Added tests for the same in `util_test` and `tensor_test`.
The previous implementation didn't allow for random arrangement of values of axis. For example if axes is set to `[2, 3]`, it would remove them both but if you pass it as `[3, 2]` it would only remove 3 and ignore 2 entirely. I tried the same with tensorflow for python in this [Google Colab Notebook](https://colab.research.google.com/drive/1jzyuRFXfIVrK50jI7vDrVuW5dYpiYw0V) and this too was inconsistent with tfjs as tensorflow python allows for removal of axis irrespective of order of input if it's allowed. This inconsistency was removed when adding the support for negative index ( it was totally unintentional but resulted from my implementation to allow negative index ).

Clarification required for following topics:
* I am not sure whether the test messages are satisfactory for the new tests added - Please let me know if this can be improved and I'll implement the same as soon as possible.
* The random input order support was a result of my judgement where i thought `[-1, -2]` was intuitively much better for a programmer but if we just replaced it with the positive index of same, it would have been `[5, 4]` which due to it's lack of ascending order would have ignored 4 completely. If this needs to changed, please let me know and I'll come up with another implementation to change this behavior.

Tests Ran:
* [x] yarn test
* [x] yarn lint

BUG


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: BUG

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1430)
<!-- Reviewable:end -->
