### PR TITLE
Simplify logic for allocating array for packed textures. 

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1806,10 +1806,13 @@ export class MathBackendWebGL implements KernelBackend {
 
   private packedReshape<R extends Rank>(input: Tensor, afterShape: ShapeMap[R]):
       Tensor<R> {
-    const inputAs3D = input.reshape(
-        [webgl_util.getBatchDim(input.shape), ...webgl_util.getRowsCols(input.shape)]);
-    const afterShapeAs3D =
-        [webgl_util.getBatchDim(afterShape), ...webgl_util.getRowsCols(afterShape)];
+    const inputAs3D = input.reshape([
+      webgl_util.getBatchDim(input.shape),
+      ...webgl_util.getRowsCols(input.shape)
+    ]);
+    const afterShapeAs3D = [
+      webgl_util.getBatchDim(afterShape), ...webgl_util.getRowsCols(afterShape)
+    ];
     const program = new ReshapePackedProgram(
         afterShapeAs3D as [number, number, number],
         inputAs3D.shape as [number, number, number]);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -336,10 +336,10 @@ export class MathBackendWebGL implements KernelBackend {
       vals = this.getValuesFromTexture(dataId);
     } else {
       if (isPacked) {
-        const batch = this.getBatchDim(shape);
+        const batch = webgl_util.getBatchDim(shape);
         let rows = 1, cols = 1;
         if (shape.length) {
-          [rows, cols] = this.getRowsCols(shape);
+          [rows, cols] = webgl_util.getRowsCols(shape);
         }
         vals = this.gpgpu.downloadPackedMatrixFromBuffer(
             bufferOrTexture, batch, rows, cols, texShape[0], texShape[1]);
@@ -366,10 +366,10 @@ export class MathBackendWebGL implements KernelBackend {
     const {shape, dtype, texture, texShape} = this.texData.get(dataId);
     if (ENV.get('WEBGL_DOWNLOAD_FLOAT_ENABLED')) {
       if (this.texData.get(dataId).isPacked) {
-        const batch = this.getBatchDim(shape);
+        const batch = webgl_util.getBatchDim(shape);
         let rows = 1, cols = 1;
         if (shape.length) {
-          [rows, cols] = this.getRowsCols(shape);
+          [rows, cols] = webgl_util.getRowsCols(shape);
         }
         return this.gpgpu.downloadMatrixFromPackedTexture(
             texture, batch, rows, cols, texShape[0], texShape[1]);
@@ -1804,26 +1804,12 @@ export class MathBackendWebGL implements KernelBackend {
         program, [input], Tensor.make(program.outputShape, {}, input.dtype));
   }
 
-  private getBatchDim(shape: number[], dimsToSkip = 2): number {
-    return util.sizeFromShape(shape.slice(0, shape.length - dimsToSkip));
-  }
-
-  private getRowsCols(shape: number[]): [number, number] {
-    if (shape.length === 0) {
-      throw Error('Cannot get rows and columns of an empty shape array.');
-    }
-
-    return [
-      shape.length > 1 ? shape[shape.length - 2] : 1, shape[shape.length - 1]
-    ];
-  }
-
   private packedReshape<R extends Rank>(input: Tensor, afterShape: ShapeMap[R]):
       Tensor<R> {
     const inputAs3D = input.reshape(
-        [this.getBatchDim(input.shape), ...this.getRowsCols(input.shape)]);
+        [webgl_util.getBatchDim(input.shape), ...webgl_util.getRowsCols(input.shape)]);
     const afterShapeAs3D =
-        [this.getBatchDim(afterShape), ...this.getRowsCols(afterShape)];
+        [webgl_util.getBatchDim(afterShape), ...webgl_util.getRowsCols(afterShape)];
     const program = new ReshapePackedProgram(
         afterShapeAs3D as [number, number, number],
         inputAs3D.shape as [number, number, number]);
@@ -2043,10 +2029,10 @@ export class MathBackendWebGL implements KernelBackend {
     if (values != null) {
       // TODO(smilkov): Propagate the original typed array to gpgpu.
       if (isPacked) {
-        const batch = this.getBatchDim(shape);
+        const batch = webgl_util.getBatchDim(shape);
         let rows = 1, cols = 1;
         if (shape.length) {
-          [rows, cols] = this.getRowsCols(shape);
+          [rows, cols] = webgl_util.getRowsCols(shape);
         }
         this.gpgpu.uploadMatrixToPackedTexture(
             newTexture, batch, rows, cols, texShape[0], texShape[1],

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -272,8 +272,7 @@ export function uploadMatrixToPackedTexture(
     matrix: Float32Array, textureConfig: TextureConfig) {
   const [w, h] = tex_util.getPackedMatrixTextureShapeWidthHeight(
       physicalRows, physicalCols);
-  const packedRGBA = new Float32Array(
-      batch * tex_util.getPackedRGBAArraySizeFromMatrixShape(rows, columns));
+  const packedRGBA = new Float32Array(w * h * 4);
   tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
   uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -272,7 +272,9 @@ export function uploadMatrixToPackedTexture(
     matrix: Float32Array, textureConfig: TextureConfig) {
   const [w, h] = tex_util.getPackedMatrixTextureShapeWidthHeight(
       physicalRows, physicalCols);
-  const packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
+  const packedRGBA =
+      new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(
+          physicalRows, physicalCols));
   tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
   uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -272,7 +272,7 @@ export function uploadMatrixToPackedTexture(
     matrix: Float32Array, textureConfig: TextureConfig) {
   const [w, h] = tex_util.getPackedMatrixTextureShapeWidthHeight(
       physicalRows, physicalCols);
-  const packedRGBA = new Float32Array(w * h * 4);
+  const packedRGBA = new Float32Array(tex_util.getPackedRGBAArraySizeFromMatrixShape(physicalRows, physicalCols));
   tex_util.encodeMatrixToPackedRGBA(matrix, batch, rows, columns, packedRGBA);
   uploadDataToTexture(gl, texture, w, h, packedRGBA, gl.RGBA);
 }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -19,6 +19,7 @@ import * as broadcast_util from '../../ops/broadcast_util';
 import * as util from '../../util';
 
 import * as shader_util from './shader_compiler_util';
+import * as tex_util from './tex_util';
 
 export type ShapeInfo = {
   logicalShape: number[],
@@ -1295,14 +1296,11 @@ function getPackedSamplerAtOutputCoords(
     supportsBroadcasting: boolean) {
   const texName = inputInfo.name;
   const texFuncSnippet = texName.charAt(0).toUpperCase() + texName.slice(1);
-  const texShape = inputInfo.shapeInfo.texShape;
   const funcName = 'get' + texFuncSnippet + 'AtOutCoords';
-  const outTexShape = outShapeInfo.texShape;
 
-  const packedTexShape =
-      [Math.ceil(outTexShape[0] / 2), Math.ceil(outTexShape[1] / 2)];
-  const texNumR = packedTexShape[0];
-  const texNumC = packedTexShape[1];
+  const outTexShape = outShapeInfo.texShape;
+  const packedTexShape = [...tex_util.getPackedMatrixTextureShapeWidthHeight(
+      outTexShape[1], outTexShape[0])];
 
   const broadcastDims = broadcast_util.getBroadcastDims(
       inputInfo.shapeInfo.logicalShape, outShapeInfo.logicalShape);
@@ -1313,7 +1311,8 @@ function getPackedSamplerAtOutputCoords(
   }
 
   const inTexShape = inputInfo.shapeInfo.texShape;
-  const packedInTexShape = [Math.ceil(inTexShape[0] / 2), Math.ceil(inTexShape[1] / 2)];
+  const packedInTexShape = [...tex_util.getPackedMatrixTextureShapeWidthHeight(
+      inTexShape[1], inTexShape[0])];
   if (util.arraysEqual(inTexShape, outTexShape)) {
     return `
       vec4 ${funcName}() {
@@ -1352,7 +1351,8 @@ function getPackedSamplerAtOutputCoords(
 
       int texR = index / ${packedInTexShape[1]};
       int texC = index - texR * ${packedInTexShape[1]};
-      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${packedInTexShape[1]}, ${packedInTexShape[0]});
+      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${packedInTexShape[1]}, ${
+      packedInTexShape[0]});
 
       ${output};
     }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -1300,7 +1300,7 @@ function getPackedSamplerAtOutputCoords(
   const outTexShape = outShapeInfo.texShape;
 
   const packedTexShape =
-      [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
+      [Math.ceil(outTexShape[0] / 2), Math.ceil(outTexShape[1] / 2)];
   const texNumR = packedTexShape[0];
   const texNumC = packedTexShape[1];
 
@@ -1313,6 +1313,7 @@ function getPackedSamplerAtOutputCoords(
   }
 
   const inTexShape = inputInfo.shapeInfo.texShape;
+  const packedInTexShape = [Math.ceil(inTexShape[0] / 2), Math.ceil(inTexShape[1] / 2)];
   if (util.arraysEqual(inTexShape, outTexShape)) {
     return `
       vec4 ${funcName}() {
@@ -1342,15 +1343,16 @@ function getPackedSamplerAtOutputCoords(
     }
   }
 
+  // index below refers to texel index
   return `
     vec4 ${funcName}() {
       ivec2 resTexRC = ivec2(resultUV.yx *
                              vec2(${packedTexShape[0]}, ${packedTexShape[1]}));
       int index = resTexRC.x * ${packedTexShape[1]} + resTexRC.y;
 
-      int texR = index / ${texNumC};
-      int texC = index - texR * ${texNumC};
-      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${texNumC}, ${texNumR});
+      int texR = index / ${packedInTexShape[1]};
+      int texC = index - texR * ${packedInTexShape[1]};
+      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${packedInTexShape[1]}, ${packedInTexShape[0]});
 
       ${output};
     }

--- a/src/kernels/webgl/tex_util.ts
+++ b/src/kernels/webgl/tex_util.ts
@@ -159,12 +159,6 @@ Note the batch dimension is needed so xxx's are inserted below 020, 021, 022,
 export function encodeMatrixToPackedRGBA(
     matrix: Float32Array, batches: number, rows: number, columns: number,
     packedRGBA: Float32Array) {
-  const requiredSize = getPackedRGBAArraySizeFromMatrixShape(rows, columns);
-  if (packedRGBA.length < requiredSize) {
-    throw new Error(`packedRGBA length (${packedRGBA.length}) must be >=
-        ${requiredSize}`);
-  }
-
   const oddWidth = (columns % 2) === 1;
   const oddHeight = (rows % 2) === 1;
   const widthInFullBlocks = Math.floor(columns / 2);

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -365,44 +365,44 @@ export function getTextureShapeFromLogicalShape(
   }
 
   let size = util.sizeFromShape(logShape);
+  if (logShape.length <= 1 && size <= maxTexSize) {
+    return [isPacked ? 2 : 1, size];
+  } else if (
+      logShape.length === 2 && logShape[0] <= maxTexSize &&
+      logShape[1] <= maxTexSize) {
+    return logShape as [number, number];
+  } else if (
+      logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
+      logShape[2] <= maxTexSize) {
+    return [logShape[0] * logShape[1], logShape[2]];
+  } else if (
+      logShape.length === 3 && logShape[0] <= maxTexSize &&
+      logShape[1] * logShape[2] <= maxTexSize) {
+    return [logShape[0], logShape[1] * logShape[2]];
+  } else if (
+      logShape.length === 4 &&
+      logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
+      logShape[3] <= maxTexSize) {
+    return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
+  } else if (
+      logShape.length === 4 && logShape[0] <= maxTexSize &&
+      logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
+    return [logShape[0], logShape[1] * logShape[2] * logShape[3]];
+  } else {
+    if (isPacked) {
+      // For packed textures size equals the number of channels required to
+      // accommodate the texture data. However in order to squarify such that
+      // inner dimensions stay even, we rewrite size to equal the number of
+      // texels. Then in the return statement we rehydrate the squarified
+      // dimensions to channel units.
 
-  if(isPacked) {
-    if(logShape.length <= 1 && size <= maxTexSize) {
-      return [2, size];
+      const batchDim = getBatchDim(logShape);
+      const [rows, cols] = getRowsCols(logShape);
+      size = batchDim * (rows / 2) * (cols / 2);
+      return util.sizeToSquarishShape(size).map(d => d * 2) as [number, number];
     }
-
-    const batchDim = getBatchDim(logShape);
-    const [rows, cols] = getRowsCols(logShape);
-    size = batchDim * (rows / 2) * (cols / 2);
-    return util.sizeToSquarishShape(size).map(d => d * 2) as [number, number];
+    return util.sizeToSquarishShape(size);
   }
-  return util.sizeToSquarishShape(size);
-  // if (logShape.length <= 1 && size <= maxTexSize) {
-  //   return [1, size];
-  // } else if (
-  //     logShape.length === 2 && logShape[0] <= maxTexSize &&
-  //     logShape[1] <= maxTexSize) {
-  //   return logShape as [number, number];
-  // } else if (
-  //     logShape.length === 3 && logShape[0] * logShape[1] <= maxTexSize &&
-  //     logShape[2] <= maxTexSize) {
-  //   return [logShape[0] * logShape[1], logShape[2]];
-  // } else if (
-  //     logShape.length === 3 && logShape[0] <= maxTexSize &&
-  //     logShape[1] * logShape[2] <= maxTexSize) {
-  //   return [logShape[0], logShape[1] * logShape[2]];
-  // } else if (
-  //     logShape.length === 4 &&
-  //     logShape[0] * logShape[1] * logShape[2] <= maxTexSize &&
-  //     logShape[3] <= maxTexSize) {
-  //   return [logShape[0] * logShape[1] * logShape[2], logShape[3]];
-  // } else if (
-  //     logShape.length === 4 && logShape[0] <= maxTexSize &&
-  //     logShape[1] * logShape[2] * logShape[3] <= maxTexSize) {
-  //   return [logShape[0], logShape[1] * logShape[2] * logShape[3]];
-  // } else {
-  //   return util.sizeToSquarishShape(size);
-  // }
 }
 
 function isEven(n: number): boolean {

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -356,6 +356,12 @@ export function getTextureShapeFromLogicalShape(
         (d, i) => i >= logShape.length - 2 ?
             util.nearestLargerEven(logShape[i]) :
             logShape[i]);
+
+    // Packed texture height is at least 2 (the channel height of a single
+    // texel).
+    if (logShape.length === 1) {
+      logShape = [2, logShape[0]];
+    }
   }
 
   // If logical shape is 2, we don't squeeze, since we want to match physical.
@@ -366,8 +372,7 @@ export function getTextureShapeFromLogicalShape(
 
   let size = util.sizeFromShape(logShape);
   if (logShape.length <= 1 && size <= maxTexSize) {
-    // For packed textures the minimum channel height is 2.
-    return [isPacked ? 2 : 1, size];
+    return [1, size];
   } else if (
       logShape.length === 2 && logShape[0] <= maxTexSize &&
       logShape[1] <= maxTexSize) {
@@ -398,7 +403,10 @@ export function getTextureShapeFromLogicalShape(
       // dimensions to channel units.
 
       const batchDim = getBatchDim(logShape);
-      const [rows, cols] = getRowsCols(logShape);
+      let rows = 2, cols = 2;
+      if (logShape.length) {
+        [rows, cols] = getRowsCols(logShape);
+      }
       size = batchDim * (rows / 2) * (cols / 2);
       return util.sizeToSquarishShape(size).map(d => d * 2) as [number, number];
     }

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -366,6 +366,7 @@ export function getTextureShapeFromLogicalShape(
 
   let size = util.sizeFromShape(logShape);
   if (logShape.length <= 1 && size <= maxTexSize) {
+    // For packed textures the minimum channel height is 2.
     return [isPacked ? 2 : 1, size];
   } else if (
       logShape.length === 2 && logShape[0] <= maxTexSize &&

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -159,6 +159,48 @@ describeWithFlags('packed batchNormalization', WEBGL_ENVS, () => {
       1.82644104, -0.52249442, 1.04803919, 0.74932291, 0.40568101, 1.2844412
     ]);
   });
+
+  it('should work when texture shapes are squarified', () => {
+    const webglMaxTextureSize = tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
+    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 4);
+    const webglLazilyUnpackFlag = tf.ENV.get('WEBGL_LAZILY_UNPACK');
+    tf.ENV.set('WEBGL_LAZILY_UNPACK', true);
+
+    const x = tf.tensor3d(
+        [
+          0.49955603, 0.04158615,  -1.09440524, 2.03854165,  -0.61578344,
+          2.87533573, 1.18105987,  0.807462,    1.87888837,
+
+          0.49955603, 0.04158615,  -1.09440524, 2.03854165,  -0.61578344,
+          2.87533573, 1.18105987,  0.807462,    1.87888837,
+
+          2.26563962, -0.37040935, 1.35848753,  -0.75347094, 0.15683117,
+          0.91925946, 0.34121279,  0.92717143,  1.89683965
+        ],
+        [3, 3, 3]);
+    const mean = tf.tensor1d([0.39745062, -0.48062894, 0.4847822]);
+    const variance = tf.tensor1d([0.32375343, 0.67117643, 1.08334653]);
+    const offset = tf.tensor1d([0.69398749, -1.29056387, 0.9429723]);
+    const scale = tf.tensor1d([-0.5607271, 0.9878457, 0.25181573]);
+    const varianceEpsilon = .001;
+
+    const result = tf.batchNormalization3d(
+        x, mean, variance, varianceEpsilon, scale, offset);
+
+    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', webglMaxTextureSize);
+    tf.ENV.set('WEBGL_LAZILY_UNPACK', webglLazilyUnpackFlag);
+
+    expectArraysClose(result, [
+      0.5935205, -0.661352,  0.5610874, -0.92077,  -1.4534101,
+      1.5210648, -0.0770478, 0.2614444, 1.2801001,
+
+      0.5935205, -0.661352,  0.5610874, -0.92077,  -1.4534101,
+      1.5210648, -0.0770478, 0.2614444, 1.2801001,
+
+      -1.144224, -1.1577613, 1.1542549, 1.8264412, -0.5224944,
+      1.0480392, 0.749323,   0.405681,  1.2844412
+    ]);
+  });
 });
 
 describeWithFlags('batchNormalization4D', ALL_ENVS, () => {

--- a/src/ops/conv2d_test.ts
+++ b/src/ops/conv2d_test.ts
@@ -132,10 +132,10 @@ describeWithFlags('conv im2row', WEBGL_ENVS, () => {
   it('should work when input texture shapes do not equal logical shapes',
      () => {
        const webglMaxTextureSize = tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
-       tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 10);
+       tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 13);
 
        const inputDepth = 1;
-       const inputSize = 5;
+       const inputSize = 6;
        const filterSize = 2;
        const outputDepth = 1;
 
@@ -143,7 +143,8 @@ describeWithFlags('conv im2row', WEBGL_ENVS, () => {
            [
              0.4,  0.75, 0.65, 0.98, 0.1,  0.41, 0.01, 0.46, 0.49,
              0.4,  0.11, 0.76, 0.73, 0.86, 0.34, 0.34, 0.71, 0.68,
-             0.62, 0.87, 0.64, 0.38, 0.29, 0.55, 0.95
+             0.62, 0.87, 0.64, 0.38, 0.29, 0.55, 0.95, 0.4,  0.75,
+             0.65, 0.98, 0.1,  0.41, 0.01, 0.46, 0.49, 0.4,  0.11
            ],
            [inputSize, inputSize, inputDepth]);
        const w = tf.tensor4d(
@@ -155,9 +156,11 @@ describeWithFlags('conv im2row', WEBGL_ENVS, () => {
        tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', webglMaxTextureSize);
 
        expectArraysClose(result, [
-         0.7836, 0.9281, 1.1687, 0.7828, 0.129,  0.3967, 0.5683, 0.862,  0.7513,
-         0.2892, 0.7381, 1.1506, 1.2005, 0.976,  0.3504, 0.8318, 0.9605, 0.9356,
-         1.1802, 0.6669, 0.608,  0.4022, 0.5173, 0.9215, 0.5415
+         0.79260, 1.01450, 1.15790, 0.71440, 0.47600, 0.37050, 0.58630, 0.79180,
+         0.65770, 0.48740, 0.79930, 0.55560, 1.23470, 0.97960, 0.59500, 0.76880,
+         0.99110, 0.48660, 1.15320, 1.11250, 0.86000, 0.69560, 0.71170, 0.33150,
+         0.87310, 0.79260, 1.01450, 1.15790, 0.71440, 0.07680, 0.24010, 0.30010,
+         0.57580, 0.53530, 0.29840, 0.06270
        ]);
      });
 });


### PR DESCRIPTION
### Changes

- Replaced an inappropriate use of `getUnpackedArraySizeFromMatrixSize` with simpler logic for computing the size of a packed texture array.
- Removed an error check in `encodeMatrixToPackedRGBA` that ensures the output array is big enough for the data because we use the same error checking logic in the construction of the output array. This cuts down the number of use cases for `getPackedMatrixTextureShapeWidthHeight`.
- Modified `getTextureShapeFromLogicalShape` to return 2 as channel height for 1D inputs, and to change the packed `size` input to `sizeToSquarish` such that channel dimensions remain even in squarification.
- Fixed the packed broadcasting logic to account for squarified textures and added a unit test.
- Modified im2col unit test to account for new squarification logic.

DEV, BUG, PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1434)
<!-- Reviewable:end -->
