### PR TITLE
Make doc of stridedSlice consistent to the API

### DIFF
--- a/src/ops/strided_slice.ts
+++ b/src/ops/strided_slice.ts
@@ -27,7 +27,7 @@ import {getStridedSlicedInfo} from './slice_util';
  * Extracts a strided slice of a tensor.
  *
  * Roughly speaking, this op extracts a slice of size (end-begin)/stride from
- * the given input_ tensor. Starting at the location specified by begin the
+ * the given input tensor (x). Starting at the location specified by begin the
  * slice continues by adding stride to the index until all dimensions are not
  * less than end. Note that a stride can be negative, which causes a reverse
  * slice.
@@ -46,9 +46,9 @@ import {getStridedSlicedInfo} from './slice_util';
  * @param begin The coordinates to start the slice from.
  * @param end: The coordinates to end the slice at.
  * @param strides: The size of the slice.
- * @param beginMask: If the ith bit of begin_mask is set, begin[i] is ignored
+ * @param beginMask: If the ith bit of beginMask is set, begin[i] is ignored
  *      and the fullest possible range in that dimension is used instead.
- * @param endMask: If the ith bit of end_mask is set, end[i] is ignored
+ * @param endMask: If the ith bit of endMask is set, end[i] is ignored
  *      and the fullest possible range in that dimension is used instead.
  * @param shrinkAxisMask: a bitmask where bit i implies that
  * the ith specification should shrink the dimensionality. begin and end must


### PR DESCRIPTION
MISC

Since it seems to be copied from the [TensorFlow core API reference](https://www.tensorflow.org/api_docs/python/tf/strided_slice), the parameter name is not consistent with the TensorFlow.js implementation. We should be able to use the consistent parameter name with the argument.

See: https://js.tensorflow.org/api/0.14.2/#stridedSlice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1515)
<!-- Reviewable:end -->
