### PR TITLE
Fix condition for expensive reshape with even columns

### DIFF
--- a/src/kernels/webgl/reshape_packed_test.ts
+++ b/src/kernels/webgl/reshape_packed_test.ts
@@ -85,24 +85,24 @@ describeWithFlags('expensive reshape with even columns', WEBGL_ENVS, () => {
     tf.ENV.set('WEBGL_LAZILY_UNPACK', webglLazilyUnpackFlagSaved);
   });
 
-  it('texture shape != physical shape, 2 --> 4 columns', () => {
+  it('2 --> 4 columns', () => {
     const maxTextureSize = tf.ENV.get('WEBGL_MAX_TEXTURE_SIZE');
 
-    let values: number[] = new Array<number>(32).fill(0);
+    let values: number[] = new Array<number>(16).fill(0);
     values = values.map((d, i) => i + 1);
-    const a = tf.tensor2d(values, [16, 2]);
+    const a = tf.tensor2d(values, [8, 2]);
     const b = tf.tensor2d([1, 2, 3, 4], [2, 2]);
 
-    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 4);
-    // Setting WEBGL_MAX_TEXTURE_SIZE to 4 makes that [16, 2] tensor is packed
-    // to texture of width 4 by height 2. Indices are packed as:
-    // -------------------------
-    // | 0 1 | 4 5 | 8 9 |12 13|       // First row's four 
-    // | 2 4 | 6 7 |10 11|14 15|       // pixels.
-    // -------------------------
+    tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', 2);
+    // Setting WEBGL_MAX_TEXTURE_SIZE to 2 makes that [8, 2] tensor is packed
+    // to texture of width 2 by height 2. Indices are packed as:
+    // -------------
+    // | 0 1 | 4 5 |       // First row's four 
+    // | 2 3 | 6 7 |       // pixels.
+    // -------------
     // ...    
     const c = tf.matMul(a, b);
-    let cAs4D = c.reshape([2, 2, 2, 4]);    
+    let cAs4D = c.reshape([2, 1, 2, 4]);    
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', maxTextureSize);
 
     //Execute non-packed operations to unpack tensor.
@@ -113,9 +113,7 @@ describeWithFlags('expensive reshape with even columns', WEBGL_ENVS, () => {
     tf.ENV.set('WEBGL_PACK', webglPackFlagSaved);    
 
     const result = [7, 10, 15, 22, 23, 34, 31, 46,
-                    39, 58, 47, 70, 55, 82, 63, 94,
-                    71, 106, 79, 118, 87, 130, 95, 142,
-                    103, 154, 111, 166, 119, 178, 127, 190];
+                    39, 58, 47, 70, 55, 82, 63, 94];
     expectArraysClose(cAs4D, result);
   });
 });

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -415,17 +415,6 @@ export function isReshapeFree(shape1: number[], shape2: number[]): boolean {
         (shape1[0] === 1 || shape2[0] === 1)) {
       return true;
     }
-  } else {
-    if (isEven(shape1[0]) && isEven(shape2[0])) {
-      if (isEven(shape1[1]) && isEven(shape2[1])) {
-        return true;
-      }
-
-      if (shape1[1] === shape2[1]) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  } 
+  return shape1[1] === shape2[1] && isEven(shape1[0]) && isEven(shape2[0]);
 }

--- a/src/kernels/webgl/webgl_util_test.ts
+++ b/src/kernels/webgl/webgl_util_test.ts
@@ -155,18 +155,18 @@ describeWithFlags('isReshapeFree', WEBGL_ENVS, () => {
        expect(webgl_util.isReshapeFree(before, after)).toBe(false);
      });
 
-  it('is free when the inner dimensions are divisible by 2', () => {
-    const before = [1, 2, 4];
-    const after = [1, 8, 10];
-    expect(webgl_util.isReshapeFree(before, after)).toBe(true);
-  });
-
   it('is free if the rows are divisible by two and the columns are the same',
      () => {
        const before = [1, 2, 3];
        const after = [1, 4, 3];
        expect(webgl_util.isReshapeFree(before, after)).toBe(true);
      });
+
+  it('is not free when the inner dimensions are different and even', () => {
+    const before = [1, 2, 4];
+    const after = [1, 8, 10];
+    expect(webgl_util.isReshapeFree(before, after)).toBe(false);
+  });
 
   it('is not free when the inner dimensions are different and not all even',
      () => {


### PR DESCRIPTION
Packed reshape when both, source and destination shape, have even
columns is not free - with current 2x2 packing, pixel's .ba values
are the next (logical) row of .rg values. If row length changes,
different values are expected in .ba values.

e.g. 2 -> 4 columns reshape:

```
0 1 4 5    -->  0 1 2 3
2 3 6 7         4 5 6 7
```

Added test that exposes the issue and the fix.

BUG

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1441)
<!-- Reviewable:end -->
