### PR TITLE
Replace 'new ImageData' with 'createImageData' in tf.toPixels

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -429,7 +429,8 @@ async function toPixels(
     canvas.width = width;
     canvas.height = height;
     const ctx = canvas.getContext('2d');
-    const imageData = new ImageData(bytes, width, height);
+    const imageData = ctx.createImageData(width, height);
+    imageData.data.set(bytes);
     ctx.putImageData(imageData, 0, 0);
   }
   if ($img !== img) {


### PR DESCRIPTION
ImageData is not defined in NodeJS.
Instead, call createImageData on CanvasRenderingContext2D to create the
object to set the pixel bytes.

#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->


---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1440)
<!-- Reviewable:end -->
