### PR TITLE
Fix firefox glsl 300 failure to compile large constants in clip_gpu

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1440,11 +1440,12 @@ export class MathBackendWebGL implements KernelBackend {
   clip<T extends Tensor>(x: T, min: number, max: number): T {
     let program;
     if (ENV.get('WEBGL_PACK_CLIP')) {
-      program = new ClipPackedProgram(x.shape, min, max);
+      program = new ClipPackedProgram(x.shape);
     } else {
-      program = new ClipProgram(x.shape, min, max);
+      program = new ClipProgram(x.shape);
     }
-    return this.compileAndRun(program, [x]) as T;
+    const customSetup = program.getCustomSetupFunc(min, max);
+    return this.compileAndRun(program, [x], null, customSetup) as T;
   }
 
   abs<T extends Tensor>(x: T): T {

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class ClipPackedProgram implements GPGPUProgram {
@@ -23,7 +24,11 @@ export class ClipPackedProgram implements GPGPUProgram {
   userCode: string;
   outputShape: number[];
 
-  constructor(aShape: number[], min: number, max: number) {
+  // Caching uniform locations for speed.
+  minLoc: WebGLUniformLocation;
+  maxLoc: WebGLUniformLocation;
+
+  constructor(aShape: number[]) {
     this.outputShape = aShape;
     this.userCode = `
       void main() {
@@ -34,8 +39,19 @@ export class ClipPackedProgram implements GPGPUProgram {
           return;
         }
 
-        setOutput(clamp(value, vec4(${min}), vec4(${max})));
+        setOutput(clamp(value, vec4(min), vec4(max)));
       }
     `;
+  }
+
+  getCustomSetupFunc(min: number, max: number) {
+    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
+      if (this.minLoc == null) {
+        this.minLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'min');
+        this.maxLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'max');
+      }
+      gpgpu.gl.uniform1f(this.minLoc, min);
+      gpgpu.gl.uniform1f(this.maxLoc, max);
+    };
   }
 }


### PR DESCRIPTION
The glsl 300 change also caused clip tests in layers to fail. In losses.ts, there is a call to clip(x, min, Number.MAX_VALUE) and Number.MAX_VALUE was spliced into the shader code causing compilation to fail.

The fix was to upload min and max as uniforms, which also reduces shader re-compilation.