### PR TITLE
Make Engine explicit implement TensorTracker.

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -18,7 +18,7 @@
 import {BackendTimingInfo, DataMover, KernelBackend} from './kernels/backend';
 import {Profiler} from './profiler';
 import {backpropagateGradients, getFilteredNodesXToY, NamedGradientMap, TapeNode} from './tape';
-import {DataId, Tensor, Tensor3D, Variable} from './tensor';
+import {DataId, Tensor, Tensor3D, TensorTracker, Variable} from './tensor';
 import {NamedTensorMap, NamedVariableMap, TensorContainer} from './tensor_types';
 import {getTensorsInContainer, isTensorInList} from './tensor_util';
 import {DataType, DataValues} from './types';
@@ -78,7 +78,7 @@ interface ScopeState {
   name: string;
 }
 
-export class Engine implements TensorManager, DataMover {
+export class Engine implements TensorManager, TensorTracker, DataMover {
   // Public since optimizers will use it.
   registeredVariables: NamedVariableMap = {};
 


### PR DESCRIPTION
Previously, Engine would only structurally match TensorTracker, by
implementing the right methods. This works on the TypeScript level, but
fails when compiling with Closure Compiler. The optimizer never sees an
assignment of an `Engine` type into a `TensorTracker` due to the
indirection in the code, and then removes and disambiguates properties
incorrectly. This is a known limitation of Closure Compiler.

The fix is simple: explicitly implement the interface that's used to
refer to the type, and Closure Compiler is aware of the property
use/name collision.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1486)
<!-- Reviewable:end -->
