### PR TITLE
Fix JSDocs for tf.all and tf.any

### DIFF
--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -479,7 +479,7 @@ function argMax_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
  * `tf.Tensor` with a single element is returned.
  *
  * ```js
- * const x = tf.tensor1d([1, 1, 1]);
+ * const x = tf.tensor1d([1, 1, 1], 'bool');
  *
  * x.all().print();  // or tf.all(x)
  * ```
@@ -526,7 +526,7 @@ function all_<T extends Tensor>(
  * `tf.Tensor` with a single element is returned.
  *
  * ```js
- * const x = tf.tensor1d([1, 1, 1]);
+ * const x = tf.tensor1d([1, 1, 1], 'bool');
  *
  * x.any().print();  // or tf.any(x)
  * ```


### PR DESCRIPTION
#### Description
<!--
Please describe the pull request here.
Also, if this is an issue/bug fix, please add the issue link for reference here.
-->
Fixes the JSDoc examples for tf.all and tf.any.  Both these ops require a boolean tensor.

---
<!-- Please do not delete this section -->
##### For repository owners only:

Please remember to apply all applicable tags to your pull request.
Tags: FEATURE, BREAKING, BUG, PERF, DEV, DOC, SECURITY

For more info see: https://github.com/tensorflow/tfjs/blob/master/DEVELOPMENT.md
