### PR TITLE
Optimize concat for the WebGL backend

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,7 +17,7 @@
 
 import * as device_util from './device_util';
 import {Engine, MemoryInfo, ProfileInfo, ScopeFn, TimingInfo} from './engine';
-import {Features, getFeaturesFromURL, getWebGLDisjointQueryTimerVersion, getWebGLMaxTextureSize, isChrome, isDownloadFloatTextureEnabled, isRenderToFloatTextureEnabled, isWebGLFenceEnabled, isWebGLVersionEnabled} from './environment_util';
+import {Features, getFeaturesFromURL, getMaxTexturesInShader, getWebGLDisjointQueryTimerVersion, getWebGLMaxTextureSize, isChrome, isDownloadFloatTextureEnabled, isRenderToFloatTextureEnabled, isWebGLFenceEnabled, isWebGLVersionEnabled} from './environment_util';
 import {KernelBackend} from './kernels/backend';
 import {DataId, setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
@@ -324,6 +324,8 @@ export class Environment {
       return this.get('IS_BROWSER') && !this.get('PROD');
     } else if (feature === 'WEBGL_MAX_TEXTURE_SIZE') {
       return getWebGLMaxTextureSize(this.get('WEBGL_VERSION'));
+    } else if (feature === 'WEBGL_MAX_TEXTURES_IN_SHADER') {
+      return getMaxTexturesInShader(this.get('WEBGL_VERSION'));
     } else if (feature === 'IS_TEST') {
       return false;
     } else if (feature === 'BACKEND') {

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -42,6 +42,8 @@ export interface Features {
   'WEBGL_PAGING_ENABLED'?: boolean;
   // The maximum texture dimension.
   'WEBGL_MAX_TEXTURE_SIZE'?: number;
+  // The maximum number of textures in a single shader program.
+  'WEBGL_MAX_TEXTURES_IN_SHADER'?: number;
   // The disjoint_query_timer extension version.
   // 0: disabled, 1: EXT_disjoint_timer_query, 2:
   // EXT_disjoint_timer_query_webgl2.
@@ -101,6 +103,7 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'WEBGL_PACK_DEPTHWISECONV', type: Type.BOOLEAN},
   {name: 'WEBGL_CONV_IM2COL', type: Type.BOOLEAN},
   {name: 'WEBGL_MAX_TEXTURE_SIZE', type: Type.NUMBER},
+  {name: 'WEBGL_MAX_TEXTURES_IN_SHADER', type: Type.NUMBER},
   {name: 'WEBGL_PAGING_ENABLED', type: Type.BOOLEAN},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN},
@@ -132,16 +135,26 @@ export function isWebGLVersionEnabled(webGLVersion: 1|2) {
   return false;
 }
 
-let MAX_TEXTURE_SIZE: number;
-// Caching MAX_TEXTURE_SIZE here because the environment gets reset between
+// We cache webgl params because the environment gets reset between
 // unit tests and we don't want to constantly query the WebGLContext for
 // MAX_TEXTURE_SIZE.
+let MAX_TEXTURE_SIZE: number;
+let MAX_TEXTURES_IN_SHADER: number;
+
 export function getWebGLMaxTextureSize(webGLVersion: number): number {
   if (MAX_TEXTURE_SIZE == null) {
     const gl = getWebGLContext(webGLVersion);
     MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
   }
   return MAX_TEXTURE_SIZE;
+}
+
+export function getMaxTexturesInShader(webGLVersion: number): number {
+  if (MAX_TEXTURES_IN_SHADER == null) {
+    const gl = getWebGLContext(webGLVersion);
+    MAX_TEXTURES_IN_SHADER = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+  }
+  return MAX_TEXTURES_IN_SHADER;
 }
 
 export function getWebGLDisjointQueryTimerVersion(webGLVersion: number):

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -108,6 +108,8 @@ type KernelInfo = {
   name: string; query: Promise<number>;
 };
 
+const CONCAT_THRESHOLD = 4;
+
 export type TimerNode = RecursiveArray<KernelInfo>|KernelInfo;
 export interface CPUTimerQuery {
   startMs: number;
@@ -620,22 +622,6 @@ export class MathBackendWebGL implements KernelBackend {
     return this.compileAndRun(program, [x]);
   }
 
-  private concat2Tensors<T extends Tensor>(a: T, b: T, axis: number): T {
-    // Any concat of n-dimensional tensors across any axis can be reduced to
-    // a concatenation of two-dimensional tensors across the axis 1 by first
-    // partitioning the axes of the original tensors into those less than the
-    // axis to be concatenated and the rest. Then reshape the tensors
-    // into a two-dimensional tensor by collapsing these two sets of axes and
-    // concatenate the resulting matrices across the axis 1, finally reshaping
-    // the result to have the proper shape.
-    const outShape = computeOutShape([a.shape, b.shape], axis);
-    const a2D = a.as2D(-1, sizeFromShape(a.shape.slice(axis)));
-    const b2D = b.as2D(-1, sizeFromShape(b.shape.slice(axis)));
-    const program = new ConcatProgram(a2D.shape, b2D.shape);
-    const res = this.compileAndRun(program, [a2D, b2D]) as Tensor;
-    return res.reshape(outShape) as T;
-  }
-
   concat(tensors: Tensor[], axis: number): Tensor {
     if (this.shouldExecuteOnCPU(tensors)) {
       return this.cpuBackend.concat(tensors, axis);
@@ -644,11 +630,25 @@ export class MathBackendWebGL implements KernelBackend {
     if (tensors.length === 1) {
       return tensors[0];
     }
-    let result = tensors[0];
-    for (let i = 1; i < tensors.length; ++i) {
-      result = this.concat2Tensors(result, tensors[i], axis);
+    if (tensors.length > CONCAT_THRESHOLD) {
+      const midIndex = tensors.length >> 2;
+      const leftSide = this.concat(tensors.slice(0, midIndex), axis);
+      const rightSide = this.concat(tensors.slice(midIndex), axis);
+      return this.concat([leftSide, rightSide], axis);
     }
-    return result;
+    // Any concat of n-dimensional tensors across any axis can be reduced to
+    // a concatenation of two-dimensional tensors across the axis 1 by first
+    // partitioning the axes of the original tensors into those less than the
+    // axis to be concatenated and the rest. Then reshape the tensors
+    // into a two-dimensional tensor by collapsing these two sets of axes and
+    // concatenate the resulting matrices across the axis 1, finally reshaping
+    // the result to have the proper shape.
+    const outShape = computeOutShape(tensors.map(t => t.shape), axis);
+    const tensors2D =
+        tensors.map(t => t.as2D(-1, sizeFromShape(t.shape.slice(axis))));
+    const program = new ConcatProgram(tensors2D.map(t => t.shape));
+    const res = this.compileAndRun(program, tensors2D) as Tensor;
+    return res.reshape(outShape);
   }
 
   neg<T extends Tensor>(x: T): T {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -629,7 +629,7 @@ export class MathBackendWebGL implements KernelBackend {
       return tensors[0];
     }
     if (tensors.length > ENV.get('WEBGL_MAX_TEXTURES_IN_SHADER')) {
-      const midIndex = tensors.length >> 2;
+      const midIndex = Math.floor(tensors.length / 2);
       const leftSide = this.concat(tensors.slice(0, midIndex), axis);
       const rightSide = this.concat(tensors.slice(midIndex), axis);
       return this.concat([leftSide, rightSide], axis);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -108,8 +108,6 @@ type KernelInfo = {
   name: string; query: Promise<number>;
 };
 
-const CONCAT_THRESHOLD = 4;
-
 export type TimerNode = RecursiveArray<KernelInfo>|KernelInfo;
 export interface CPUTimerQuery {
   startMs: number;
@@ -630,7 +628,7 @@ export class MathBackendWebGL implements KernelBackend {
     if (tensors.length === 1) {
       return tensors[0];
     }
-    if (tensors.length > CONCAT_THRESHOLD) {
+    if (tensors.length > ENV.get('WEBGL_MAX_TEXTURES_IN_SHADER')) {
       const midIndex = tensors.length >> 2;
       const leftSide = this.concat(tensors.slice(0, midIndex), axis);
       const rightSide = this.concat(tensors.slice(midIndex), axis);

--- a/src/kernels/webgl/concat_gpu.ts
+++ b/src/kernels/webgl/concat_gpu.ts
@@ -26,9 +26,9 @@ export class ConcatProgram implements GPGPUProgram {
   // Concats 2d tensors along axis=1. See comments in MathBackendWebGL.concat().
   constructor(shapes: Array<[number, number]>) {
     this.outputShape = concat_util.computeOutShape(shapes, 1 /* axis */);
-    this.variableNames = shapes.map((_, i) => 'T' + i);
+    this.variableNames = shapes.map((_, i) => `T${i}`);
 
-    const offsets = new Array(shapes.length - 1);
+    const offsets: number[] = new Array(shapes.length - 1);
     offsets[0] = shapes[0][1];
     for (let i = 1; i < offsets.length; i++) {
       offsets[i] = offsets[i - 1] + shapes[i][1];

--- a/src/ops/concat_test.ts
+++ b/src/ops/concat_test.ts
@@ -289,6 +289,34 @@ describeWithFlags('concat3d', ALL_ENVS, () => {
     expectArraysClose(values, [1, 2, 3, 4, 5, 6]);
   });
 
+  it('concat a large number of tensors, axis=0', () => {
+    const tensors = [];
+    const expected = [];
+    for (let i = 0; i < 100; i++) {
+      tensors.push(tf.tensor([i], [1]));
+      expected.push(i);
+    }
+    const axis = 0;
+    const res = tf.concat(tensors, axis);
+    expect(res.shape).toEqual([100]);
+    expect(res.dtype).toBe('float32');
+    expectArraysEqual(res, expected);
+  });
+
+  it('concat a large number of tensors, axis=1', () => {
+    const tensors = [];
+    const expected = [];
+    for (let i = 0; i < 100; i++) {
+      tensors.push(tf.tensor([i], [1, 1]));
+      expected.push(i);
+    }
+    const axis = 1;
+    const res = tf.concat(tensors, axis);
+    expect(res.shape).toEqual([1, 100]);
+    expect(res.dtype).toBe('float32');
+    expectArraysEqual(res, expected);
+  });
+
   it('concat axis=2', () => {
     const tensor1 = tf.tensor3d([1, 11, 2, 22, 3, 33, 4, 44], [2, 2, 2]);
     const tensor2 = tf.tensor3d(

--- a/src/ops/concat_test.ts
+++ b/src/ops/concat_test.ts
@@ -300,7 +300,7 @@ describeWithFlags('concat3d', ALL_ENVS, () => {
     const res = tf.concat(tensors, axis);
     expect(res.shape).toEqual([100]);
     expect(res.dtype).toBe('float32');
-    expectArraysEqual(res, expected);
+    expectArraysClose(res, expected);
   });
 
   it('concat a large number of tensors, axis=1', () => {
@@ -314,7 +314,7 @@ describeWithFlags('concat3d', ALL_ENVS, () => {
     const res = tf.concat(tensors, axis);
     expect(res.shape).toEqual([1, 100]);
     expect(res.dtype).toBe('float32');
-    expectArraysEqual(res, expected);
+    expectArraysClose(res, expected);
   });
 
   it('concat axis=2', () => {


### PR DESCRIPTION
Speedup WebGL concat by 5x without warmup and 2x with shader warmup.

Benchmark used:
```js
const tensors = [];
for (let i = 0; i < 400; i++) {
  tensors.push(tf.ones([1, 696]));
}
const start = performance.now();
const res = tf.concat(tensors, 0 /* axis */);
res.dataSync();
console.log('Took', performance.now() - start);
```

Without warmup: 626ms (this PR) vs 3066ms (master)
With warmup: 34ms (this PR) vs 65ms (master)

The benchmark above reflects a real workflow of preparing training data (stacking 400 examples, 696 values each), taken from the Audio recognition codelab. Measuring both with warmup and without warmup is important since in the use-case of collecting examples, the number of examples is dynamic and causes recompilation of the shaders.

**Details**
- Add a new WebGL flag `WEBGL_MAX_TEXTURES_IN_SHADER` that gives the maximum number of textures we can have as uniform samples in a single shader.
- Change concat_gpu to take arbitrary number of inputs.
- When concating a large number of tensors, do binary concatenation (divide-and-conquer) to reduce number of concat calls.

PERF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1449)
<!-- Reviewable:end -->
