### PR TITLE
implement isNaN, isInf, isFinite

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -275,6 +275,16 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
     throw new Error('Not yet implemented');
   }
 
+  isNaN<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  isInf<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+  isFinite<T extends Tensor>(x: T): T {
+    throw new Error('Not yet implemented');
+  }
+
   pow<T extends Tensor>(a: T, b: Tensor): T {
     throw new Error('Not yet implemented');
   }

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -976,39 +976,39 @@ export class MathBackendCPU implements KernelBackend {
     this.assertNotComplex(x, 'x');
 
     const values = x.dataSync();
-    const newValues = new Float32Array(values.length);
+    const newValues = new Uint8Array(values.length);
     for (let i = 0; i < values.length; ++i) {
       if (Number.isNaN(values[i])) {
         newValues[i] = 1;
       }
     }
-    return Tensor.make(x.shape, {values: newValues}) as T;
+    return Tensor.make(x.shape, {values: newValues}, 'bool') as T;
   }
 
   isInf<T extends Tensor>(x: T): T {
     this.assertNotComplex(x, 'x');
 
     const values = x.dataSync();
-    const newValues = new Float32Array(values.length);
+    const newValues = new Uint8Array(values.length);
     for (let i = 0; i < values.length; ++i) {
       if (Math.abs(values[i]) === Infinity) {
         newValues[i] = 1;
       }
     }
-    return Tensor.make(x.shape, {values: newValues}) as T;
+    return Tensor.make(x.shape, {values: newValues}, 'bool') as T;
   }
 
   isFinite<T extends Tensor>(x: T): T {
     this.assertNotComplex(x, 'x');
 
     const values = x.dataSync();
-    const newValues = new Float32Array(values.length);
+    const newValues = new Uint8Array(values.length);
     for (let i = 0; i < values.length; ++i) {
       if (Number.isFinite(values[i])) {
         newValues[i] = 1;
       }
     }
-    return Tensor.make(x.shape, {values: newValues}) as T;
+    return Tensor.make(x.shape, {values: newValues}, 'bool') as T;
   }
 
   round<T extends Tensor>(x: T): T {
@@ -3370,7 +3370,7 @@ export class MathBackendCPU implements KernelBackend {
   }
 
   fill<R extends Rank>(
-    shape: ShapeMap[R], value: number|string, dtype?: DataType): Tensor<R> {
+      shape: ShapeMap[R], value: number|string, dtype?: DataType): Tensor<R> {
     dtype = dtype || inferDtype(value);
     const values = getArrayFromDType(dtype, sizeFromShape(shape)) as TypedArray;
     values.fill(value as number);

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -972,6 +972,45 @@ export class MathBackendCPU implements KernelBackend {
     return Tensor.make(x.shape, {values: newValues}) as T;
   }
 
+  isNaN<T extends Tensor>(x: T): T {
+    this.assertNotComplex(x, 'x');
+
+    const values = x.dataSync();
+    const newValues = new Float32Array(values.length);
+    for (let i = 0; i < values.length; ++i) {
+      if (Number.isNaN(values[i])) {
+        newValues[i] = 1;
+      }
+    }
+    return Tensor.make(x.shape, {values: newValues}) as T;
+  }
+
+  isInf<T extends Tensor>(x: T): T {
+    this.assertNotComplex(x, 'x');
+
+    const values = x.dataSync();
+    const newValues = new Float32Array(values.length);
+    for (let i = 0; i < values.length; ++i) {
+      if (Math.abs(values[i]) === Infinity) {
+        newValues[i] = 1;
+      }
+    }
+    return Tensor.make(x.shape, {values: newValues}) as T;
+  }
+
+  isFinite<T extends Tensor>(x: T): T {
+    this.assertNotComplex(x, 'x');
+
+    const values = x.dataSync();
+    const newValues = new Float32Array(values.length);
+    for (let i = 0; i < values.length; ++i) {
+      if (Number.isFinite(values[i])) {
+        newValues[i] = 1;
+      }
+    }
+    return Tensor.make(x.shape, {values: newValues}) as T;
+  }
+
   round<T extends Tensor>(x: T): T {
     this.assertNotComplex(x, 'round');
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1496,31 +1496,19 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   isNaN<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram|UnaryOpPackedProgram;
-    if (ENV.get('WEBGL_PACK')) {
-      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_NAN);
-    } else {
-      program = new UnaryOpProgram(x.shape, unary_op.IS_NAN);
-    }
-    return this.compileAndRun(program, [x]) as T;
+    const program = new UnaryOpProgram(x.shape, unary_op.IS_NAN);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [x], output) as T;
   }
   isInf<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram|UnaryOpPackedProgram;
-    if (ENV.get('WEBGL_PACK')) {
-      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_INF);
-    } else {
-      program = new UnaryOpProgram(x.shape, unary_op.IS_INF);
-    }
-    return this.compileAndRun(program, [x]) as T;
+    const program = new UnaryOpProgram(x.shape, unary_op.IS_INF);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [x], output) as T;
   }
   isFinite<T extends Tensor>(x: T): T {
-    let program: UnaryOpProgram|UnaryOpPackedProgram;
-    if (ENV.get('WEBGL_PACK')) {
-      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_FINITE);
-    } else {
-      program = new UnaryOpProgram(x.shape, unary_op.IS_FINITE);
-    }
-    return this.compileAndRun(program, [x]) as T;
+    const program = new UnaryOpProgram(x.shape, unary_op.IS_FINITE);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [x], output) as T;
   }
 
   round<T extends Tensor>(x: T): T {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1290,16 +1290,14 @@ export class MathBackendWebGL implements KernelBackend {
     const program = ENV.get('WEBGL_PACK_BINARY_OPERATIONS') ?
         new BinaryOpPackedProgram(binaryop_packed_gpu.MIN, a.shape, b.shape) :
         new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [a, b], null, customSetup);
+    return this.compileAndRun(program, [a, b]);
   }
 
   mod(a: Tensor, b: Tensor): Tensor {
     const program = ENV.get('WEBGL_PACK_BINARY_OPERATIONS') ?
         new BinaryOpPackedProgram(binaryop_packed_gpu.MOD, a.shape, b.shape) :
         new BinaryOpProgram(binaryop_gpu.MOD, a.shape, b.shape);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [a, b], null, customSetup);
+    return this.compileAndRun(program, [a, b]);
   }
 
   max(x: Tensor, axes: number[]): Tensor {
@@ -1323,8 +1321,7 @@ export class MathBackendWebGL implements KernelBackend {
     const program = ENV.get('WEBGL_PACK_BINARY_OPERATIONS') ?
         new BinaryOpPackedProgram(binaryop_packed_gpu.MAX, a.shape, b.shape) :
         new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [a, b], null, customSetup);
+    return this.compileAndRun(program, [a, b]);
   }
 
   all(x: Tensor, axes: number[]): Tensor {
@@ -1480,8 +1477,7 @@ export class MathBackendWebGL implements KernelBackend {
     const output = usePackedOp ?
         this.makePackedTensor(program.outputShape, dtype) as T :
         this.makeOutputArray(program.outputShape, dtype) as T;
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun<T>(program, [a, b], output, customSetup);
+    return this.compileAndRun<T>(program, [a, b], output);
   }
 
   ceil<T extends Tensor>(x: T): T {
@@ -1496,6 +1492,34 @@ export class MathBackendWebGL implements KernelBackend {
 
   sign<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.SIGN);
+    return this.compileAndRun(program, [x]) as T;
+  }
+
+  isNaN<T extends Tensor>(x: T): T {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
+      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_NAN);
+    } else {
+      program = new UnaryOpProgram(x.shape, unary_op.IS_NAN);
+    }
+    return this.compileAndRun(program, [x]) as T;
+  }
+  isInf<T extends Tensor>(x: T): T {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
+      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_INF);
+    } else {
+      program = new UnaryOpProgram(x.shape, unary_op.IS_INF);
+    }
+    return this.compileAndRun(program, [x]) as T;
+  }
+  isFinite<T extends Tensor>(x: T): T {
+    let program: UnaryOpProgram|UnaryOpPackedProgram;
+    if (ENV.get('WEBGL_PACK')) {
+      program = new UnaryOpPackedProgram(x.shape, unary_packed_op.IS_FINITE);
+    } else {
+      program = new UnaryOpProgram(x.shape, unary_op.IS_FINITE);
+    }
     return this.compileAndRun(program, [x]) as T;
   }
 
@@ -1526,8 +1550,7 @@ export class MathBackendWebGL implements KernelBackend {
     } else {
       program = new UnaryOpProgram(x.shape, unary_op.LOG);
     }
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [x], null, customSetup) as T;
+    return this.compileAndRun(program, [x]) as T;
   }
 
   log1p<T extends Tensor>(x: T): T {
@@ -1672,8 +1695,7 @@ export class MathBackendWebGL implements KernelBackend {
     const program = ENV.get('WEBGL_PACK_BINARY_OPERATIONS') ?
         new BinaryOpPackedProgram(binaryop_packed_gpu.ATAN2, a.shape, b.shape) :
         new BinaryOpProgram(binaryop_gpu.ATAN2, a.shape, b.shape);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [a, b], null, customSetup) as T;
+    return this.compileAndRun(program, [a, b]) as T;
   }
 
   sinh<T extends Tensor>(x: T): T {
@@ -1698,14 +1720,12 @@ export class MathBackendWebGL implements KernelBackend {
 
   acosh<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.ACOSH);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [x], null, customSetup) as T;
+    return this.compileAndRun(program, [x]) as T;
   }
 
   atanh<T extends Tensor>(x: T): T {
     const program = new UnaryOpProgram(x.shape, unary_op.ATANH);
-    const customSetup = program.getCustomSetupFunc();
-    return this.compileAndRun(program, [x], null, customSetup) as T;
+    return this.compileAndRun(program, [x]) as T;
   }
 
   erf<T extends Tensor>(x: T): T {

--- a/src/kernels/webgl/argminmax_packed_gpu.ts
+++ b/src/kernels/webgl/argminmax_packed_gpu.ts
@@ -127,7 +127,7 @@ export class ArgMinMaxPackedProgram implements GPGPUProgram {
           inIdx = srcIdx;
           ${fetchCandidateIdx}
           vec4 candidate = ${fetchValue};
-          bvec4 nan = isNaN(candidate);
+          bvec4 nan = isnan(candidate);
           bvec4 replace = bvec4(
             vec4(${compOp}(candidate, bestValue)) * (vec4(1.0) - vec4(nan)));
 

--- a/src/kernels/webgl/clip_gpu.ts
+++ b/src/kernels/webgl/clip_gpu.ts
@@ -35,7 +35,7 @@ export class ClipProgram implements GPGPUProgram {
 
       void main() {
         float value = getAAtOutCoords();
-        if (isNaN(value)) {
+        if (isnan(value)) {
           setOutput(value);
           return;
         }

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -37,7 +37,7 @@ export class ClipPackedProgram implements GPGPUProgram {
       void main() {
         vec4 value = getAAtOutCoords();
 
-        if (hasNaN(value)) {
+        if (any(isnan(value))) {
           setOutput(value);
           return;
         }

--- a/src/kernels/webgl/encode_float_gpu.ts
+++ b/src/kernels/webgl/encode_float_gpu.ts
@@ -31,7 +31,7 @@ export class EncodeFloatProgram implements GPGPUProgram {
       const float FLOAT_MIN = 1.17549435e-38;
 
       lowp vec4 encode_float(highp float v) {
-        if (isNaN(v)) {
+        if (isnan(v)) {
           return vec4(255, 255, 255, 255);
         }
 

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -81,12 +81,7 @@ export function getGlslDifferences(): GLSL {
         return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
       }
       bvec4 isnan(vec4 val) {
-        return equal(
-          ivec4(lessThan(val, vec4(1.0))) +
-            ivec4(lessThan(vec4(0.0), val)) +
-            ivec4(equal(val, vec4(0.0))),
-          ivec4(0)
-        );
+        return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
       }
     `;
     defineSpecialInf = `

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -25,6 +25,8 @@ export type GLSL = {
   texture2D: string,
   output: string,
   defineOutput: string,
+  defineSpecialNaN: string,
+  defineSpecialInf: string,
   defineRound: string
 };
 
@@ -36,6 +38,8 @@ export function getGlslDifferences(): GLSL {
   let texture2D: string;
   let output: string;
   let defineOutput: string;
+  let defineSpecialNaN: string;
+  let defineSpecialInf: string;
   let defineRound: string;
 
   if (ENV.get('WEBGL_VERSION') === 2) {
@@ -46,6 +50,12 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture';
     output = 'outputColor';
     defineOutput = 'out vec4 outputColor;';
+    defineSpecialNaN = `
+      const float NAN = uintBitsToFloat(uint(0x7fc00000));
+    `;
+    defineSpecialInf = `
+      const float INFINITY = uintBitsToFloat(uint(0x7f800000));
+    `;
     defineRound = `
       #define round(value) newRound(value)
       int newRound(float value) {
@@ -64,6 +74,31 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture2D';
     output = 'gl_FragColor';
     defineOutput = '';
+    defineSpecialNaN = `
+      uniform float NAN;
+
+      bool isnan(float val) {
+        return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
+      }
+      bvec4 isnan(vec4 val) {
+        return equal(
+          ivec4(lessThan(val, vec4(1.0))) +
+            ivec4(lessThan(vec4(0.0), val)) +
+            ivec4(equal(val, vec4(0.0))),
+          ivec4(0)
+        );
+      }
+    `;
+    defineSpecialInf = `
+      uniform float INFINITY;
+
+      bool isinf(float val) {
+        return abs(val) == INFINITY;
+      }
+      bvec4 isinf(vec4 val) {
+        return equal(abs(val), vec4(INFINITY));
+      }
+    `;
     defineRound = `
       int round(float value) {
         return int(floor(value + 0.5));
@@ -83,6 +118,8 @@ export function getGlslDifferences(): GLSL {
     texture2D,
     output,
     defineOutput,
+    defineSpecialNaN,
+    defineSpecialInf,
     defineRound
   };
 }

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -155,7 +155,7 @@ export function runProgram<T extends Tensor, K extends Tensor>(
   gpgpu.setProgram(binary.webGLProgram);
 
   // Set special uniforms (NAN, INFINITY)
-  if (ENV.get('WEBGL_VERSION') !== 2) {
+  if (ENV.get('WEBGL_VERSION') === 1) {
     const infLoc =
         gpgpu.getUniformLocation(binary.webGLProgram, 'INFINITY', false);
     if (infLoc !== null) {

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from '../../environment';
 import {Tensor} from '../../tensor';
 import {TypedArray} from '../../types';
 import * as util from '../../util';
@@ -83,6 +84,7 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
   const webGLProgram = gpgpu.createProgram(source);
 
   const uniformLocations: {[name: string]: WebGLUniformLocation} = {};
+  // Add user-defined uniforms
   for (let i = 0; i < program.variableNames.length; i++) {
     const varName = program.variableNames[i];
     const shouldThrow = false;
@@ -151,6 +153,22 @@ export function runProgram<T extends Tensor, K extends Tensor>(
     gpgpu.setOutputMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
   }
   gpgpu.setProgram(binary.webGLProgram);
+
+  // Set special uniforms (NAN, INFINITY)
+  if (ENV.get('WEBGL_VERSION') !== 2) {
+    const infLoc =
+        gpgpu.getUniformLocation(binary.webGLProgram, 'INFINITY', false);
+    if (infLoc !== null) {
+      gpgpu.gl.uniform1f(infLoc, Infinity);
+    }
+
+    const nanLoc = gpgpu.getUniformLocation(binary.webGLProgram, 'NAN', false);
+    if (nanLoc !== null) {
+      gpgpu.gl.uniform1f(nanLoc, NaN);
+    }
+  }
+
+  // Set user-defined inputs
   inputs.forEach((input, i) => {
     const varName = binary.program.variableNames[i];
     const varLoc = binary.uniformLocations[varName];

--- a/src/kernels/webgl/unaryop_gpu.ts
+++ b/src/kernels/webgl/unaryop_gpu.ts
@@ -18,7 +18,6 @@
 import * as erf_util from '../../ops/erf_util';
 import * as selu_util from '../../ops/selu_util';
 
-import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class UnaryOpProgram implements GPGPUProgram {
@@ -26,13 +25,9 @@ export class UnaryOpProgram implements GPGPUProgram {
   userCode: string;
   outputShape: number[];
 
-  // Caching uniform location for speed.
-  startLoc: WebGLUniformLocation;
-
   constructor(aShape: number[], opSnippet: string) {
     this.outputShape = aShape;
     this.userCode = `
-      uniform float NAN;
       float unaryOperation(float x) {
         ${opSnippet}
       }
@@ -45,23 +40,9 @@ export class UnaryOpProgram implements GPGPUProgram {
       }
     `;
   }
-
-  getCustomSetupFunc() {
-    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.startLoc == null) {
-        this.startLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'NAN');
-        if (this.startLoc == null) {
-          // This means the compiler has optimized and realized it doesn't need
-          // the uniform.
-          return;
-        }
-      }
-      gpgpu.gl.uniform1f(this.startLoc, NaN);
-    };
-  }
 }
 
-const CHECK_NAN_SNIPPET = `if (isNaN(x)) return x;`;
+const CHECK_NAN_SNIPPET = `if (isnan(x)) return x;`;
 
 export const LINEAR = `return x;`;
 
@@ -94,9 +75,15 @@ export const CEIL = `return ceil(x);`;
 export const FLOOR = `return floor(x);`;
 
 export const SIGN = `
-  if (isNaN(x)) { return 0.0; }
+  if (isnan(x)) { return 0.0; }
   return sign(x);
 `;
+
+export const IS_NAN = `return float(isnan(x));`;
+
+export const IS_INF = `return float(isinf(x));`;
+
+export const IS_FINITE = `return float(!isnan(x) && !isinf(x));`;
 
 export const ROUND = `
   // OpenGL ES does not support round function.

--- a/src/kernels/webgl/unaryop_packed_gpu.ts
+++ b/src/kernels/webgl/unaryop_packed_gpu.ts
@@ -42,12 +42,6 @@ export const RELU = `
   return result;
 `;
 
-export const IS_NAN = `return vec4(isnan(x));`;
-
-export const IS_INF = `return vec4(isinf(x));`;
-
-export const IS_FINITE = `return vec4(not(isnan(x))) * vec4(not(isinf(x)));`;
-
 export class UnaryOpPackedProgram implements GPGPUProgram {
   variableNames = ['A'];
   userCode: string;

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -109,6 +109,73 @@ function sign_<T extends Tensor>(x: T|TensorLike): T {
 }
 
 /**
+ * Returns an element-wise indication that is 1 if the value is NaN.
+ *
+ * ```js
+ * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+ *
+ * x.isNaN().print();  // or tf.isNaN(x)
+ * ```
+ * @param x The input Tensor.
+ */
+/** @doc {heading: 'Operations', subheading: 'Basic math'} */
+function isNaN_<T extends Tensor>(x: T|TensorLike): T {
+  const $x = convertToTensor(x, 'x', 'isNaN');
+
+  // TODO(nsthorat): Let gradients be null for cases where we want to stop
+  // backpropgation.
+  const grad = (dy: T) => {
+    return {$x: () => zerosLike(dy)};
+  };
+  return ENV.engine.runKernel(backend => backend.isNaN($x), {$x}, grad);
+}
+
+/**
+ * Returns an element-wise indication that is 1 if the value is Infinity
+ * or -Infinity.
+ *
+ * ```js
+ * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+ *
+ * x.isInf().print();  // or tf.isNaN(x)
+ * ```
+ * @param x The input Tensor.
+ */
+/** @doc {heading: 'Operations', subheading: 'Basic math'} */
+function isInf_<T extends Tensor>(x: T|TensorLike): T {
+  const $x = convertToTensor(x, 'x', 'isInf');
+
+  // TODO(nsthorat): Let gradients be null for cases where we want to stop
+  // backpropgation.
+  const grad = (dy: T) => {
+    return {$x: () => zerosLike(dy)};
+  };
+  return ENV.engine.runKernel(backend => backend.isInf($x), {$x}, grad);
+}
+
+/**
+ * Returns an element-wise indication that is 1 if the value is finite.
+ *
+ * ```js
+ * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+ *
+ * x.isFinite().print();  // or tf.isNaN(x)
+ * ```
+ * @param x The input Tensor.
+ */
+/** @doc {heading: 'Operations', subheading: 'Basic math'} */
+function isFinite_<T extends Tensor>(x: T|TensorLike): T {
+  const $x = convertToTensor(x, 'x', 'isFinite');
+
+  // TODO(nsthorat): Let gradients be null for cases where we want to stop
+  // backpropgation.
+  const grad = (dy: T) => {
+    return {$x: () => zerosLike(dy)};
+  };
+  return ENV.engine.runKernel(backend => backend.isFinite($x), {$x}, grad);
+}
+
+/**
  * Computes round of input `tf.Tensor` element-wise: `round(x)`.
  * It implements banker's rounding.
  *
@@ -865,6 +932,9 @@ export const round = op({round_});
 export const rsqrt = op({rsqrt_});
 export const sigmoid = op({sigmoid_});
 export const sign = op({sign_});
+export const isNaN = op({isNaN_});
+export const isInf = op({isInf_});
+export const isFinite = op({isFinite_});
 export const sin = op({sin_});
 export const sinh = op({sinh_});
 export const softplus = op({softplus_});

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -109,7 +109,7 @@ function sign_<T extends Tensor>(x: T|TensorLike): T {
 }
 
 /**
- * Returns an element-wise indication that is 1 if the value is NaN.
+ * RReturns which elements of x are NaN.
  *
  * ```js
  * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
@@ -131,8 +131,7 @@ function isNaN_<T extends Tensor>(x: T|TensorLike): T {
 }
 
 /**
- * Returns an element-wise indication that is 1 if the value is Infinity
- * or -Infinity.
+ * Returns which elements of x are Infinity or -Infinity.
  *
  * ```js
  * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
@@ -154,7 +153,7 @@ function isInf_<T extends Tensor>(x: T|TensorLike): T {
 }
 
 /**
- * Returns an element-wise indication that is 1 if the value is finite.
+ * Returns which elements of x are finite.
  *
  * ```js
  * const x = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -1574,6 +1574,7 @@ describeWithFlags('isNaN', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
     const r = tf.isNaN(a);
+    expect(r.dtype).toEqual('bool');
     expectArraysClose(r, [1, 0, 0, 0, 0]);
   });
 
@@ -1630,6 +1631,7 @@ describeWithFlags('isInf', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
     const r = tf.isInf(a);
+    expect(r.dtype).toEqual('bool');
     expectArraysClose(r, [0, 1, 1, 0, 0]);
   });
 
@@ -1686,6 +1688,7 @@ describeWithFlags('isFinite', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
     const r = tf.isFinite(a);
+    expect(r.dtype).toEqual('bool');
     expectArraysClose(r, [0, 0, 0, 1, 1]);
   });
 

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -1570,6 +1570,174 @@ describeWithFlags('sign', ALL_ENVS, () => {
   });
 });
 
+describeWithFlags('isNaN', ALL_ENVS, () => {
+  it('basic', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const r = tf.isNaN(a);
+    expectArraysClose(r, [1, 0, 0, 0, 0]);
+  });
+
+  it('gradients: Scalar', () => {
+    const a = tf.scalar(NaN);
+    const dy = tf.scalar(3);
+
+    const gradients = tf.grad(a => tf.isNaN(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0]);
+  });
+
+  it('gradients: Tensor1D', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const dy = tf.tensor1d([1, 1, 1, 1, 1]);
+
+    const gradients = tf.grad(a => tf.isNaN(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0, 0]);
+  });
+
+  it('gradients: Tensor2D', () => {
+    const a = tf.tensor2d([NaN, Infinity, -Infinity, 0], [2, 2]);
+    const dy = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+
+    const gradients = tf.grad(a => tf.isNaN(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0]);
+  });
+
+  it('throws when passed a non-tensor', () => {
+    expect(() => tf.isNaN({} as tf.Tensor))
+        .toThrowError(/Argument 'x' passed to 'isNaN' must be a Tensor/);
+  });
+
+  it('accepts a tensor-like object', () => {
+    const r = tf.isNaN([NaN, Infinity, -Infinity, 0, 1]);
+    expectArraysClose(r, [1, 0, 0, 0, 0]);
+  });
+
+  it('throws for string tensor', () => {
+    expect(() => tf.isNaN('q'))
+        .toThrowError(/Argument 'x' passed to 'isNaN' must be numeric/);
+  });
+});
+
+describeWithFlags('isInf', ALL_ENVS, () => {
+  it('basic', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const r = tf.isInf(a);
+    expectArraysClose(r, [0, 1, 1, 0, 0]);
+  });
+
+  it('gradients: Scalar', () => {
+    const a = tf.scalar(NaN);
+    const dy = tf.scalar(3);
+
+    const gradients = tf.grad(a => tf.isInf(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0]);
+  });
+
+  it('gradients: Tensor1D', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const dy = tf.tensor1d([1, 1, 1, 1, 1]);
+
+    const gradients = tf.grad(a => tf.isInf(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0, 0]);
+  });
+
+  it('gradients: Tensor2D', () => {
+    const a = tf.tensor2d([NaN, Infinity, -Infinity, 0], [2, 2]);
+    const dy = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+
+    const gradients = tf.grad(a => tf.isInf(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0]);
+  });
+
+  it('throws when passed a non-tensor', () => {
+    expect(() => tf.isInf({} as tf.Tensor))
+        .toThrowError(/Argument 'x' passed to 'isInf' must be a Tensor/);
+  });
+
+  it('accepts a tensor-like object', () => {
+    const r = tf.isInf([NaN, Infinity, -Infinity, 0, 1]);
+    expectArraysClose(r, [0, 1, 1, 0, 0]);
+  });
+
+  it('throws for string tensor', () => {
+    expect(() => tf.isInf('q'))
+        .toThrowError(/Argument 'x' passed to 'isInf' must be numeric/);
+  });
+});
+
+describeWithFlags('isFinite', ALL_ENVS, () => {
+  it('basic', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const r = tf.isFinite(a);
+    expectArraysClose(r, [0, 0, 0, 1, 1]);
+  });
+
+  it('gradients: Scalar', () => {
+    const a = tf.scalar(NaN);
+    const dy = tf.scalar(3);
+
+    const gradients = tf.grad(a => tf.isFinite(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0]);
+  });
+
+  it('gradients: Tensor1D', () => {
+    const a = tf.tensor1d([NaN, Infinity, -Infinity, 0, 1]);
+    const dy = tf.tensor1d([1, 1, 1, 1, 1]);
+
+    const gradients = tf.grad(a => tf.isFinite(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0, 0]);
+  });
+
+  it('gradients: Tensor2D', () => {
+    const a = tf.tensor2d([NaN, Infinity, -Infinity, 0], [2, 2]);
+    const dy = tf.tensor2d([1, 2, 3, 4], [2, 2]);
+
+    const gradients = tf.grad(a => tf.isFinite(a))(a, dy);
+
+    expect(gradients.shape).toEqual(a.shape);
+    expect(gradients.dtype).toEqual('float32');
+    expectArraysClose(gradients, [0, 0, 0, 0]);
+  });
+
+  it('throws when passed a non-tensor', () => {
+    expect(() => tf.isFinite({} as tf.Tensor))
+        .toThrowError(/Argument 'x' passed to 'isFinite' must be a Tensor/);
+  });
+
+  it('accepts a tensor-like object', () => {
+    const r = tf.isFinite([NaN, Infinity, -Infinity, 0, 1]);
+    expectArraysClose(r, [0, 0, 0, 1, 1]);
+  });
+
+  it('throws for string tensor', () => {
+    expect(() => tf.isFinite('q'))
+        .toThrowError(/Argument 'x' passed to 'isFinite' must be numeric/);
+  });
+});
+
 describeWithFlags('exp', ALL_ENVS, () => {
   it('exp', () => {
     const a = tf.tensor1d([1, 2, 0]);


### PR DESCRIPTION
also implement NAN, INFINITY, isnan, isinf for the WebGL backend.

~~_I suppose my `isnan()` implementation might not work. The previous was okay, I just wanted to try this one as it is a bit simpler._~~

---

Some odd things I have noticed:

* The `getNaN()` didn't appear to be used anywhere.

* The caching mechanics for the previous implementation of `NAN`, didn't appear to work. As every call to an operator would initialize a new `GPUProgram`. There is now no caching implementation for `NAN`, but in WebGL 2.0 it is defined as a constant.

* The `PROD` env handling of NAN, gives a false sense of security and causes undefined behavior. In `PROD`, NAN's are still produced and propagated through arithmetic operators. It is simply the specialized NAN handling that is disabled, which means the behavior is determined by the arithmetic operators. These often have undefined behavior, since some WebGL environments don't support NAN natively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1523)
<!-- Reviewable:end -->
