### PR TITLE
Add tf.deprecationWarn() and tf.disableDeprecationWarnings()

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -19,7 +19,7 @@ import * as device_util from './device_util';
 import {Engine, MemoryInfo, ProfileInfo, ScopeFn, TimingInfo} from './engine';
 import {Features, getFeaturesFromURL, getMaxTexturesInShader, getNumMBBeforePaging, getWebGLDisjointQueryTimerVersion, getWebGLMaxTextureSize, isChrome, isDownloadFloatTextureEnabled, isRenderToFloatTextureEnabled, isWebGLFenceEnabled, isWebGLVersionEnabled} from './environment_util';
 import {KernelBackend} from './kernels/backend';
-import {DataId, setTensorTracker, Tensor} from './tensor';
+import {DataId, setDeprecationWarningFn, setTensorTracker, Tensor} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
@@ -378,6 +378,8 @@ export class Environment {
       return false;
     } else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
       return !this.get('PROD');
+    } else if (feature === 'DEPRECATION_WARNINGS_ENABLED') {
+      return true;
     }
     throw new Error(`Unknown feature ${feature}.`);
   }
@@ -497,5 +499,21 @@ function getOrMakeEnvironment(): Environment {
 export function enableProdMode(): void {
   ENV.set('PROD', true);
 }
+
+/** Globally disables deprecation warnings */
+export function disableDeprecationWarnings(): void {
+  ENV.set('DEPRECATION_WARNINGS_ENABLED', false);
+  console.warn(`Deprecation warnings have been disabled.`);
+}
+
+/** Warn users about deprecated functionality. */
+export function deprecationWarn(msg: string) {
+  if (ENV.get('DEPRECATION_WARNINGS_ENABLED')) {
+    console.warn(
+        msg + ' You can disable deprecation warnings with ' +
+        'tf.disableDeprecationWarnings().');
+  }
+}
+setDeprecationWarningFn(deprecationWarn);
 
 export let ENV = getOrMakeEnvironment();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -503,7 +503,7 @@ export function enableProdMode(): void {
 /** Globally disables deprecation warnings */
 export function disableDeprecationWarnings(): void {
   ENV.set('DEPRECATION_WARNINGS_ENABLED', false);
-  console.warn(`Deprecation warnings have been disabled.`);
+  console.warn(`TensorFlow.js deprecation warnings have been disabled.`);
 }
 
 /** Warn users about deprecated functionality. */

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -242,7 +242,8 @@ describe('deprecation warnings', () => {
     tf.disableDeprecationWarnings();
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn)
-        .toHaveBeenCalledWith('Deprecation warnings have been disabled.');
+        .toHaveBeenCalledWith(
+            'TensorFlow.js deprecation warnings have been disabled.');
 
     // deprecationWarn no longer warns.
     deprecationWarn('xyz is deprecated.');

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as device_util from './device_util';
-import {deprecationWarn, disableDeprecationWarnings, ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
+import {deprecationWarn, ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
 import {BEFORE_PAGING_CONSTANT, Features, getQueryParams} from './environment_util';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
@@ -239,7 +239,7 @@ describe('deprecation warnings', () => {
   });
 
   it('disableDeprecationWarnings called, deprecationWarn doesnt warn', () => {
-    disableDeprecationWarnings();
+    tf.disableDeprecationWarnings();
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn)
         .toHaveBeenCalledWith('Deprecation warnings have been disabled.');

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -230,7 +230,7 @@ describe('deprecation warnings', () => {
   });
 
   it('deprecationWarn warns', () => {
-    deprecationWarn('xyz is deprecated');
+    deprecationWarn('xyz is deprecated.');
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn)
         .toHaveBeenCalledWith(
@@ -245,7 +245,7 @@ describe('deprecation warnings', () => {
         .toHaveBeenCalledWith('Deprecation warnings have been disabled.');
 
     // deprecationWarn no longer warns.
-    deprecationWarn('xyz is deprecated');
+    deprecationWarn('xyz is deprecated.');
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as device_util from './device_util';
-import {ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
+import {deprecationWarn, disableDeprecationWarnings, ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
 import {BEFORE_PAGING_CONSTANT, Features, getQueryParams} from './environment_util';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
@@ -216,5 +216,36 @@ describeWithFlags('WEBGL_SIZE_UPLOAD_UNIFORM', WEBGL_ENVS, () => {
     const env = new Environment();
     env.set('WEBGL_RENDER_FLOAT32_ENABLED', true);
     expect(env.get('WEBGL_SIZE_UPLOAD_UNIFORM')).toBeGreaterThan(0);
+  });
+});
+
+describe('deprecation warnings', () => {
+  let oldWarn: (msg: string) => void;
+  beforeEach(() => {
+    oldWarn = console.warn;
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+  });
+  afterEach(() => {
+    console.warn = oldWarn;
+  });
+
+  it('deprecationWarn warns', () => {
+    deprecationWarn('xyz is deprecated');
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            'xyz is deprecated. You can disable deprecation warnings with ' +
+            'tf.disableDeprecationWarnings().');
+  });
+
+  it('disableDeprecationWarnings called, deprecationWarn doesnt warn', () => {
+    disableDeprecationWarnings();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith('Deprecation warnings have been disabled.');
+
+    // deprecationWarn no longer warns.
+    deprecationWarn('xyz is deprecated');
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -16,7 +16,7 @@
  */
 
 import * as device_util from './device_util';
-import {deprecationWarn, ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
+import {ENV, Environment, EPSILON_FLOAT16, EPSILON_FLOAT32} from './environment';
 import {BEFORE_PAGING_CONSTANT, Features, getQueryParams} from './environment_util';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
@@ -230,7 +230,7 @@ describe('deprecation warnings', () => {
   });
 
   it('deprecationWarn warns', () => {
-    deprecationWarn('xyz is deprecated.');
+    tf.deprecationWarn('xyz is deprecated.');
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn)
         .toHaveBeenCalledWith(
@@ -246,7 +246,7 @@ describe('deprecation warnings', () => {
             'TensorFlow.js deprecation warnings have been disabled.');
 
     // deprecationWarn no longer warns.
-    deprecationWarn('xyz is deprecated.');
+    tf.deprecationWarn('xyz is deprecated.');
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -92,6 +92,8 @@ export interface Features {
   // Whether to do sanity checks when inferring a shape from user-provided
   // values, used when creating a new tensor.
   'TENSORLIKE_CHECK_SHAPE_CONSISTENCY'?: boolean;
+  // Whether deprecation warnings are enabled.
+  'DEPRECATION_WARNINGS_ENABLED'?: boolean;
 }
 
 export enum Type {
@@ -126,6 +128,7 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'EPSILON', type: Type.NUMBER},
   {name: 'PROD', type: Type.BOOLEAN},
   {name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN},
+  {name: 'DEPRECATION_WARNINGS_ENABLED', type: Type.BOOLEAN},
 ];
 
 export interface URLProperty {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import './kernels/backend_cpu';
 
 import {nextFrame} from './browser_util';
 import * as environment from './environment';
-import {disableDeprecationWarnings, enableProdMode, Environment} from './environment';
+import {deprecationWarn, disableDeprecationWarnings, enableProdMode, Environment} from './environment';
 // Serialization.
 import * as io from './io/io';
 import * as math from './math';
@@ -65,20 +65,11 @@ export const disposeVariables = Environment.disposeVariables;
 export const memory = Environment.memory;
 export {version as version_core};
 
-export {nextFrame};
+// Top-level method exports.
+export {nextFrame, enableProdMode, disableDeprecationWarnings, deprecationWarn};
 
 // Second level exports.
-export {
-  environment,
-  io,
-  math,
-  serialization,
-  test_util,
-  util,
-  webgl,
-  enableProdMode,
-  disableDeprecationWarnings
-};
+export {environment, io, math, serialization, test_util, util, webgl};
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import './kernels/backend_cpu';
 
 import {nextFrame} from './browser_util';
 import * as environment from './environment';
-import {enableProdMode, Environment} from './environment';
+import {disableDeprecationWarnings, enableProdMode, Environment} from './environment';
 // Serialization.
 import * as io from './io/io';
 import * as math from './math';
@@ -76,7 +76,8 @@ export {
   test_util,
   util,
   webgl,
-  enableProdMode
+  enableProdMode,
+  disableDeprecationWarnings
 };
 
 // Backend specific.

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -362,7 +362,8 @@ let trackerFn: () => TensorTracker = null;
 let opHandler: OpHandler = null;
 // Used to warn about deprecated methods.
 let deprecationWarningFn: (msg: string) => void = null;
-// tslint:disable-next-line:no-unused-expression
+// This here so that we can use this method on dev branches and keep the
+// functionality at master. tslint:disable-next-line:no-unused-expression
 [deprecationWarningFn];
 
 /**
@@ -383,8 +384,8 @@ export function setOpHandler(handler: OpHandler) {
 }
 
 /**
- * An external consumer can register itself as the op handler. This way the
- * Tensor class can have chaining methods that call into ops via the op handler.
+ * Sets the deprecation warning function to be used by this file. This way the
+ * Tensor class can be a leaf but still use the environment.
  */
 export function setDeprecationWarningFn(fn: (msg: string) => void) {
   deprecationWarningFn = fn;

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -363,7 +363,8 @@ let opHandler: OpHandler = null;
 // Used to warn about deprecated methods.
 let deprecationWarningFn: (msg: string) => void = null;
 // This here so that we can use this method on dev branches and keep the
-// functionality at master. tslint:disable-next-line:no-unused-expression
+// functionality at master.
+// tslint:disable-next-line:no-unused-expression
 [deprecationWarningFn];
 
 /**

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -360,6 +360,10 @@ export interface OpHandler {
 let trackerFn: () => TensorTracker = null;
 // Used by chaining methods to call into ops.
 let opHandler: OpHandler = null;
+// Used to warn about deprecated methods.
+let deprecationWarningFn: (msg: string) => void = null;
+// tslint:disable-next-line:no-unused-expression
+[deprecationWarningFn];
 
 /**
  * An external consumer can register itself as the tensor tracker. This way
@@ -376,6 +380,14 @@ export function setTensorTracker(fn: () => TensorTracker) {
  */
 export function setOpHandler(handler: OpHandler) {
   opHandler = handler;
+}
+
+/**
+ * An external consumer can register itself as the op handler. This way the
+ * Tensor class can have chaining methods that call into ops via the op handler.
+ */
+export function setDeprecationWarningFn(fn: (msg: string) => void) {
+  deprecationWarningFn = fn;
 }
 
 /**


### PR DESCRIPTION
This adds an environment flag for whether deprecation warnings are enabled, and two methods, `deprecationWarn` which will warn the user about deprecated methods (turned off by the global environment flag) and `disableDeprecationWarnings` which will completely turn off all deprecation warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1539)
<!-- Reviewable:end -->
