### PR TITLE
Wrap cropAndResize with an `op` decorator

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -194,7 +194,7 @@ export class Engine implements TensorManager, TensorTracker, DataMover {
       saved.push(x);
       return x;
     };
-    const scopeName = this.activeScope.name;
+    const scopeName = this.activeScope != null ? this.activeScope.name : '';
     const startingBytecount = this.numBytes;
     const startingNumTensors = this.numTensors;
 

--- a/src/ops/image_ops.ts
+++ b/src/ops/image_ops.ts
@@ -301,4 +301,4 @@ export const resizeBilinear = op({resizeBilinear_});
 export const resizeNearestNeighbor = op({resizeNearestNeighbor_});
 export const nonMaxSuppression = op({nonMaxSuppression_});
 export const nonMaxSuppressionAsync = nonMaxSuppressionAsync_;
-export const cropAndResize = cropAndResize_;
+export const cropAndResize = op({cropAndResize_});


### PR DESCRIPTION
Because we weren't wrapping cropAndResize using the op decorator, a user was seeing this stack trace when executing a model that had cropAndResize as an op:
```
engine.ts:197 Uncaught (in promise) TypeError: Cannot read property 'name' of null
    at e.runKernel (engine.ts:197)
    at Object.cropAndResize_ [as cropAndResize] (image_ops.ts:296)
    at executeOp$8 (image_executor.ts:65)
    at executeOp$16 (operation_executor.ts:65)
    at p (graph_executor.ts:323)
    at e.processStack (graph_executor.ts:309)
    at e.<anonymous> (graph_executor.ts:294)
    at callbacks.ts:17
    at Object.next (callbacks.ts:17)
    at i (callbacks.ts:17)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1506)
<!-- Reviewable:end -->
