### PR TITLE
Fix reduction op compilation on Firefox Linux

### DIFF
--- a/src/kernels/webgl/pool_gpu.ts
+++ b/src/kernels/webgl/pool_gpu.ts
@@ -45,7 +45,8 @@ export class Pool2DProgram implements GPGPUProgram {
 
     let initializationValue = '0.0';
     if (!isAvgPool) {
-      initializationValue = '-1.0 / 0.0';
+      // WebGL on Firefox Linux can't compile 1/0 so we do 1/eps.
+      initializationValue = '-1.0 / 1e-20';
     }
 
     if (computePositions) {

--- a/src/kernels/webgl/reduce_gpu.ts
+++ b/src/kernels/webgl/reduce_gpu.ts
@@ -38,10 +38,12 @@ export class ReduceProgram implements GPGPUProgram {
     if (reduceType === 'prod') {
       initializationValue = '1.0';
     } else if (reduceType === 'min') {
-      initializationValue = '1.0 / 0.0';
+      // WebGL on Firefox Linux can't compile 1/0 so we do 1/eps.
+      initializationValue = '1.0 / 1e-20';
       compareOp = `min`;
     } else if (reduceType === 'max') {
-      initializationValue = '-1.0 / 0.0';
+      // WebGL on Firefox Linux can't compile 1/0 so we do 1/eps.
+      initializationValue = '-1.0 / 1e-20';
       compareOp = `max`;
     }
 


### PR DESCRIPTION
Due to glsl 300, WebGL on Firefox on Linux can't compile 1.0 / 0.0, thus we use 1.0 / 1e-20. Relevant discussion: https://github.com/tensorflow/tfjs-core/pull/1421#issuecomment-451258903

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1477)
<!-- Reviewable:end -->
