### PR TITLE
Add partial support for broadcasting of bias in fusedMatMul.

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -16,7 +16,7 @@
  */
 
 import {Conv2DInfo, Conv3DInfo} from '../ops/conv_util';
-import {FusableActivation} from '../ops/fused_util';
+import {Activation} from '../ops/fused_util';
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
 import {DataType, DataValues, Rank, ShapeMap} from '../types';
 
@@ -124,7 +124,7 @@ export class KernelBackend implements TensorStorage, BackendTimer {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: Activation): Tensor3D {
     throw new Error('Not yet implemented');
   }
 

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -124,7 +124,7 @@ export class KernelBackend implements TensorStorage, BackendTimer {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor3D, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: FusableActivation): Tensor3D {
     throw new Error('Not yet implemented');
   }
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -484,7 +484,7 @@ export class MathBackendCPU implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor3D, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: FusableActivation): Tensor3D {
     let result = this.batchMatMul(a, b, transposeA, transposeB);
     if (bias) {
       result = this.add(result, bias) as Tensor3D;

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -25,7 +25,7 @@ import * as broadcast_util from '../ops/broadcast_util';
 import * as concat_util from '../ops/concat_util';
 import {Conv2DInfo, Conv3DInfo} from '../ops/conv_util';
 import * as erf_util from '../ops/erf_util';
-import {FusableActivation} from '../ops/fused_util';
+import {Activation} from '../ops/fused_util';
 import * as gather_nd_util from '../ops/gather_nd_util';
 import * as ops from '../ops/ops';
 import {buffer, scalar, tensor, tensor3d, tensor4d} from '../ops/ops';
@@ -46,7 +46,7 @@ import {topkImpl} from './topk_impl';
 import {whereImpl} from './where_impl';
 
 function mapActivation(
-    backend: MathBackendCPU, activation: FusableActivation, x: Tensor): Tensor {
+    backend: MathBackendCPU, activation: Activation, x: Tensor): Tensor {
   if (activation === 'linear') {
     return backend.linear(x);
   } else if (activation === 'relu') {
@@ -484,7 +484,7 @@ export class MathBackendCPU implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: Activation): Tensor3D {
     let result = this.batchMatMul(a, b, transposeA, transposeB);
     if (bias) {
       result = this.add(result, bias) as Tensor3D;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -25,7 +25,7 @@ import * as axis_util from '../ops/axis_util';
 import * as broadcast_util from '../ops/broadcast_util';
 import {computeOutShape} from '../ops/concat_util';
 import {Conv2DInfo, Conv3DInfo} from '../ops/conv_util';
-import {FusableActivation} from '../ops/fused_util';
+import {Activation} from '../ops/fused_util';
 import * as gather_nd_util from '../ops/gather_nd_util';
 import * as reduce_util from '../ops/reduce_util';
 import * as scatter_nd_util from '../ops/scatter_nd_util';
@@ -132,7 +132,7 @@ export interface WebGLTimingInfo extends TimingInfo {
 }
 
 function mapActivationToShaderProgram(
-    activation: FusableActivation, packed = false): string {
+    activation: Activation, packed = false): string {
   if (activation === 'linear') {
     if (packed) {
       return unary_packed_op.LINEAR;
@@ -789,7 +789,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: Activation): Tensor3D {
     const outerShapeA = transposeA ? a.shape[2] : a.shape[1];
     const outerShapeB = transposeB ? b.shape[1] : b.shape[2];
     const [batch, , ] = a.shape;
@@ -1441,8 +1441,8 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   exp<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram | UnaryOpPackedProgram;
-    if(ENV.get('WEBGL_PACK')) {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
       program = new UnaryOpPackedProgram(x.shape, unary_op.EXP);
     } else {
       program = new UnaryOpProgram(x.shape, unary_op.EXP);
@@ -1456,8 +1456,8 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   log<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram | UnaryOpPackedProgram;
-    if(ENV.get('WEBGL_PACK')) {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
       program = new UnaryOpPackedProgram(x.shape, unary_packed_op.LOG);
     } else {
       program = new UnaryOpProgram(x.shape, unary_op.LOG);
@@ -1492,8 +1492,8 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   relu<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram | UnaryOpPackedProgram;
-    if(ENV.get('WEBGL_PACK')) {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
       program = new UnaryOpPackedProgram(x.shape, unary_packed_op.RELU);
     } else {
       program = new UnaryOpProgram(x.shape, unary_op.RELU);

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -787,7 +787,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor3D, activation?: FusableActivation): Tensor3D {
+      bias?: Tensor, activation?: FusableActivation): Tensor3D {
     const outerShapeA = transposeA ? a.shape[2] : a.shape[1];
     const outerShapeB = transposeB ? b.shape[1] : b.shape[2];
     const [batch, , ] = a.shape;
@@ -805,9 +805,9 @@ export class MathBackendWebGL implements KernelBackend {
           activation ? mapActivationToShaderProgram(activation, true) : null);
       const output =
           this.makePackedTensor(program.outputShape, dtype) as Tensor2D;
-      const inputs = [aSqueezed, bSqueezed];
+      const inputs: TensorHandle[] = [aSqueezed, bSqueezed];
       if (bias) {
-        inputs.push(bias.as2D(bias.shape[1], bias.shape[2]));
+        inputs.push(bias);
       }
       const result = this.compileAndRun<Tensor2D>(program, inputs, output);
       return result.reshape([1, result.shape[0], result.shape[1]]);
@@ -815,7 +815,7 @@ export class MathBackendWebGL implements KernelBackend {
       const program = new MatMulProgram(
           a.shape, b.shape, transposeA, transposeB, !!bias,
           activation ? mapActivationToShaderProgram(activation) : null);
-      const inputs = [a, b];
+      const inputs: TensorHandle[] = [a, b];
       if (bias) {
         inputs.push(bias);
       }

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -116,7 +116,20 @@ function matMul_<T extends Tensor>(
           `implemented yet.`);
     }
 
-    const biasGradient = bias != null ? {$bias: () => dyActivation} : {};
+    let biasGradient = {};
+    if (bias != null) {
+      biasGradient = {
+        $bias: () => {
+          let res = dyActivation;
+          const reduceAxes =
+              broadcast_util.getReductionAxes($bias.shape, outShape);
+          if (reduceAxes.length > 0) {
+            res = res.sum(reduceAxes);
+          }
+          return res.reshape($bias.shape);
+        }
+      }
+    }
 
     if (!transposeA && !transposeB) {
       return Object.assign(

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -24,7 +24,7 @@ import {TensorLike} from '../types';
 import * as util from '../util';
 
 import * as broadcast_util from './broadcast_util';
-import {FusableActivation} from './fused_util';
+import {Activation} from './fused_util';
 
 /**
  * Computes the dot product of two matrices with optional activation and bias.
@@ -47,7 +47,7 @@ import {FusableActivation} from './fused_util';
 /** @doc {heading: 'Operations', subheading: 'Matrices', namespace: 'fused'} */
 function matMul_<T extends Tensor>(
     a: T|TensorLike, b: T|TensorLike, transposeA = false, transposeB = false,
-    bias?: Tensor|TensorLike, activation: FusableActivation = 'linear'): T {
+    bias?: Tensor|TensorLike, activation: Activation = 'linear'): T {
   let $a = convertToTensor(a, 'a', 'fused matMul');
   let $b = convertToTensor(b, 'b', 'fused matMul');
   [$a, $b] = makeTypesMatch($a, $b);
@@ -176,4 +176,4 @@ function matMul_<T extends Tensor>(
 
 export const matMul = op({matMul_});
 
-export {FusableActivation};
+export {Activation};

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -98,7 +98,9 @@ function matMul_<T extends Tensor>(
     $bias = convertToTensor(bias, 'bias', 'fused matMul');
     [$bias] = makeTypesMatch($bias, $a);
 
-    outShape = broadcast_util.assertAndGetBroadcastShape(outShape, $bias.shape);
+    util.assert(
+        broadcast_util.getBroadcastDims(outShape, $bias.shape).length === 0,
+        `Error in fused matMul: broadcasting is not yet supported for bias add.`);
   }
 
   const grad = (dy: Tensor3D, saved: Tensor[]) => {

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -166,3 +166,5 @@ function matMul_<T extends Tensor>(
 }
 
 export const matMul = op({matMul_});
+
+export {FusableActivation};

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -26,7 +26,6 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {FusableActivation} from './fused_util';
 
-
 /**
  * Computes the dot product of two matrices with optional activation and bias.
  *
@@ -100,7 +99,7 @@ function matMul_<T extends Tensor>(
 
     util.assert(
         broadcast_util.getBroadcastDims(outShape, $bias.shape).length === 0,
-        `Error in fused matMul: broadcasting is not yet supported for bias add.`);
+        `Error in fused matMul: broadcasting is not supported for bias add.`);
   }
 
   const grad = (dy: Tensor3D, saved: Tensor[]) => {

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -86,7 +86,7 @@ function matMul_<T extends Tensor>(
           `${$b.shape} and transposeA=${transposeA}` +
           ` and transposeB=${transposeB} must match.`);
 
-  let outShape = $a.shape.slice(0, -2).concat([outerShapeA, outerShapeB]);
+  const outShape = $a.shape.slice(0, -2).concat([outerShapeA, outerShapeB]);
 
   const a3D = transposeA ? $a.as3D(batchDimA, innerShapeA, outerShapeA) :
                            $a.as3D(batchDimA, outerShapeA, innerShapeA);

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -128,7 +128,7 @@ function matMul_<T extends Tensor>(
           }
           return res.reshape($bias.shape);
         }
-      }
+      };
     }
 
     if (!transposeA && !transposeB) {

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -65,8 +65,9 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
     const c = tf.tensor1d([1, 1]);
+    const act: tf.fused.Activation = 'relu';
 
-    const d = tf.fused.matMul(a, b, false, false, c, 'relu');
+    const d = tf.fused.matMul(a, b, false, false, c, act);
 
     expect(d.shape).toEqual([2, 2]);
     expectArraysClose(d, [1, 9, 0, 21]);

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -61,7 +61,7 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(d, [1, 9, 0, 21]);
   });
 
-  fit('A x B with relu and broadcasted bias', () => {
+  it('A x B with relu and broadcasted bias', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
     const c = tf.tensor1d([1, 1]);

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -61,6 +61,17 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     expectArraysClose(d, [1, 9, 0, 21]);
   });
 
+  fit('A x B with relu and broadcasted bias', () => {
+    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
+    const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
+    const c = tf.tensor1d([1, 1]);
+
+    const d = tf.fused.matMul(a, b, false, false, c, 'relu');
+
+    expect(d.shape).toEqual([2, 2]);
+    expectArraysClose(d, [1, 9, 0, 21]);
+  });
+
   it('A x B with bias only', () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);

--- a/src/ops/fused_util.ts
+++ b/src/ops/fused_util.ts
@@ -15,4 +15,4 @@
  * =============================================================================
  */
 
-export type FusableActivation = 'linear'|'relu';
+export type Activation = 'linear'|'relu';


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/tensorflow/tfjs-layers/pull/397

#### Changes
- Allow broadcasting of 1D bias in fused matMul
- Export `FusableActivation` type declaration so it can be used in layers

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1502)
<!-- Reviewable:end -->
