### PR TITLE
Potential fix for tfjs issue 545

### DIFF
--- a/src/ops/norm.ts
+++ b/src/ops/norm.ts
@@ -87,7 +87,7 @@ function normImpl(
 
   // vector
   if (x.rank === 1 || typeof axis === 'number' ||
-      axis instanceof Array && axis.length === 1) {
+      Array.isArray(axis) && axis.length === 1) {
     if (p === 1) {
       return x.abs().sum(axis);
     }
@@ -106,7 +106,7 @@ function normImpl(
   }
 
   // matrix (assumption axis[0] < axis[1])
-  if (axis instanceof Array && axis.length === 2) {
+  if (Array.isArray(axis) && axis.length === 2) {
     if (p === 1) {
       return x.abs().sum(axis[0]).max(axis[1] - 1);
     }

--- a/src/tensor_util_env.ts
+++ b/src/tensor_util_env.ts
@@ -31,11 +31,11 @@ export function inferShape(val: TensorLike): number[] {
   }
   const shape: number[] = [];
 
-  while (firstElem instanceof Array || isTypedArray(firstElem)) {
+  while (Array.isArray(firstElem) || isTypedArray(firstElem)) {
     shape.push(firstElem.length);
     firstElem = firstElem[0];
   }
-  if (val instanceof Array && ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
+  if (Array.isArray(val) && ENV.get('TENSORLIKE_CHECK_SHAPE_CONSISTENCY')) {
     deepAssertShapeConsistency(val, shape, []);
   }
 
@@ -45,7 +45,7 @@ export function inferShape(val: TensorLike): number[] {
 function deepAssertShapeConsistency(
     val: TensorLike, shape: number[], indices: number[]) {
   indices = indices || [];
-  if (!(val instanceof Array) && !isTypedArray(val)) {
+  if (!(Array.isArray(val)) && !isTypedArray(val)) {
     assert(
         shape.length === 0,
         () => `Element arr[${indices.join('][')}] is a primitive, ` +

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -127,8 +127,8 @@ export function expectArraysEqual(
     expected: Tensor|TypedArray|number[]|boolean[]|string[]) {
   if (actual instanceof Tensor && actual.dtype === 'string' ||
       expected instanceof Tensor && expected.dtype === 'string' ||
-      actual instanceof Array && isString(actual[0]) ||
-      expected instanceof Array && isString(expected[0])) {
+      Array.isArray(actual) && isString(actual[0]) ||
+      Array.isArray(expected) && isString(expected[0])) {
     // tslint:disable-next-line:triple-equals
     return expectArraysPredicate(actual, expected, (a, b) => a == b);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -440,7 +440,7 @@ export function isNumber(value: {}): boolean {
 }
 
 export function inferDtype(values: TensorLike): DataType {
-  if (values instanceof Array) {
+  if (Array.isArray(values)) {
     return inferDtype(values[0]);
   }
   if (values instanceof Float32Array) {


### PR DESCRIPTION
When testing TensorFlow models using jest and **tfjs-node**, errors like the one reported by [tfjs issue 545](https://github.com/tensorflow/tfjs/issues/545) occurs.

I think they comes from the fact that jest patch several default objects like Array which make subsequent call to instanceof fail.

Probably because the Array object available at "creation time" is not the same that the one used at "test time".

Note that **this fix actually resolve the `tensor1d() requires values to be a flat/TypedArray` error** of me and @smith-kyle in [tfjs issue 545](https://github.com/tensorflow/tfjs/issues/545)

_Sorry for this approximative description, i'm not a tensor flow expert, i'm just trying to make our jest unit test work correctly with tensorflow._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1503)
<!-- Reviewable:end -->
