### PR TITLE
Packed batch<=>space ND: transpose, slice, 5-D and 6-D packed sampling.

### DIFF
--- a/src/jasmine_util.ts
+++ b/src/jasmine_util.ts
@@ -117,6 +117,40 @@ export let TEST_ENVS: TestEnv[] = [
   }
 ];
 
+// When not running in node (headless environment), append additional WebGL
+// testing environment in order to test packed operations. This way, we specify
+// a subset of tests to run, both with packed and non-packed operations. Calling
+// this method needs to be coupled with deactivateWebGLPackedTestEnv to remove
+// packed testing environment. Only the tests specified between
+// activateWebGLPackedTestEnv and deactivateWebGLPackedTestEnv are run in
+// additional packed operations mode.
+export function activateWebGLPackedTestEnv() {
+  if (!ENV.get('IS_NODE')) {
+    TEST_ENVS.push(
+      {
+        name: 'webgl-packed',
+        factory: () => new MathBackendWebGL(),
+        features: {'WEBGL_VERSION': ENV.get('WEBGL_VERSION'),
+                   'WEBGL_CPU_FORWARD': false,
+                   'WEBGL_PACK': true}
+      }
+    );
+  }
+}
+
+// With activateWebGLPackedTestEnv, delimits set of tests to be run in both
+// packed and non-packed environment mode.
+export function deactivateWebGLPackedTestEnv() {
+  if (!ENV.get('IS_NODE')) {
+    // Additional packed operation testing environent is appended: remove it
+    // to affect only the tests specified between activateWebGLPackedTestEnv and
+    // deactivateWebGLPackedTestEnv.
+    if (TEST_ENVS.pop().features['WEBGL_PACK'] !== true) {
+      throw new Error('Error with WEBGL_PACK setup in tests.'); 
+    }
+  }
+}
+
 export const CPU_FACTORY = () => new MathBackendCPU();
 
 if (typeof __karma__ !== 'undefined') {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -98,6 +98,7 @@ import {TextureData, TextureUsage} from './webgl/tex_util';
 import {TextureManager} from './webgl/texture_manager';
 import {TileProgram} from './webgl/tile_gpu';
 import {TransposeProgram} from './webgl/transpose_gpu';
+import {TransposePackedProgram} from './webgl/transpose_packed_gpu';
 import * as unary_op from './webgl/unaryop_gpu';
 import {UnaryOpProgram} from './webgl/unaryop_gpu';
 import {UnpackProgram} from './webgl/unpack_gpu';
@@ -798,7 +799,9 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   transpose<T extends Tensor>(x: T, perm: number[]): T {
-    const program = new TransposeProgram(x.shape, perm);
+    const program = ENV.get('WEBGL_PACK') ?
+        new TransposePackedProgram(x.shape, perm) :
+        new TransposeProgram(x.shape, perm);
     return this.compileAndRun(program, [x]);
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -92,6 +92,7 @@ import {ScatterProgram} from './webgl/scatter_gpu';
 import {SegmentOpProgram} from './webgl/segment_gpu';
 import {SelectProgram} from './webgl/select_gpu';
 import {SliceProgram} from './webgl/slice_gpu';
+import {SlicePackedProgram} from './webgl/slice_packed_gpu';
 import {StridedSliceProgram} from './webgl/strided_slice_gpu';
 import * as tex_util from './webgl/tex_util';
 import {TextureData, TextureUsage} from './webgl/tex_util';
@@ -587,7 +588,9 @@ export class MathBackendWebGL implements KernelBackend {
       return this.cpuBackend.slice(x, begin, size);
     }
 
-    const program = new SliceProgram(size);
+    const program = ENV.get('WEBGL_PACK') ?
+        new SlicePackedProgram(size) :
+        new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
   }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -111,12 +111,8 @@ function getPackedSamplerFromInInfo(inInfo: InputInfo): string {
       return getPackedSampler2D(inInfo);
     case 3:
       return getPackedSampler3D(inInfo);
-    case 4:
-      return getPackedSampler4D(inInfo);
     default:
-      throw new Error(
-          `Packed ${shape.length}-D input sampling` +
-          ` is not yet supported`);
+      return getPackedSamplerND(inInfo);
   }
 }
 
@@ -157,13 +153,8 @@ function getPackedOutputSamplingSnippet(
     case 3:
       return getOutputPacked3DCoords(
           outShape as [number, number, number], outTexShape);
-    case 4:
-      return getOutputPacked4DCoords(
-          outShape as [number, number, number, number], outTexShape);
     default:
-      throw new Error(
-          `${outShape.length}-D packed output ` +
-          `coordinate fetching is not yet supported`);
+      return getOutputPackedNDCoords(outShape, outTexShape);
   }
 }
 
@@ -250,15 +241,6 @@ vec2 UVfrom4D(int texNumR, int texNumC, int stride0,
     int depth2) {
   // Explicitly use integer operations as dot() only works on floats.
   int index = row * stride0 + col * stride1 + depth * stride2 + depth2;
-  int texR = index / texNumC;
-  int texC = index - texR * texNumC;
-  return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
-}
-vec2 packedUVfrom4D(int texNumR, int texNumC, int texelsInBatch2,
-    int texelsInBatch, int texelsInLogicalRow, int b2, int b,
-    int row, int col) {
-  int index = b2 * texelsInBatch2 + b * texelsInBatch +
-    (row / 2) * texelsInLogicalRow + (col / 2);
   int texR = index / texNumC;
   int texC = index - texR * texNumC;
   return (vec2(texC, texR) + halfCR) / vec2(texNumC, texNumR);
@@ -513,24 +495,34 @@ function getOutput3DCoords(
   `;
 }
 
-function getOutputPacked4DCoords(
-    shape: [number, number, number, number],
-    texShape: [number, number]): string {
+function getOutputPackedNDCoords(
+    shape: number[], texShape: [number, number]): string {
   const packedTexShape =
       [Math.ceil(texShape[0] / 2), Math.ceil(texShape[1] / 2)];
 
-  const texelsInLogicalRow = Math.ceil(shape[3] / 2);
-  const texelsInBatch = texelsInLogicalRow * Math.ceil(shape[2] / 2);
-  const texelsInBatch2 = texelsInBatch * shape[1];
+  const texelsInLogicalRow = Math.ceil(shape[shape.length - 1] / 2);
+  const texelsInBatch =
+      texelsInLogicalRow * Math.ceil(shape[shape.length - 2] / 2);
+  let texelsInBatchN = texelsInBatch;
+  let batches = ``;
+  let coords = 'b, r, c';
+
+  for (let b = 2; b < shape.length - 1; b++) {
+    texelsInBatchN *= shape[shape.length - b - 1];
+    batches = `
+      int b${b} = index / ${texelsInBatchN};
+      index -= b${b} * ${texelsInBatchN};
+    ` + batches;
+    coords = `b${b}, ` + coords; 
+  }
 
   return `
-    ivec4 getOutputCoords() {
+    ivec${shape.length} getOutputCoords() {
       ivec2 resTexRC = ivec2(resultUV.yx *
                              vec2(${packedTexShape[0]}, ${packedTexShape[1]}));
       int index = resTexRC.x * ${packedTexShape[1]} + resTexRC.y;
-
-      int b2 = index / ${texelsInBatch2};
-      index -= b2 * ${texelsInBatch2};
+      
+      ${batches}
 
       int b = index / ${texelsInBatch};
       index -= b * ${texelsInBatch};
@@ -538,7 +530,7 @@ function getOutputPacked4DCoords(
       int r = 2 * (index / ${texelsInLogicalRow});
       int c = imod(index, ${texelsInLogicalRow}) * 2;
 
-      return ivec4(b2, b, r, c);
+      return ivec${shape.length}(${coords});
     }
   `;
 }
@@ -936,8 +928,9 @@ function getSampler3D(inputInfo: InputInfo): string {
   `;
 }
 
-function getPackedSampler4D(inputInfo: InputInfo): string {
+function getPackedSamplerND(inputInfo: InputInfo): string {  
   const shape = inputInfo.shapeInfo.logicalShape;
+  const rank = shape.length;
   const texName = inputInfo.name;
   const funcName = 'get' + texName.charAt(0).toUpperCase() + texName.slice(1);
   const texShape = inputInfo.shapeInfo.texShape;
@@ -946,16 +939,22 @@ function getPackedSampler4D(inputInfo: InputInfo): string {
   const texNumR = packedTexShape[0];
   const texNumC = packedTexShape[1];
 
-  const valuesPerRow = Math.ceil(shape[3] / 2);
-  const texelsInBatch = valuesPerRow * Math.ceil(shape[2] / 2);
-  const texelsInBatch2 = texelsInBatch * shape[1];
-
+  const valuesPerRow = Math.ceil(shape[rank - 1] / 2);
+  let texelsInBatch = valuesPerRow * Math.ceil(shape[rank - 2] / 2);
+  let params = `int b, int row, int col`;
+  let index = `b * ${texelsInBatch} + (row / 2) * ${valuesPerRow} + (col / 2)`;
+  for (let b = 2; b < rank - 1; b++) {
+    params = `int b${b}, ` + params;
+    texelsInBatch *= shape[rank - b - 1]; 
+    index = `b${b} * ${texelsInBatch} + ` + index;
+  }
   return `
-    vec4 ${funcName}(int b2, int b, int row, int col) {
-      vec2 uv = packedUVfrom4D(
-        ${texNumR}, ${texNumC}, ${texelsInBatch2},
-        ${texelsInBatch}, ${valuesPerRow}, b2, b, row, col);
-      return texture2D(${texName}, uv);
+    vec4 ${funcName}(${params}) {
+      int index = ${index};
+      int texR = index / ${texNumC};
+      int texC = index - texR * ${texNumC};
+      vec2 uv = (vec2(texC, texR) + halfCR) / vec2(${texNumC}, ${texNumR});
+      return texture2D(${texName}, uv);      
     }
   `;
 }

--- a/src/kernels/webgl/slice_packed_gpu.ts
+++ b/src/kernels/webgl/slice_packed_gpu.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {GPGPUContext} from './gpgpu_context';
+import {GPGPUProgram} from './gpgpu_math';
+import {getCoordsDataType} from './shader_compiler';
+import { getChannels } from '../packing_util';
+
+export class SlicePackedProgram implements GPGPUProgram {
+  variableNames = ['source'];
+  usesPackedTextures = true;
+  outputShape: number[];
+  userCode: string;
+  rank: number;
+
+  // Caching uniform location for speed.
+  startLoc: WebGLUniformLocation;
+
+  constructor(destSize: number[]) {
+    this.outputShape = destSize;
+    this.rank = destSize.length;
+
+    const dtype = getCoordsDataType(this.rank);
+    const coords = getChannels('loc', this.rank);
+    const range = getChannels('range', this.rank);
+
+    const columnLimit = `${coords[this.rank - 1]} < ${range[this.rank - 1]}`;
+    const rowLimit = this.rank === 1 ? '' :
+        `${coords[this.rank - 2]} < ${range[this.rank - 2]}`;
+
+    const innerDims =
+        this.rank === 1 ? 'loc' : `vec2(${coords.slice(-2).join()})`;
+
+    const componentSetup = [
+      `${dtype} loc = sourceLoc;`,
+      `${coords[this.rank - 1]} += 1;
+       if(${columnLimit}) {
+      `,
+      this.rank === 1 ? `` : 
+      `}
+       loc = sourceLoc;
+       ${coords[this.rank - 2]} += 1;
+       if(${rowLimit}) {`,
+      this.rank === 1 ? '' :
+      `  ${coords[this.rank - 1]} += 1;
+         if(${columnLimit}) {`
+    ];
+
+    let mainLoop = ``;
+    for (let i = 0, j = this.rank === 1 ? 2 : 4; i < j; i++) {
+      mainLoop += `
+        ${componentSetup[i]}
+        result[${i}] = getChannel(getSource(${coords.join()}), ${innerDims});
+      `;
+    }
+    mainLoop += (this.rank === 1 ? `} ` : `}}`);
+ 
+    this.userCode = `
+      uniform ${dtype} start;
+      void main() {
+        ${dtype} sourceLoc = start + getOutputCoords();
+        ${dtype} range = start + ${dtype}(${destSize.join()}); 
+        vec4 result = vec4(0.);
+        ${mainLoop}
+        setOutput(result);
+      }
+    `;
+  }
+
+  getCustomSetupFunc(start: number[]) {
+    if (start.length !== this.rank) {
+      throw Error(
+          `The rank (${this.rank}) of the program must match the ` +
+          `length of start (${start.length})`);
+    }
+    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
+      if (this.startLoc == null) {
+        this.startLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'start');
+        if (this.startLoc == null) {
+          // This means the compiler has optimized and realized it doesn't need
+          // the uniform.
+          return;
+        }
+      }
+      if (this.rank === 1) {
+        gpgpu.gl.uniform1i(this.startLoc, start[0]);
+      } else if (this.rank === 2) {
+        gpgpu.gl.uniform2i(this.startLoc, start[0], start[1]);
+      } else if (this.rank === 3) {
+        gpgpu.gl.uniform3i(this.startLoc, start[0], start[1], start[2]);
+      } else if (this.rank === 4) {
+        gpgpu.gl.uniform4i(
+            this.startLoc, start[0], start[1], start[2], start[3]);
+      } else {
+        throw Error(`Slicing for rank ${this.rank} is not yet supported`);
+      }
+    };
+  }
+}

--- a/src/kernels/webgl/transpose_packed_gpu.ts
+++ b/src/kernels/webgl/transpose_packed_gpu.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {GPGPUProgram} from './gpgpu_math';
+import {getCoordsDataType} from './shader_compiler';
+import { getVecChannels } from '../packing_util';
+
+export class TransposePackedProgram implements GPGPUProgram {
+  variableNames = ['A'];
+  outputShape: number[];
+  userCode: string;
+  rank: number;
+  usesPackedTextures = true;
+
+  constructor(aShape: number[], newDim: number[]) {
+    const outputShape: number[] = new Array(aShape.length);
+    for (let i = 0; i < outputShape.length; i++) {
+      outputShape[i] = aShape[newDim[i]];
+    }
+    this.outputShape = outputShape;
+    this.rank = outputShape.length;
+    if (this.rank > 6) {
+      throw Error(
+          `Packed transpose for rank ${this.rank} is not yet supported.`);
+    }
+    const dtype = getCoordsDataType(this.rank);
+
+    const outputOrder = getVecChannels('rc', this.rank);
+    const switchedOrder = new Array(this.rank);
+    for (let i = 0; i < newDim.length; i++) {
+      switchedOrder[newDim[i]] = outputOrder[i];
+    }
+    const innerDims = `vec2(${switchedOrder.slice(-2).join()})`;
+    let main = ``;
+    
+    const componentSetup = [
+      `${dtype} rc = resRC;`,
+      `${outputOrder[this.rank - 1]} += 1;
+       if(${outputOrder[this.rank - 1]} < ${outputShape[this.rank - 1]}) {
+      `,
+      `}
+       rc = resRC;
+       ${outputOrder[this.rank - 2]} += 1;
+       if(${outputOrder[this.rank - 2]} < ${outputShape[this.rank - 2]}) {`,
+      `  ${outputOrder[this.rank - 1]} += 1;
+         if(${outputOrder[this.rank - 1]} < ${outputShape[this.rank - 1]}) {`
+    ];
+    for (let i = 0; i < 4; i++) {
+      main += `
+        ${componentSetup[i]}
+          result[${i}] =
+            getChannel(getA(${switchedOrder.join()}), ${innerDims});
+      `;
+    }
+    main += `
+         }
+       }`;
+
+    this.userCode = `
+    void main() {
+      ${dtype} resRC = getOutputCoords();
+      vec4 result = vec4(0.);       
+      ${main}
+      setOutput(result);
+    }
+    `;
+  }
+}

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '../index';
-import {describeWithFlags} from '../jasmine_util';
+import {describeWithFlags, activateWebGLPackedTestEnv, deactivateWebGLPackedTestEnv} from '../jasmine_util';
 import {ALL_ENVS, BROWSER_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, NODE_ENVS, WEBGL_ENVS} from '../test_util';
 import * as util from '../util';
 import {expectArrayInMeanStdRange, jarqueBeraNormalityTest} from './rand_util';
@@ -3217,6 +3217,8 @@ describeWithFlags('cumsum', ALL_ENVS, () => {
   });
 });
 
+activateWebGLPackedTestEnv();
+
 describeWithFlags('batchToSpaceND', ALL_ENVS, () => {
   it('tensor4d, input shape=[4, 1, 1, 1], blockShape=[2, 2]', () => {
     const t = tf.tensor4d([1, 2, 3, 4], [4, 1, 1, 1]);
@@ -3610,6 +3612,8 @@ describeWithFlags('batchToSpaceND X spaceToBatchND', ALL_ENVS, () => {
         gradient, [2, 8, 3, 9, 14, 20, 15, 21, 5, 11, 6, 12, 17, 23, 18, 24]);
   });
 });
+
+deactivateWebGLPackedTestEnv();
 
 describeWithFlags('depthToSpace', ALL_ENVS, () => {
   it('tensor4d, input shape=[1, 1, 1, 4], blockSize=2, format=NHWC', () => {

--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -16,9 +16,11 @@
  */
 
 import * as tf from '../index';
-import {describeWithFlags} from '../jasmine_util';
+import {describeWithFlags, activateWebGLPackedTestEnv, deactivateWebGLPackedTestEnv} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose, expectNumbersClose} from '../test_util';
 import {Rank} from '../types';
+
+activateWebGLPackedTestEnv();
 
 describeWithFlags('slice1d', ALL_ENVS, () => {
   it('slices 1x1 into 1x1 (effectively a copy)', () => {
@@ -230,3 +232,5 @@ describeWithFlags('slice ergonomics', ALL_ENVS, () => {
     expectArraysClose(result, [4, 8]);
   });
 });
+
+deactivateWebGLPackedTestEnv();

--- a/src/ops/transpose_test.ts
+++ b/src/ops/transpose_test.ts
@@ -16,8 +16,11 @@
  */
 
 import * as tf from '../index';
-import {describeWithFlags} from '../jasmine_util';
+import {describeWithFlags, activateWebGLPackedTestEnv, deactivateWebGLPackedTestEnv} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose} from '../test_util';
+
+
+activateWebGLPackedTestEnv();
 
 describeWithFlags('transpose', ALL_ENVS, () => {
   it('of scalar is no-op', () => {
@@ -153,3 +156,5 @@ describeWithFlags('transpose', ALL_ENVS, () => {
     expectArraysClose(res, [1, 3, 11, 33, 2, 4, 22, 44]);
   });
 });
+
+deactivateWebGLPackedTestEnv();

--- a/src/ops/transpose_test.ts
+++ b/src/ops/transpose_test.ts
@@ -19,7 +19,6 @@ import * as tf from '../index';
 import {describeWithFlags, activateWebGLPackedTestEnv, deactivateWebGLPackedTestEnv} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose} from '../test_util';
 
-
 activateWebGLPackedTestEnv();
 
 describeWithFlags('transpose', ALL_ENVS, () => {


### PR DESCRIPTION
Packed transpose and slice and 5-D and 6-D packed sampling, in this PR, implement support for packed batchToSpaceND and packed spaceToBatchND.
It is verified using DeepLabV3+ MobileNetV2 segmentation, with exclusion of packed batch normalization ([erroneous](https://github.com/tensorflow/tfjs-core/pull/1423#issuecomment-444565205)).

Instead of adding additional tests, existing transpose, slice, batchToSpaceND and spaceToBatchND tests are reused for packed operations using activateWebGLPackedTestEnv. activateWebGLPackedTestEnv and deactivateWebGLPackedTestEnv delimit set of tests to be run in both packed and non-packed environment mode. When majority of operations get their packed variants, this could be replaced by running additional packed env for all tests.

PERF

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1443)
<!-- Reviewable:end -->
