### PR TITLE
Remove delayedStorage mode. Also add internal format for packed half float textures and pass in backend at a few more tensor construction sites.

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -262,7 +262,7 @@ export class Engine implements TensorManager, TensorTracker, DataMover {
         bytes = util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
       }
       this.tensorInfo.set(a.dataId, {
-        backend: this.backend,
+        backend: backend != null ? backend : this.backend,
         dtype: a.dtype,
         shape: a.shape,
         bytes,

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -576,42 +576,44 @@ describe('Switching cpu backends', () => {
   });
 });
 
-describeWithFlags('WebGL backend without render float32 support', WEBGL_ENVS, () => {
-  const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
-  const savedPackFlag = tf.ENV.get('WEBGL_PACK');
+describeWithFlags(
+    'WebGL backend without render float32 support', WEBGL_ENVS, () => {
+      const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
+      const savedPackFlag = tf.ENV.get('WEBGL_PACK');
 
-  beforeEach(() => {
-    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
-    tf.ENV.registerBackend('half-float-webgl', () => new MathBackendWebGL());
-  });
+      beforeEach(() => {
+        tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
+        tf.ENV.registerBackend(
+            'half-float-webgl', () => new MathBackendWebGL());
+      });
 
-  afterEach(() => {
-    tf.ENV.removeBackend('half-float-webgl');
-  });
+      afterEach(() => {
+        tf.ENV.removeBackend('half-float-webgl');
+      });
 
-  afterAll(() => {
-    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
-    tf.ENV.set('WEBGL_PACK', savedPackFlag);
-  });
+      afterAll(() => {
+        tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
+        tf.ENV.set('WEBGL_PACK', savedPackFlag);
+      });
 
-  it('should work when packing is false', () => {
-    tf.ENV.set('WEBGL_PACK', false);
+      it('should work when packing is false', () => {
+        tf.ENV.set('WEBGL_PACK', false);
 
-    const a = tf.tensor2d([1, 2], [1, 2]);
-    const b = tf.tensor2d([1, 2], [1, 2]);
-    const c = tf.add(a, b);
-    expectArraysClose(c, [2, 4]);
-  });
+        const a = tf.tensor2d([1, 2], [1, 2]);
+        const b = tf.tensor2d([1, 2], [1, 2]);
+        const c = tf.add(a, b);
+        expectArraysClose(c, [2, 4]);
+      });
 
-  it('should work when packing is true', () => {
-    tf.ENV.set('WEBGL_PACK', false);
+      it('should work when packing is true', () => {
+        tf.ENV.set('WEBGL_PACK', false);
 
-    const a = tf.tensor2d([1, 2], [1, 2]);
-    const b = tf.tensor2d([1, 2], [1, 2]);
-    const c = tf.add(a, b);
-    expectArraysClose(c, [2, 4]);
-  });
-});
+        const a = tf.tensor2d([1, 2], [1, 2]);
+        const b = tf.tensor2d([1, 2], [1, 2]);
+        const c = tf.add(a, b);
+        expectArraysClose(c, [2, 4]);
+      });
+    });
 
 describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
   beforeEach(() => {

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -581,10 +581,13 @@ describeWithFlags(
       const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
       const savedPackFlag = tf.ENV.get('WEBGL_PACK');
 
-      beforeEach(() => {
+      beforeAll(() => {
         tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
+      });
+
+      beforeEach(() => {
         tf.ENV.registerBackend(
-            'half-float-webgl', () => new MathBackendWebGL());
+            'half-float-webgl', () => new MathBackendWebGL(null));
       });
 
       afterEach(() => {
@@ -597,6 +600,7 @@ describeWithFlags(
       });
 
       it('should work when packing is false', () => {
+        tf.setBackend('half-float-webgl');
         tf.ENV.set('WEBGL_PACK', false);
 
         const a = tf.tensor2d([1, 2], [1, 2]);
@@ -606,7 +610,8 @@ describeWithFlags(
       });
 
       it('should work when packing is true', () => {
-        tf.ENV.set('WEBGL_PACK', false);
+        tf.setBackend('half-float-webgl');
+        tf.ENV.set('WEBGL_PACK', true);
 
         const a = tf.tensor2d([1, 2], [1, 2]);
         const b = tf.tensor2d([1, 2], [1, 2]);

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -576,6 +576,43 @@ describe('Switching cpu backends', () => {
   });
 });
 
+describeWithFlags('WebGL backend without render float32 support', WEBGL_ENVS, () => {
+  const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
+  const savedPackFlag = tf.ENV.get('WEBGL_PACK');
+
+  beforeEach(() => {
+    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
+    tf.ENV.registerBackend('half-float-webgl', () => new MathBackendWebGL());
+  });
+
+  afterEach(() => {
+    tf.ENV.removeBackend('half-float-webgl');
+  });
+
+  afterAll(() => {
+    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
+    tf.ENV.set('WEBGL_PACK', savedPackFlag);
+  });
+
+  it('should work when packing is false', () => {
+    tf.ENV.set('WEBGL_PACK', false);
+
+    const a = tf.tensor2d([1, 2], [1, 2]);
+    const b = tf.tensor2d([1, 2], [1, 2]);
+    const c = tf.add(a, b);
+    expectArraysClose(c, [2, 4]);
+  });
+
+  it('should work when packing is true', () => {
+    tf.ENV.set('WEBGL_PACK', false);
+
+    const a = tf.tensor2d([1, 2], [1, 2]);
+    const b = tf.tensor2d([1, 2], [1, 2]);
+    const c = tf.add(a, b);
+    expectArraysClose(c, [2, 4]);
+  });
+});
+
 describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
   beforeEach(() => {
     tf.ENV.registerBackend('webgl1', () => new MathBackendWebGL());

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -576,47 +576,48 @@ describe('Switching cpu backends', () => {
   });
 });
 
-describeWithFlags(
-    'WebGL backend without render float32 support', WEBGL_ENVS, () => {
-      const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
+// We do not yet fully support half float backends. These tests are a starting
+// point.
+describeWithFlags('backend without render float32 support', WEBGL_ENVS, () => {
+  const savedRenderFloat32Flag = tf.ENV.get('WEBGL_RENDER_FLOAT32_ENABLED');
 
-      beforeAll(() => {
-        tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
-      });
+  beforeAll(() => {
+    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', false);
+  });
 
-      beforeEach(() => {
-        tf.ENV.registerBackend(
-            'half-float-webgl', () => new MathBackendWebGL(null));
-      });
+  beforeEach(() => {
+    tf.ENV.registerBackend(
+        'half-float-webgl', () => new MathBackendWebGL(null));
+  });
 
-      afterEach(() => {
-        tf.ENV.removeBackend('half-float-webgl');
-      });
+  afterEach(() => {
+    tf.ENV.removeBackend('half-float-webgl');
+  });
 
-      afterAll(() => {
-        tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
-      });
+  afterAll(() => {
+    tf.ENV.set('WEBGL_RENDER_FLOAT32_ENABLED', savedRenderFloat32Flag);
+  });
 
-      it('basic usage', () => {
-        tf.setBackend('half-float-webgl');
+  it('basic usage', () => {
+    tf.setBackend('half-float-webgl');
 
-        const a = tf.tensor2d([1, 2], [1, 2]);
-        const b = tf.tensor2d([1, 2], [1, 2]);
-        const c = tf.add(a, b);
-        expectArraysClose(c, [2, 4]);
-      });
+    const a = tf.tensor2d([1, 2], [1, 2]);
+    const b = tf.tensor2d([1, 2], [1, 2]);
+    const c = tf.add(a, b);
+    expectArraysClose(c, [2, 4]);
+  });
 
-      it('disposing tensors should not cause errors', () => {
-        tf.setBackend('half-float-webgl');
-        expect(() => tf.tidy(() => {
-          const a = tf.tensor2d([1, 2], [1, 2]);
-          const b = tf.tensor2d([1, 2], [1, 2]);
-          const c = tf.add(a, b);
-          c.dataSync();
-          return c.add(tf.tensor2d([2, 4], [1, 2]));
-        })).not.toThrowError();
-      });
-    });
+  it('disposing tensors should not cause errors', () => {
+    tf.setBackend('half-float-webgl');
+    expect(() => tf.tidy(() => {
+      const a = tf.tensor2d([1, 2], [1, 2]);
+      const b = tf.tensor2d([1, 2], [1, 2]);
+      const c = tf.add(a, b);
+      c.dataSync();
+      return c.add(tf.tensor2d([2, 4], [1, 2]));
+    })).not.toThrowError();
+  });
+});
 
 describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
   beforeEach(() => {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2179,7 +2179,8 @@ export class MathBackendWebGL implements KernelBackend {
         const inputValues = (input as Tensor).dataSync();
         this.delayedStorage = true;
 
-        input = Tensor.make(input.shape, {values: inputValues}, input.dtype, this);
+        input =
+            Tensor.make(input.shape, {values: inputValues}, input.dtype, this);
         texData = this.texData.get(input.dataId);
         texData.isPacked = true;
       }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -655,7 +655,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   private shallowSlice(x: Tensor, begin: number[], size: number[]): Tensor {
     const xTexData = this.texData.get(x.dataId);
-    const t = Tensor.make(size, {}, xTexData.dtype);
+    const t = Tensor.make(size, {}, xTexData.dtype, this);
     const newTexData = this.texData.get(t.dataId);
     // Copy texture data from the original tensor.
     Object.assign(newTexData, xTexData);
@@ -1677,7 +1677,7 @@ export class MathBackendWebGL implements KernelBackend {
     const xReshaped =
         Tensor.make(
             [1, xShape[0] * xShape[1] * (xShape[2] + 1), convInfo.inChannels],
-            {dataId: x.dataId}, x.dtype) as Tensor3D;
+            {dataId: x.dataId}, x.dtype, this) as Tensor3D;
 
     xTexData.shape[xTexData.shape.length - 2]++;
     util.assert(
@@ -1700,7 +1700,7 @@ export class MathBackendWebGL implements KernelBackend {
     pointwiseConvTexData.shape = convInfo.outShape;
     return Tensor.make(
                convInfo.outShape, {dataId: pointwiseConv.dataId},
-               pointwiseConv.dtype) as Tensor4D;
+               pointwiseConv.dtype, this) as Tensor4D;
   }
 
   conv2dWithIm2Row(x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo):
@@ -2063,7 +2063,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   private makeOutputArray<T extends Tensor>(shape: number[], dtype: DataType):
       T {
-    return Tensor.make(shape, {}, dtype) as T;
+    return Tensor.make(shape, {}, dtype, this) as T;
   }
 
   private makePackedTensor<T extends Tensor, D extends DataType = 'float32'>(
@@ -2177,7 +2177,7 @@ export class MathBackendWebGL implements KernelBackend {
         const inputValues = (input as Tensor).dataSync();
         this.delayedStorage = true;
 
-        input = Tensor.make(input.shape, {values: inputValues}, input.dtype);
+        input = Tensor.make(input.shape, {values: inputValues}, input.dtype, this);
         texData = this.texData.get(input.dataId);
         texData.isPacked = true;
       }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2337,7 +2337,16 @@ export class MathBackendWebGL implements KernelBackend {
     const dontKeepCopyOnGPU = this.delayedStorage;
     const texData = this.texData.get(dataId);
     const {texture, texShape, dtype, usage, isPacked} = texData;
-    if (dontKeepCopyOnGPU && texture != null) {
+
+    // If changing texData.usage to UPLOAD entails a different physical texture
+    // type, we must dispose it to maintain the correctness of the
+    // TextureManager shape cache.
+    const uploadIncompatibleWithPhysical =
+        webgl_util.getPhysicalFromLogicalTextureType(usage, isPacked) !==
+        webgl_util.getPhysicalFromLogicalTextureType(
+            TextureUsage.UPLOAD, isPacked);
+    if (uploadIncompatibleWithPhysical ||
+        (dontKeepCopyOnGPU && texture != null)) {
       this.releaseTexture(dataId, texture, texShape, usage, isPacked);
       texData.texture = null;
       texData.texShape = null;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2345,8 +2345,7 @@ export class MathBackendWebGL implements KernelBackend {
         webgl_util.getPhysicalFromLogicalTextureType(usage, isPacked) !==
         webgl_util.getPhysicalFromLogicalTextureType(
             TextureUsage.UPLOAD, isPacked);
-    if (uploadIncompatibleWithPhysical ||
-        (dontKeepCopyOnGPU && texture != null)) {
+    if(texture != null && (uploadIncompatibleWithPhysical || dontKeepCopyOnGPU)) {
       this.releaseTexture(dataId, texture, texShape, usage, isPacked);
       texData.texture = null;
       texData.texShape = null;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2345,7 +2345,8 @@ export class MathBackendWebGL implements KernelBackend {
         webgl_util.getPhysicalFromLogicalTextureType(usage, isPacked) !==
         webgl_util.getPhysicalFromLogicalTextureType(
             TextureUsage.UPLOAD, isPacked);
-    if(texture != null && (uploadIncompatibleWithPhysical || dontKeepCopyOnGPU)) {
+    if (texture != null &&
+        (uploadIncompatibleWithPhysical || dontKeepCopyOnGPU)) {
       this.releaseTexture(dataId, texture, texShape, usage, isPacked);
       texData.texture = null;
       texData.texShape = null;

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -128,9 +128,8 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
     expect(() => tf.tensor(['a', 'b', 'c'], [4], 'string')).toThrowError();
   });
 
-  it('delayed storage, reading', () => {
-    const delayedStorage = true;
-    const backend = new MathBackendWebGL(null, delayedStorage);
+  it('reading', () => {
+    const backend = new MathBackendWebGL(null);
     tf.ENV.registerBackend('test-storage', () => backend);
     tf.setBackend('test-storage');
 
@@ -150,9 +149,8 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
     expect(texManager.getNumUsedTextures()).toBe(0);
   });
 
-  it('delayed storage, read packed and then use by an unpacked op', () => {
-    const delayedStorage = true;
-    const backend = new MathBackendWebGL(null, delayedStorage);
+  it('read packed and then use by an unpacked op', () => {
+    const backend = new MathBackendWebGL(null);
     tf.ENV.registerBackend('test-storage', () => backend);
     tf.setBackend('test-storage');
 
@@ -172,8 +170,7 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
   });
 
   it('delayed storage, overwriting', () => {
-    const delayedStorage = true;
-    const backend = new MathBackendWebGL(null, delayedStorage);
+    const backend = new MathBackendWebGL(null);
     tf.ENV.registerBackend('test-storage', () => backend);
     tf.setBackend('test-storage');
 
@@ -193,60 +190,6 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
     expectArraysClose(
         backend.readSync(t.dataId) as Float32Array,
         new Float32Array([4, 5, 6]));
-    expect(texManager.getNumUsedTextures()).toBe(0);
-  });
-
-  it('immediate storage reading', () => {
-    const delayedStorage = false;
-    const backend = new MathBackendWebGL(null, delayedStorage);
-    tf.ENV.registerBackend('test-storage', () => backend);
-    tf.setBackend('test-storage');
-
-    const texManager = backend.getTextureManager();
-    const t = tf.Tensor.make([3], {}, 'float32');
-    backend.write(t.dataId, new Float32Array([1, 2, 3]));
-    expect(texManager.getNumUsedTextures()).toBe(1);
-    expectArraysClose(
-        backend.readSync(t.dataId) as Float32Array,
-        new Float32Array([1, 2, 3]));
-    expect(texManager.getNumUsedTextures()).toBe(1);
-    backend.disposeData(t.dataId);
-    expect(texManager.getNumUsedTextures()).toBe(0);
-  });
-
-  it('immediate storage overwriting', () => {
-    const delayedStorage = false;
-    const backend = new MathBackendWebGL(null, delayedStorage);
-    tf.ENV.registerBackend('test-storage', () => backend);
-    tf.setBackend('test-storage');
-
-    const texManager = backend.getTextureManager();
-    const t = tf.Tensor.make([3], {}, 'float32');
-    backend.write(t.dataId, new Float32Array([1, 2, 3]));
-    expect(texManager.getNumUsedTextures()).toBe(1);
-    backend.write(t.dataId, new Float32Array([4, 5, 6]));
-    expect(texManager.getNumUsedTextures()).toBe(1);
-    expectArraysClose(
-        backend.readSync(t.dataId) as Float32Array,
-        new Float32Array([4, 5, 6]));
-    expect(texManager.getNumUsedTextures()).toBe(1);
-    backend.disposeData(t.dataId);
-    expect(texManager.getNumUsedTextures()).toBe(0);
-  });
-
-  it('disposal of backend disposes all textures', () => {
-    const delayedStorage = false;
-    const backend = new MathBackendWebGL(null, delayedStorage);
-    const texManager = backend.getTextureManager();
-    tf.ENV.registerBackend('test-storage', () => backend);
-    tf.setBackend('test-storage');
-
-    const t = tf.Tensor.make([3], {}, 'float32');
-    backend.write(t.dataId, new Float32Array([1, 2, 3]));
-    const t2 = tf.Tensor.make([3], {}, 'float32');
-    backend.write(t2.dataId, new Float32Array([4, 5, 6]));
-    expect(texManager.getNumUsedTextures()).toBe(2);
-    backend.dispose();
     expect(texManager.getNumUsedTextures()).toBe(0);
   });
 });

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -140,7 +140,7 @@ function createAndConfigureTexture(
       gl,
       () => gl.texImage2D(
           tex2d, 0, internalFormat, width, height, 0, textureFormat,
-          gl.FLOAT, null));
+          textureType, null));
   webgl_util.callAndCheck(gl, () => gl.bindTexture(gl.TEXTURE_2D, null));
   return texture;
 }

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -24,6 +24,7 @@ import * as webgl_util from './webgl_util';
 export interface TextureConfig {
   internalFormatFloat: number;
   textureFormatFloat: number;
+  internalFormatPackedHalfFloat: number;
   internalFormatHalfFloat: number;
   internalFormatPackedFloat: number;
 

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -161,7 +161,7 @@ export function createFloat16MatrixTexture(
   const [width, height] =
       tex_util.getUnpackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
-      gl, width, height, textureConfig.internalFormatFloat,
+      gl, width, height, textureConfig.internalFormatHalfFloat,
       textureConfig.textureFormatFloat, textureConfig.textureTypeHalfFloat);
 }
 

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -135,7 +135,7 @@ function createAndConfigureTexture(
       gl,
       () => gl.texImage2D(
           tex2d, 0, internalFormat, width, height, 0, textureFormat,
-          textureType, null));
+          gl.FLOAT, null));
   webgl_util.callAndCheck(gl, () => gl.bindTexture(gl.TEXTURE_2D, null));
   return texture;
 }

--- a/src/kernels/webgl/gpgpu_util.ts
+++ b/src/kernels/webgl/gpgpu_util.ts
@@ -72,6 +72,7 @@ export function getTextureConfig(
 
   let internalFormatFloat: number;
   let internalFormatHalfFloat: number;
+  let internalFormatPackedHalfFloat: number;
   let internalFormatPackedFloat: number;
   let textureFormatFloat: number;
 
@@ -84,6 +85,7 @@ export function getTextureConfig(
   if (ENV.get('WEBGL_VERSION') === 2) {
     internalFormatFloat = glany.R32F;
     internalFormatHalfFloat = glany.R16F;
+    internalFormatPackedHalfFloat = glany.RGBA16F;
     internalFormatPackedFloat = glany.RGBA32F;
     textureFormatFloat = glany.RED;
     downloadUnpackNumChannels = 4;
@@ -92,6 +94,7 @@ export function getTextureConfig(
   } else {
     internalFormatFloat = gl.RGBA;
     internalFormatHalfFloat = gl.RGBA;
+    internalFormatPackedHalfFloat = gl.RGBA;
     internalFormatPackedFloat = glany.RGBA;
     textureFormatFloat = gl.RGBA;
     downloadUnpackNumChannels = 4;
@@ -105,6 +108,7 @@ export function getTextureConfig(
   return {
     internalFormatFloat,
     internalFormatHalfFloat,
+    internalFormatPackedHalfFloat,
     internalFormatPackedFloat,
     textureFormatFloat,
     downloadTextureFormat,
@@ -185,7 +189,7 @@ export function createFloat16PackedMatrixTexture(
   const [width, height] =
       tex_util.getPackedMatrixTextureShapeWidthHeight(rows, columns);
   return createAndConfigureTexture(
-      gl, width, height, textureConfig.internalFormatHalfFloat, gl.RGBA,
+      gl, width, height, textureConfig.internalFormatPackedHalfFloat, gl.RGBA,
       textureConfig.textureTypeHalfFloat);
 }
 

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -146,8 +146,14 @@ export class TextureManager {
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
   if (logicalTexType === TextureUsage.UPLOAD) {
-    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
-                      PhysicalTextureType.UNPACKED_FLOAT32;
+    if (isPacked) {
+      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+          PhysicalTextureType.PACKED_2X2_FLOAT32 :
+          PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+        PhysicalTextureType.UNPACKED_FLOAT32 :
+        PhysicalTextureType.UNPACKED_FLOAT16;
   } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
     if (isPacked) {
       return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -145,8 +145,10 @@ export class TextureManager {
 
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
-  if (logicalTexType === TextureUsage.UPLOAD ||
-      logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
+  if (logicalTexType === TextureUsage.UPLOAD) {
+    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
+                      PhysicalTextureType.UNPACKED_FLOAT32;
+  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
     if (isPacked) {
       return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
           PhysicalTextureType.PACKED_2X2_FLOAT32 :

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -15,9 +15,8 @@
  * =============================================================================
  */
 
-import {ENV} from '../../environment';
-
 import {GPGPUContext} from './gpgpu_context';
+import {getPhysicalFromLogicalTextureType} from './webgl_util';
 import {PhysicalTextureType, TextureUsage} from './tex_util';
 
 export class TextureManager {
@@ -141,28 +140,6 @@ export class TextureManager {
     this.numUsedTextures = 0;
     this.numFreeTextures = 0;
   }
-}
-
-function getPhysicalFromLogicalTextureType(
-    logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
-  if (logicalTexType === TextureUsage.UPLOAD) {
-    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
-                      PhysicalTextureType.UNPACKED_FLOAT32;
-  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
-    if (isPacked) {
-      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-          PhysicalTextureType.PACKED_2X2_FLOAT32 :
-          PhysicalTextureType.PACKED_2X2_FLOAT16;
-    }
-    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-        PhysicalTextureType.UNPACKED_FLOAT32 :
-        PhysicalTextureType.UNPACKED_FLOAT16;
-  } else if (
-      logicalTexType === TextureUsage.DOWNLOAD ||
-      logicalTexType === TextureUsage.PIXELS) {
-    return PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
-  }
-  throw new Error(`Unknown logical texture type ${logicalTexType}`);
 }
 
 function getKeyFromTextureShape(

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
+import {ENV} from '../../environment';
 import {GPGPUContext} from './gpgpu_context';
-import {getPhysicalFromLogicalTextureType} from './webgl_util';
 import {PhysicalTextureType, TextureUsage} from './tex_util';
 
 export class TextureManager {
@@ -140,6 +140,28 @@ export class TextureManager {
     this.numUsedTextures = 0;
     this.numFreeTextures = 0;
   }
+}
+
+function getPhysicalFromLogicalTextureType(
+    logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
+  if (logicalTexType === TextureUsage.UPLOAD) {
+    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
+                      PhysicalTextureType.UNPACKED_FLOAT32;
+  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
+    if (isPacked) {
+      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+          PhysicalTextureType.PACKED_2X2_FLOAT32 :
+          PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+        PhysicalTextureType.UNPACKED_FLOAT32 :
+        PhysicalTextureType.UNPACKED_FLOAT16;
+  } else if (
+      logicalTexType === TextureUsage.DOWNLOAD ||
+      logicalTexType === TextureUsage.PIXELS) {
+    return PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
+  }
+  throw new Error(`Unknown logical texture type ${logicalTexType}`);
 }
 
 function getKeyFromTextureShape(

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -145,16 +145,8 @@ export class TextureManager {
 
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
-  if (logicalTexType === TextureUsage.UPLOAD) {
-    if (isPacked) {
-      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-          PhysicalTextureType.PACKED_2X2_FLOAT32 :
-          PhysicalTextureType.PACKED_2X2_FLOAT16;
-    }
-    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-        PhysicalTextureType.UNPACKED_FLOAT32 :
-        PhysicalTextureType.UNPACKED_FLOAT16;
-  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
+  if (logicalTexType === TextureUsage.UPLOAD ||
+      logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
     if (isPacked) {
       return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
           PhysicalTextureType.PACKED_2X2_FLOAT32 :

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../../environment';
 import * as util from '../../util';
-import {PhysicalTextureType, TextureUsage} from './tex_util';
 
 export function callAndCheck<T>(gl: WebGLRenderingContext, func: () => T): T {
   const returnValue = func();
@@ -352,28 +351,6 @@ export function getRowsCols(shape: number[]): [number, number] {
   return [
     shape.length > 1 ? shape[shape.length - 2] : 1, shape[shape.length - 1]
   ];
-}
-
-export function getPhysicalFromLogicalTextureType(
-    logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
-  if (logicalTexType === TextureUsage.UPLOAD) {
-    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
-                      PhysicalTextureType.UNPACKED_FLOAT32;
-  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
-    if (isPacked) {
-      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-          PhysicalTextureType.PACKED_2X2_FLOAT32 :
-          PhysicalTextureType.PACKED_2X2_FLOAT16;
-    }
-    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
-        PhysicalTextureType.UNPACKED_FLOAT32 :
-        PhysicalTextureType.UNPACKED_FLOAT16;
-  } else if (
-      logicalTexType === TextureUsage.DOWNLOAD ||
-      logicalTexType === TextureUsage.PIXELS) {
-    return PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
-  }
-  throw new Error(`Unknown logical texture type ${logicalTexType}`);
 }
 
 export function getTextureShapeFromLogicalShape(

--- a/src/kernels/webgl/webgl_util.ts
+++ b/src/kernels/webgl/webgl_util.ts
@@ -17,6 +17,7 @@
 
 import {ENV} from '../../environment';
 import * as util from '../../util';
+import {PhysicalTextureType, TextureUsage} from './tex_util';
 
 export function callAndCheck<T>(gl: WebGLRenderingContext, func: () => T): T {
   const returnValue = func();
@@ -351,6 +352,28 @@ export function getRowsCols(shape: number[]): [number, number] {
   return [
     shape.length > 1 ? shape[shape.length - 2] : 1, shape[shape.length - 1]
   ];
+}
+
+export function getPhysicalFromLogicalTextureType(
+    logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
+  if (logicalTexType === TextureUsage.UPLOAD) {
+    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
+                      PhysicalTextureType.UNPACKED_FLOAT32;
+  } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
+    if (isPacked) {
+      return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+          PhysicalTextureType.PACKED_2X2_FLOAT32 :
+          PhysicalTextureType.PACKED_2X2_FLOAT16;
+    }
+    return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?
+        PhysicalTextureType.UNPACKED_FLOAT32 :
+        PhysicalTextureType.UNPACKED_FLOAT16;
+  } else if (
+      logicalTexType === TextureUsage.DOWNLOAD ||
+      logicalTexType === TextureUsage.PIXELS) {
+    return PhysicalTextureType.PACKED_4X1_UNSIGNED_BYTE;
+  }
+  throw new Error(`Unknown logical texture type ${logicalTexType}`);
 }
 
 export function getTextureShapeFromLogicalShape(


### PR DESCRIPTION
This PR fixes https://github.com/tensorflow/tfjs/issues/1194

#### Changes
- Remove `delayedStorage` as configurable parameter of WebGL backend constructor. Replace `delayedStorage` with private `keepCopyOfTextureOnGPUAfterRead` flag that can be flipped to enable reading from a texture without releasing it. 
- Add a new internal format `internalFormatPackedHalfFloat` (`gl.RGBA16F`) to support packed half float textures.
- Passing in backend in a few more places where we construct tensors for good measure.

BUG

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1543)
<!-- Reviewable:end -->
