### PR TITLE
Make tfjs-core compatible with the closure compiler

### DIFF
--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -89,8 +89,9 @@ export class IORouterRegistry {
       url: string|string[], handlerType: 'save'|'load',
       onProgress?: Function): IOHandler[] {
     const validHandlers: IOHandler[] = [];
-    const routers = handlerType === 'load' ? this.getInstance().loadRouters :
-                                             this.getInstance().saveRouters;
+    const routers = handlerType === 'load' ?
+        IORouterRegistry.getInstance().loadRouters :
+        IORouterRegistry.getInstance().saveRouters;
     routers.forEach(router => {
       const handler = router(url, onProgress);
       if (handler !== null) {

--- a/src/io/weights_loader.ts
+++ b/src/io/weights_loader.ts
@@ -58,12 +58,11 @@ export async function loadWeightsAsArrayBuffer(
   const fetchStartFraction = 0;
   const fetchEndFraction = 0.5;
 
-  if (onProgress != null) {
-    util.monitorPromisesProgress(
-        requests, onProgress, fetchStartFraction, fetchEndFraction);
-  }
+  const responses = onProgress == null ?
+      await Promise.all(requests) :
+      await util.monitorPromisesProgress(
+          requests, onProgress, fetchStartFraction, fetchEndFraction);
 
-  const responses = await Promise.all(requests);
   const badContentType = responses.filter(response => {
     const contentType = response.headers.get(CONTENT_TYPE);
     return !contentType || contentType.indexOf(OCTET_STREAM_TYPE) === -1;
@@ -82,12 +81,10 @@ export async function loadWeightsAsArrayBuffer(
   const bufferStartFraction = 0.5;
   const bufferEndFraction = 1;
 
-  if (onProgress != null) {
-    util.monitorPromisesProgress(
-        bufferPromises, onProgress, bufferStartFraction, bufferEndFraction);
-  }
-
-  const buffers = await Promise.all(bufferPromises);
+  const buffers = onProgress == null ?
+      await Promise.all(bufferPromises) :
+      await util.monitorPromisesProgress(
+          bufferPromises, onProgress, bufferStartFraction, bufferEndFraction);
   return buffers;
 }
 

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -216,9 +216,9 @@ function getFloatTextureSetRGBASnippet(glsl: GLSL): string {
 }
 
 function getShaderPrefix(glsl: GLSL): string {
-  let NAN_CHECKS = '';
+  let nanChecks = '';
   if (ENV.get('PROD')) {
-    NAN_CHECKS = `
+    nanChecks = `
       bool isNaN(float val) {
         return false;
       }
@@ -232,7 +232,7 @@ function getShaderPrefix(glsl: GLSL): string {
      * Previous NaN check '(val < 0.0 || 0.0 < val || val == 0.0) ? false :
      * true' does not work on iOS 12
      */
-    NAN_CHECKS = `
+    nanChecks = `
       bool isNaN(float val) {
         return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
       }
@@ -275,7 +275,7 @@ function getShaderPrefix(glsl: GLSL): string {
       int v;
     };
 
-    ${NAN_CHECKS}
+    ${nanChecks}
 
     float getNaN(vec4 values) {
       return dot(vec4(1), values);

--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -115,6 +115,8 @@ export class AdadeltaOptimizer extends Optimizer {
       epsilon: this.epsilon
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(config.learningRate, config.rho, config.epsilon);

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -82,6 +82,8 @@ export class AdagradOptimizer extends Optimizer {
       initialAccumulatorValue: this.initialAccumulatorValue,
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(config.learningRate, config.initialAccumulatorValue);

--- a/src/optimizers/adam_optimizer.ts
+++ b/src/optimizers/adam_optimizer.ts
@@ -139,6 +139,8 @@ export class AdamOptimizer extends Optimizer {
       epsilon: this.epsilon,
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(

--- a/src/optimizers/adamax_optimizer.ts
+++ b/src/optimizers/adamax_optimizer.ts
@@ -146,6 +146,8 @@ export class AdamaxOptimizer extends Optimizer {
       decay: this.decay
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -93,6 +93,8 @@ export class MomentumOptimizer extends SGDOptimizer {
       useNesterov: this.useNesterov
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(config.learningRate, config.momentum, config.useNesterov);

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -165,6 +165,8 @@ export class RMSPropOptimizer extends Optimizer {
       centered: this.centered
     };
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -65,6 +65,8 @@ export class SGDOptimizer extends Optimizer {
   getConfig(): ConfigDict {
     return {learningRate: this.learningRate};
   }
+
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(config.learningRate);

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -32,12 +32,12 @@ import {assert} from './util';
  * convertTsToPythonic from serialization_utils in -Layers.
  *
  */
-export type ConfigDictValue =
-    boolean|number|string|null|ConfigDictArray|ConfigDict;
-export interface ConfigDict {
+export declare type ConfigDictValue =
+    boolean | number | string | null | ConfigDictArray | ConfigDict;
+export declare interface ConfigDict {
   [key: string]: ConfigDictValue;
 }
-export interface ConfigDictArray extends Array<ConfigDictValue> {}
+export declare interface ConfigDictArray extends Array<ConfigDictValue> {}
 
 /**
  * Type to represent the class-type of Serializable objects.
@@ -47,11 +47,11 @@ export interface ConfigDictArray extends Array<ConfigDictValue> {}
  *
  * Source for this idea: https://stackoverflow.com/a/43607255
  */
-export type SerializableConstructor<T extends Serializable> = {
+export declare type SerializableConstructor<T extends Serializable> = {
   // tslint:disable-next-line:no-any
   new (...args: any[]): T; className: string; fromConfig: FromConfigMethod<T>;
 };
-export type FromConfigMethod<T extends Serializable> =
+export declare type FromConfigMethod<T extends Serializable> =
     (cls: SerializableConstructor<T>, config: ConfigDict) => T;
 
 /**

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -90,6 +90,7 @@ export abstract class Serializable {
    * @param cls A Constructor for the class to instantiate.
    * @param config The Configuration for the object.
    */
+  /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(config);

--- a/src/util.ts
+++ b/src/util.ts
@@ -607,8 +607,8 @@ export function now(): number {
  * @param endFraction Optional fraction end. Default to 1.
  */
 export function monitorPromisesProgress(
-    promises: Array<Promise<{}>>, onProgress: Function, startFraction?: number,
-    endFraction?: number): void {
+    promises: Array<Promise<{}|void>>, onProgress: Function,
+    startFraction?: number, endFraction?: number) {
   checkPromises(promises);
   startFraction = startFraction == null ? 0 : startFraction;
   endFraction = endFraction == null ? 1 : endFraction;
@@ -626,7 +626,7 @@ export function monitorPromisesProgress(
     return promise;
   }
 
-  function checkPromises(promises: Array<Promise<{}>>): void {
+  function checkPromises(promises: Array<Promise<{}|void>>): void {
     assert(
         promises != null && Array.isArray(promises) && promises.length > 0,
         'promises must be a none empty array');
@@ -648,5 +648,5 @@ export function monitorPromisesProgress(
                 endFraction}`);
   }
 
-  promises.forEach(registerMonitor);
+  return Promise.all(promises.map(registerMonitor));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -601,26 +601,24 @@ export function now(): number {
 /**
  * Monitor Promise.all progress, fire onProgress callback function.
  *
- * @param {Array<Promise<D | Function | {} | void>>} promises,
- *    Promise list going to be monitored
- * @param {Function} onProgress, callback function.
- *    Fired when a promise resolved.
- * @param {number} startFraction, Optional fraction start. Default to 0.
- * @param {number} endFraction, Optional fraction end. Default to 1.
+ * @param promises Promise list going to be monitored
+ * @param onProgress Callback function. Fired when a promise resolved.
+ * @param startFraction Optional fraction start. Default to 0.
+ * @param endFraction Optional fraction end. Default to 1.
  */
-export function monitorPromisesProgress<D extends DataType>(
-    promises: Array<Promise<D | Function | {} | void>>, onProgress: Function,
-    startFraction?: number, endFraction?: number) {
+export function monitorPromisesProgress(
+    promises: Array<Promise<{}>>, onProgress: Function, startFraction?: number,
+    endFraction?: number): void {
   checkPromises(promises);
   startFraction = startFraction == null ? 0 : startFraction;
   endFraction = endFraction == null ? 1 : endFraction;
   checkFraction(startFraction, endFraction);
   let resolvedPromise = 0;
 
-  function registerMonitor(promise: Promise<D | Function | {} | void>) {
-    promise.then((value: D | Function | {} | void) => {
-      const fraction = startFraction + ++resolvedPromise / promises.length *
-          (endFraction - startFraction);
+  function registerMonitor(promise: Promise<{}>) {
+    promise.then(value => {
+      const fraction = startFraction +
+          ++resolvedPromise / promises.length * (endFraction - startFraction);
       // pass fraction as parameter to callback function.
       onProgress(fraction);
       return value;
@@ -628,31 +626,27 @@ export function monitorPromisesProgress<D extends DataType>(
     return promise;
   }
 
-  function checkPromises(
-      promises: Array<Promise<D | Function | {} | void>>): void {
+  function checkPromises(promises: Array<Promise<{}>>): void {
     assert(
         promises != null && Array.isArray(promises) && promises.length > 0,
-        'promises must be a none empty array'
-    );
+        'promises must be a none empty array');
   }
 
   function checkFraction(startFraction: number, endFraction: number): void {
     assert(
         startFraction >= 0 && startFraction <= 1,
         `Progress fraction must be in range [0, 1], but ` +
-        `got startFraction ${startFraction}`
-    );
+            `got startFraction ${startFraction}`);
     assert(
         endFraction >= 0 && endFraction <= 1,
         `Progress fraction must be in range [0, 1], but ` +
-        `got endFraction ${endFraction}`
-    );
+            `got endFraction ${endFraction}`);
     assert(
         endFraction >= startFraction,
         `startFraction must be no more than endFraction, but ` +
-        `got startFraction ${startFraction} and endFraction ${endFraction}`
-    );
+            `got startFraction ${startFraction} and endFraction ${
+                endFraction}`);
   }
 
-  return Promise.all(promises.map(registerMonitor));
+  promises.forEach(registerMonitor);
 }

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -15,9 +15,9 @@
  * =============================================================================
  */
 
+import {scalar, tensor2d} from './ops/ops';
 import {inferShape} from './tensor_util_env';
 import * as util from './util';
-import {scalar, tensor2d} from './ops/ops';
 
 describe('Util', () => {
   it('Correctly gets size from shape', () => {
@@ -76,8 +76,7 @@ describe('Util', () => {
 
   it('infer shape 4d array', () => {
     const a = [
-      [[[1], [2]], [[2], [3]], [[5], [6]]],
-      [[[5], [6]], [[4], [5]], [[1], [2]]]
+      [[[1], [2]], [[2], [3]], [[5], [6]]], [[[5], [6]], [[4], [5]], [[1], [2]]]
     ];
     expect(inferShape(a)).toEqual([2, 3, 2, 1]);
   });
@@ -459,20 +458,21 @@ describe('util.hasEncodingLoss', () => {
 describe('util.toNestedArray', () => {
   it('2 dimensions', () => {
     const a = new Float32Array([1, 2, 3, 4, 5, 6]);
-    expect(util.toNestedArray([2, 3], a))
-      .toEqual([[1,2,3], [4,5,6]]);
+    expect(util.toNestedArray([2, 3], a)).toEqual([[1, 2, 3], [4, 5, 6]]);
   });
 
   it('3 dimensions (2x2x3)', () => {
     const a = new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-    expect(util.toNestedArray([2, 2, 3], a))
-      .toEqual([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]]);
+    expect(util.toNestedArray([2, 2, 3], a)).toEqual([
+      [[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]
+    ]);
   });
 
   it('3 dimensions (3x2x2)', () => {
     const a = new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-    expect(util.toNestedArray([3, 2, 2], a))
-      .toEqual([[[0, 1],[2, 3]],[[4, 5],[6, 7]],[[8, 9],[10, 11]]]);
+    expect(util.toNestedArray([3, 2, 2], a)).toEqual([
+      [[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]]
+    ]);
   });
 
   it('invalid dimension', () => {
@@ -482,8 +482,7 @@ describe('util.toNestedArray', () => {
 
   it('tensor to nested array', () => {
     const x = tensor2d([1, 2, 3, 4], [2, 2]);
-    expect(util.toNestedArray(x.shape, x.dataSync()))
-      .toEqual([[1, 2], [3, 4]]);
+    expect(util.toNestedArray(x.shape, x.dataSync())).toEqual([[1, 2], [3, 4]]);
   });
 
   it('scalar to nested array', () => {
@@ -501,12 +500,12 @@ describe('util.monitorPromisesProgress', () => {
   it('Default progress from 0 to 1', (done) => {
     const expectFractions: number[] = [0.25, 0.50, 0.75, 1.00];
     const fractionList: number[] = [];
-    const tasks = Array(4).fill(0).map(()=>{
+    const tasks = Array(4).fill(0).map(() => {
       return Promise.resolve();
     });
-    util.monitorPromisesProgress(tasks, (progress: number)=>{
-      fractionList.push(parseFloat(progress.toFixed(2)));
-    }).then(()=>{
+    util.monitorPromisesProgress(tasks, (progress: number) => {
+          fractionList.push(parseFloat(progress.toFixed(2)));
+        }).then(() => {
       expect(fractionList).toEqual(expectFractions);
       done();
     });
@@ -517,12 +516,12 @@ describe('util.monitorPromisesProgress', () => {
     const endFraction = 0.8;
     const expectFractions: number[] = [0.35, 0.50, 0.65, 0.80];
     const fractionList: number[] = [];
-    const tasks = Array(4).fill(0).map(()=>{
+    const tasks = Array(4).fill(0).map(() => {
       return Promise.resolve();
     });
-    util.monitorPromisesProgress(tasks, (progress: number)=>{
-      fractionList.push(parseFloat(progress.toFixed(2)));
-      }, startFraction, endFraction).then(()=>{
+    util.monitorPromisesProgress(tasks, (progress: number) => {
+          fractionList.push(parseFloat(progress.toFixed(2)));
+        }, startFraction, endFraction).then(() => {
       expect(fractionList).toEqual(expectFractions);
       done();
     });
@@ -532,11 +531,11 @@ describe('util.monitorPromisesProgress', () => {
     expect(() => {
       const startFraction = -1;
       const endFraction = 1;
-      const tasks = Array(4).fill(0).map(()=>{
+      const tasks = Array(4).fill(0).map(() => {
         return Promise.resolve();
       });
-      util.monitorPromisesProgress(tasks, (progress: number)=>{},
-          startFraction, endFraction);
+      util.monitorPromisesProgress(
+          tasks, (progress: number) => {}, startFraction, endFraction);
     }).toThrowError();
   });
 
@@ -544,23 +543,23 @@ describe('util.monitorPromisesProgress', () => {
     expect(() => {
       const startFraction = 0.8;
       const endFraction = 0.2;
-      const tasks = Array(4).fill(0).map(()=>{
+      const tasks = Array(4).fill(0).map(() => {
         return Promise.resolve();
       });
-      util.monitorPromisesProgress(tasks, (progress: number)=>{},
-          startFraction, endFraction);
+      util.monitorPromisesProgress(
+          tasks, (progress: number) => {}, startFraction, endFraction);
     }).toThrowError();
   });
 
   it('throws error when promises is null', () => {
     expect(() => {
-      util.monitorPromisesProgress(null, (progress: number)=>{});
+      util.monitorPromisesProgress(null, (progress: number) => {});
     }).toThrowError();
   });
 
   it('throws error when promises is empty array', () => {
     expect(() => {
-      util.monitorPromisesProgress([], (progress: number)=>{});
+      util.monitorPromisesProgress([], (progress: number) => {});
     }).toThrowError();
   });
 });


### PR DESCRIPTION
- Add `/** @nocollapse */` on static properties to tell closure not to remove them.
- Prepend `declare` in front of interfaces and types that are external (used in json deserialization/serialization) so closure doesn't rename its properties.
- Fix issues where the promise was unused.

Similar changes in tfjs-layers: https://github.com/tensorflow/tfjs-layers/pull/442

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1521)
<!-- Reviewable:end -->
