### PR TITLE
Checkout dependent package release branches when running integration tests on the 0.15.x release branches.

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -30,6 +30,7 @@ function test () {
   echo 'Cloning layers'
   git clone https://github.com/tensorflow/tfjs-layers.git --depth 5
   cd tfjs-layers
+  git checkout 0.10.x  # Checkout the corresponding release branch
   yarn && yarn link-local '@tensorflow/tfjs-core' && ./scripts/test-travis.sh
   LAYERS_EXIT_CODE=$?
 
@@ -44,6 +45,7 @@ function test () {
   echo 'Cloning converter'
   git clone https://github.com/tensorflow/tfjs-converter.git --depth 5
   cd tfjs-converter
+  git checkout 0.8.x  # Checkout the corresponding release branch
   yarn && yarn link-local '@tensorflow/tfjs-core'
   yarn build && yarn lint && yarn test-travis
   CONVERTER_EXIT_CODE=$?


### PR DESCRIPTION
Waiting for a union & node release so I can also do this for Node, but getting this ready.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1525)
<!-- Reviewable:end -->
