### PR TITLE
Allow tf.oneHot to take indices with arbitrary rank

### DIFF
--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -161,7 +161,8 @@ export function getMaxTexturesInShader(webGLVersion: number): number {
     const gl = getWebGLContext(webGLVersion);
     MAX_TEXTURES_IN_SHADER = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
   }
-  return MAX_TEXTURES_IN_SHADER;
+  // We cap at 16 to avoid spurious runtime "memory exhausted" error.
+  return Math.min(16, MAX_TEXTURES_IN_SHADER);
 }
 
 export function getWebGLDisjointQueryTimerVersion(webGLVersion: number):

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2491,6 +2491,16 @@ describeWithFlags('oneHot', ALL_ENVS, () => {
     expectArraysClose(da, [0, 0, 0]);
   });
 
+  it('gradient when indices is 3d', () => {
+    const a = tf.tensor3d([1, 2, 3, 4], [1, 2, 2], 'int32');
+    const dy = tf.ones([1, 2, 2, 3], 'float32');
+    const depth = 3;
+    const da = tf.grad(x => tf.oneHot(x, depth))(a, dy);
+    expect(da.dtype).toBe('float32');
+    expect(da.shape).toEqual(a.shape);
+    expectArraysClose(da, [0, 0, 0, 0]);
+  });
+
   it('oneHot with indices as 2d', () => {
     const indices = tf.tensor2d([[1, 3], [2, 3]], [2, 2], 'int32');
     const depth = 4;

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -2425,6 +2425,12 @@ describeWithFlags('oneHot', ALL_ENVS, () => {
     expectArraysClose(res, [0, 0, 1, 0]);
   });
 
+  it('oneHot with chaining compiles', () => {
+    const indices = 2;
+    // Asserts that there is no compiler error.
+    tf.oneHot(indices, 4).toFloat();
+  });
+
   it('Depth 2, transposed diagonal', () => {
     const indices = tf.tensor1d([1, 0], 'int32');
     const res = tf.oneHot(indices, 2);
@@ -2483,6 +2489,17 @@ describeWithFlags('oneHot', ALL_ENVS, () => {
     expect(da.dtype).toBe('float32');
     expect(da.shape).toEqual([3]);
     expectArraysClose(da, [0, 0, 0]);
+  });
+
+  it('oneHot with indices as 2d', () => {
+    const indices = tf.tensor2d([[1, 3], [2, 3]], [2, 2], 'int32');
+    const depth = 4;
+    const res = tf.oneHot(indices, depth);
+    expect(res.shape).toEqual([2, 2, depth]);
+    expectArraysClose(res, [0, 1, 0, 0,
+                            0, 0, 0, 1,
+                            0, 0, 1, 0,
+                            0, 0, 0, 1]);
   });
 });
 


### PR DESCRIPTION
Make `tf.oneHot` take arbitrary rank indices to align with [tf.one_hot](https://www.tensorflow.org/api_docs/python/tf/one_hot)

If indices is rank R, the output is rank R+1.

Also:
- Fix the issue with the max number of textures
- Fixes compiler error when chaining after oneHot: `tf.oneHot().someChainOp()` which breaks layers when it depends on core@master

FEATURE
BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1476)
<!-- Reviewable:end -->
