### PR TITLE
Cherry pick to 0.15.x: Make tf.browser.fromPixels / toPixels and route tf.fromPixels / tf.toPixels to it.

### DIFF
--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -32,7 +32,7 @@ describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
       pixels.data[i] = 250;
     }
 
-    const a = tf.fromPixels(pixels, 4);
+    const a = tf.browser.fromPixels(pixels, 4);
     const b = tf.scalar(20, 'int32');
 
     const res = tf.add(a, b);
@@ -622,12 +622,12 @@ describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
 
   it('fromPixels with mixed backends works', () => {
     tf.setBackend('webgl1');
-    const a =
-        tf.fromPixels(new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
+    const a = tf.browser.fromPixels(
+        new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
 
     tf.setBackend('webgl2');
-    const b =
-        tf.fromPixels(new ImageData(new Uint8ClampedArray([5, 6, 7, 8]), 1, 1));
+    const b = tf.browser.fromPixels(
+        new ImageData(new Uint8ClampedArray([5, 6, 7, 8]), 1, 1));
 
     expectArraysClose(tf.add(a, b), [6, 8, 10]);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {deprecationWarn, disableDeprecationWarnings, enableProdMode, Environment
 // Serialization.
 import * as io from './io/io';
 import * as math from './math';
+import * as browser from './ops/browser';
 import * as serialization from './serialization';
 import {setOpHandler} from './tensor';
 import * as test_util from './test_util';
@@ -70,7 +71,7 @@ export {version as version_core};
 export {nextFrame, enableProdMode, disableDeprecationWarnings, deprecationWarn};
 
 // Second level exports.
-export {environment, io, math, serialization, test_util, util, webgl};
+export {browser, environment, io, math, serialization, test_util, util, webgl};
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -115,7 +115,8 @@ export class MathBackendCPU implements KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('pixels passed to tf.fromPixels() can not be null');
+      throw new Error(
+          'pixels passed to tf.browser.fromPixels() can not be null');
     }
     let vals: Uint8ClampedArray;
     // tslint:disable-next-line:no-any
@@ -150,7 +151,7 @@ export class MathBackendCPU implements KernelBackend {
                  .data;
     } else {
       throw new Error(
-          'pixels passed to tf.fromPixels() must be either an ' +
+          'pixels passed to tf.browser.fromPixels() must be either an ' +
           `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
           `ImageData, but was ${(pixels as {}).constructor.name}`);
     }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -205,7 +205,8 @@ export class MathBackendWebGL implements KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('pixels passed to tf.fromPixels() can not be null');
+      throw new Error(
+          'pixels passed to tf.browser.fromPixels() can not be null');
     }
     const texShape: [number, number] = [pixels.height, pixels.width];
     const outShape = [pixels.height, pixels.width, numChannels];
@@ -215,7 +216,7 @@ export class MathBackendWebGL implements KernelBackend {
         !(pixels instanceof HTMLCanvasElement) &&
         !(pixels instanceof ImageData)) {
       throw new Error(
-          'pixels passed to tf.fromPixels() must be either an ' +
+          'pixels passed to tf.browser.fromPixels() must be either an ' +
           `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
           `ImageData, but was ${(pixels as {}).constructor.name}`);
     }

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -20,7 +20,9 @@ import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../t
 import {convertToTensor, convertToTensorArray} from '../tensor_util_env';
 import {DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike4D} from '../types';
 import * as util from '../util';
+
 import {getAxesPermutation, getInnerMostAxes} from './axis_util';
+import {fromPixels as browserFromPixels, toPixels as browserToPixels} from './browser';
 import {concat} from './concat_split';
 import {op} from './operation';
 import {MPRandGauss} from './rand';
@@ -306,17 +308,7 @@ function oneHot_(
 }
 
 /**
- * Creates a `tf.Tensor` from an image.
- *
- * ```js
- * const image = new ImageData(1, 1);
- * image.data[0] = 100;
- * image.data[1] = 150;
- * image.data[2] = 200;
- * image.data[3] = 255;
- *
- * tf.fromPixels(image).print();
- * ```
+ * Deprecated. Use `tf.browser.fromPixels`.
  *
  * @param pixels The input image to construct the tensor from. The
  * supported image types are all 4-channel.
@@ -328,22 +320,11 @@ function oneHot_(
 function fromPixels_(
     pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
     numChannels = 3): Tensor3D {
-  if (numChannels > 4) {
-    throw new Error(
-        'Cannot construct Tensor with more than 4 channels from pixels.');
-  }
-  return ENV.engine.fromPixels(pixels, numChannels);
+  return browserFromPixels(pixels, numChannels);
 }
 
 /**
- * Draws a `tf.Tensor` of pixel values to a byte array or optionally a
- * canvas.
- *
- * When the dtype of the input is 'float32', we assume values in the range
- * [0-1]. Otherwise, when input is 'int32', we assume values in the range
- * [0-255].
- *
- * Returns a promise that resolves when the canvas has been drawn to.
+ * Deprecated. Use `tf.browser.toPixels`.
  *
  * @param img A rank-2 or rank-3 tensor. If rank-2, draws grayscale. If
  *     rank-3, must have depth of 1, 3 or 4. When depth of 1, draws
@@ -356,89 +337,7 @@ function fromPixels_(
 async function toPixels(
     img: Tensor2D|Tensor3D|TensorLike,
     canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
-  let $img = convertToTensor(img, 'img', 'toPixels');
-  if (!(img instanceof Tensor)) {
-    // Assume int32 if user passed a native array.
-    $img = $img.toInt();
-  }
-  if ($img.rank !== 2 && $img.rank !== 3) {
-    throw new Error(
-        `toPixels only supports rank 2 or 3 tensors, got rank ${$img.rank}.`);
-  }
-  const [height, width] = $img.shape.slice(0, 2);
-  const depth = $img.rank === 2 ? 1 : $img.shape[2];
-
-  if (depth > 4 || depth === 2) {
-    throw new Error(
-        `toPixels only supports depth of size ` +
-        `1, 3 or 4 but got ${depth}`);
-  }
-
-  const minTensor = $img.min();
-  const maxTensor = $img.max();
-  const min = (await minTensor.data())[0];
-  const max = (await maxTensor.data())[0];
-  minTensor.dispose();
-  maxTensor.dispose();
-  if ($img.dtype === 'float32') {
-    if (min < 0 || max > 1) {
-      throw new Error(
-          `Tensor values for a float32 Tensor must be in the ` +
-          `range [0 - 1] but got range [${min} - ${max}].`);
-    }
-  } else if ($img.dtype === 'int32') {
-    if (min < 0 || max > 255) {
-      throw new Error(
-          `Tensor values for a int32 Tensor must be in the ` +
-          `range [0 - 255] but got range [${min} - ${max}].`);
-    }
-  } else {
-    throw new Error(
-        `Unsupported type for toPixels: ${$img.dtype}.` +
-        ` Please use float32 or int32 tensors.`);
-  }
-
-  const data = await $img.data();
-  const multiplier = $img.dtype === 'float32' ? 255 : 1;
-  const bytes = new Uint8ClampedArray(width * height * 4);
-
-  for (let i = 0; i < height * width; ++i) {
-    let r, g, b, a;
-    if (depth === 1) {
-      r = data[i] * multiplier;
-      g = data[i] * multiplier;
-      b = data[i] * multiplier;
-      a = 255;
-    } else if (depth === 3) {
-      r = data[i * 3] * multiplier;
-      g = data[i * 3 + 1] * multiplier;
-      b = data[i * 3 + 2] * multiplier;
-      a = 255;
-    } else if (depth === 4) {
-      r = data[i * 4] * multiplier;
-      g = data[i * 4 + 1] * multiplier;
-      b = data[i * 4 + 2] * multiplier;
-      a = data[i * 4 + 3] * multiplier;
-    }
-
-    const j = i * 4;
-    bytes[j + 0] = Math.round(r);
-    bytes[j + 1] = Math.round(g);
-    bytes[j + 2] = Math.round(b);
-    bytes[j + 3] = Math.round(a);
-  }
-
-  if (canvas != null) {
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    const imageData = new ImageData(bytes, width, height);
-    ctx.putImageData(imageData, 0, 0);
-  }
-  if ($img !== img) {
-    $img.dispose();
-  }
-  return bytes;
+  return browserToPixels(img, canvas);
 }
 
 /**
@@ -1207,7 +1106,7 @@ export const cumsum = op({cumsum_});
 export const depthToSpace = op({depthToSpace_});
 export const expandDims = op({expandDims_});
 export const eye = op({eye_});
-export const fromPixels = op({fromPixels_});
+export const fromPixels = fromPixels_;
 export const multinomial = op({multinomial_});
 export const oneHot = op({oneHot_});
 export const pad = op({pad_});

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -1249,7 +1249,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   it('accepts a canvas-like element', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any);
+    const t = tf.browser.fromPixels(c as any);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 3]);
     tf.test_util.expectArraysEqual(
@@ -1259,7 +1259,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   it('accepts a canvas-like element, numChannels=4', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any, 4);
+    const t = tf.browser.fromPixels(c as any, 4);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 4]);
     tf.test_util.expectArraysEqual(
@@ -1268,7 +1268,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
 
   it('errors when passed a non-canvas object', () => {
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels(5 as any)).toThrowError();
+    expect(() => tf.browser.fromPixels(5 as any)).toThrowError();
   });
 });
 
@@ -1280,7 +1280,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = tf.fromPixels(pixels, 3);
+    const array = tf.browser.fromPixels(pixels, 3);
 
     expectArraysEqual(array, [0, 80, 160]);
   });
@@ -1292,7 +1292,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = tf.fromPixels(pixels, 4);
+    const array = tf.browser.fromPixels(pixels, 4);
 
     expectArraysEqual(array, [0, 80, 160, 240]);
   });
@@ -1307,7 +1307,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       pixels.data[i] = i * 2;
     }
 
-    const array = tf.fromPixels(pixels, 3);
+    const array = tf.browser.fromPixels(pixels, 3);
 
     expectArraysEqual(array, [0, 2, 4, 8, 10, 12, 16, 18, 20, 24, 26, 28]);
   });
@@ -1321,7 +1321,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       pixels.data[i] = i * 2;
     }
 
-    const array = tf.fromPixels(pixels, 4);
+    const array = tf.browser.fromPixels(pixels, 4);
 
     expectArraysClose(
         array,
@@ -1339,7 +1339,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[5] = 6;
     pixels.data[6] = 7;
     pixels.data[7] = 255;  // Not used.
-    const res = tf.fromPixels(pixels, 3);
+    const res = tf.browser.fromPixels(pixels, 3);
     expect(res.shape).toEqual([2, 1, 3]);
     expect(res.dtype).toBe('int32');
     expectArraysClose(res, [2, 3, 4, 5, 6, 7]);
@@ -1351,7 +1351,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[1] = 3;
     pixels.data[2] = 4;
     pixels.data[3] = 255;  // Not used.
-    const a = tf.fromPixels(pixels, 3).reshape([1, 1, 1, 3]);
+    const a = tf.browser.fromPixels(pixels, 3).reshape([1, 1, 1, 3]);
     const res = a.add(tf.scalar(2, 'int32'));
     expect(res.shape).toEqual([1, 1, 1, 3]);
     expect(res.dtype).toBe('int32');
@@ -1369,8 +1369,8 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixelsB.data[1] = 6;
     pixelsB.data[2] = 7;
     pixelsB.data[3] = 255;  // Not used.
-    const a = tf.fromPixels(pixelsA, 3).toFloat();
-    const b = tf.fromPixels(pixelsB, 3).toFloat();
+    const a = tf.browser.fromPixels(pixelsA, 3).toFloat();
+    const b = tf.browser.fromPixels(pixelsB, 3).toFloat();
     const res = a.add(b);
     expect(res.shape).toEqual([1, 1, 3]);
     expect(res.dtype).toBe('float32');
@@ -1378,15 +1378,17 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
   });
 
   it('throws when passed a primitive number', () => {
+    const msg = /pixels passed to tf.browser.fromPixels\(\) must be either/;
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels(3 as any))
-        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+    expect(() => tf.browser.fromPixels(3 as any))
+        .toThrowError(msg);
   });
 
   it('throws when passed a string', () => {
+    const msg = /pixels passed to tf.browser.fromPixels\(\) must be either/;
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels('test' as any))
-        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+    expect(() => tf.browser.fromPixels('test' as any))
+        .toThrowError(msg);
   });
 });
 
@@ -1394,7 +1396,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-2 float32 tensor', async () => {
     const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
       Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
@@ -1404,7 +1406,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
 
   it('draws a rank-2 int32 tensor', async () => {
     const x = tf.tensor2d([10, 20], [2, 1], 'int32');
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
   });
@@ -1412,7 +1414,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 float32 tensor, 1 channel', async () => {
     const x = tf.tensor3d([.15, .2], [2, 1, 1], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
       Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
@@ -1423,7 +1425,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 1 channel', async () => {
     const x = tf.tensor3d([10, 20], [2, 1, 1], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
   });
@@ -1435,7 +1437,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
     const x =
         tf.tensor3d([.05, .1001, .15, .2, .25, .3001], [2, 1, 3], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
       255, Math.round(.2 * 255), Math.round(.25 * 255), Math.round(.3001 * 255),
@@ -1447,7 +1449,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 3 channel', async () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60], [2, 1, 3], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 20, 30, 255, 40, 50, 60, 255]);
     expect(data).toEqual(expected);
   });
@@ -1456,7 +1458,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
     const x = tf.tensor3d(
         [.05, .1001, .15, .2, .25, .3001, .35, .4], [2, 1, 4], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
       Math.round(.20 * 255), Math.round(.25 * 255), Math.round(.3001 * 255),
@@ -1468,52 +1470,56 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 4 channel', async () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60, 70, 80], [2, 1, 4], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 20, 30, 40, 50, 60, 70, 80]);
     expect(data).toEqual(expected);
   });
 
   it('throws for scalars', done => {
     // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels(tf.scalar(1) as any), done);
+    expectPromiseToFail(() => tf.browser.toPixels(tf.scalar(1) as any), done);
   });
 
   it('throws for rank-1 tensors', done => {
-    // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels(tf.tensor1d([1]) as any), done);
+    expectPromiseToFail(
+        // tslint:disable-next-line:no-any
+        () => tf.browser.toPixels(tf.tensor1d([1]) as any), done);
   });
   it('throws for rank-4 tensors', done => {
     expectPromiseToFail(
         // tslint:disable-next-line:no-any
-        () => tf.toPixels(tf.tensor4d([1], [1, 1, 1, 1]) as any), done);
+        () => tf.browser.toPixels(tf.tensor4d([1], [1, 1, 1, 1]) as any), done);
   });
   it('throws for bool dtype', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor2d([1], [1, 1], 'bool')), done);
+        () => tf.browser.toPixels(tf.tensor2d([1], [1, 1], 'bool')), done);
   });
   it('throws for rank-3 depth = 2', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor3d([1, 2], [1, 1, 2])), done);
+        () => tf.browser.toPixels(tf.tensor3d([1, 2], [1, 1, 2])), done);
   });
   it('throws for rank-3 depth = 5', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor3d([1, 2, 3, 4, 5], [1, 1, 5])), done);
+        () => tf.browser.toPixels(tf.tensor3d([1, 2, 3, 4, 5], [1, 1, 5])),
+        done);
   });
   it('throws for float32 tensor with values not in [0 - 1]', done => {
-    expectPromiseToFail(() => tf.toPixels(tf.tensor2d([-1, .5], [1, 2])), done);
+    expectPromiseToFail(
+        () => tf.browser.toPixels(tf.tensor2d([-1, .5], [1, 2])), done);
   });
   it('throws for int32 tensor with values not in [0 - 255]', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor2d([-1, 100], [1, 2], 'int32')), done);
+        () => tf.browser.toPixels(tf.tensor2d([-1, 100], [1, 2], 'int32')),
+        done);
   });
   it('throws when passed a non-tensor', done => {
     // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels({} as any), done);
+    expectPromiseToFail(() => tf.browser.toPixels({} as any), done);
   });
 
   it('accepts a tensor-like object', async () => {
     const x = [[10], [20]];  // 2x1;
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
 
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
@@ -1525,7 +1531,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255),
@@ -1545,7 +1551,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor2d([10, 20], [2, 1], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
       expect(data).toEqual(expected);
@@ -1562,7 +1568,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([.15, .2], [2, 1, 1], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255),
@@ -1582,7 +1588,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([10, 20], [2, 1, 1], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
       expect(data).toEqual(expected);
@@ -1600,7 +1606,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         tf.tensor3d([.05, .1001, .15, .20, .25, .3001], [2, 1, 3], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.25 * 255),
@@ -1620,7 +1626,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60], [2, 1, 3], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 20, 30, 255, 40, 50, 60, 255]);
       expect(data).toEqual(expected);
@@ -1640,7 +1646,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         [.05, .1001, .15, 1, .20, .25, .3001, 1], [2, 1, 4], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
         255, Math.round(.20 * 255), Math.round(.25 * 255),
@@ -1664,7 +1670,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         tf.tensor3d([10, 20, 30, 255, 50, 60, 70, 255], [2, 1, 4], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 20, 30, 255, 50, 60, 70, 255]);
       expect(data).toEqual(expected);
@@ -1681,7 +1687,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = [[127], [100]];  // 2x1;
     const canvas = document.createElement('canvas');
 
-    const data = await tf.toPixels(x, canvas);
+    const data = await tf.browser.toPixels(x, canvas);
     const expected =
         new Uint8ClampedArray([127, 127, 127, 255, 100, 100, 100, 255]);
     expect(data).toEqual(expected);

--- a/src/ops/browser.ts
+++ b/src/ops/browser.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../environment';
+import {Tensor, Tensor2D, Tensor3D} from '../tensor';
+import {convertToTensor} from '../tensor_util_env';
+import {TensorLike} from '../types';
+
+import {op} from './operation';
+
+/**
+ * Creates a `tf.Tensor` from an image.
+ *
+ * ```js
+ * const image = new ImageData(1, 1);
+ * image.data[0] = 100;
+ * image.data[1] = 150;
+ * image.data[2] = 200;
+ * image.data[3] = 255;
+ *
+ * tf.browser.fromPixels(image).print();
+ * ```
+ *
+ * @param pixels The input image to construct the tensor from. The
+ * supported image types are all 4-channel.
+ * @param numChannels The number of channels of the output tensor. A
+ * numChannels value less than 4 allows you to ignore channels. Defaults to
+ * 3 (ignores alpha channel of input image).
+ */
+/** @doc {heading: 'Browser', namespace: 'browser'} */
+function fromPixels_(
+    pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
+    numChannels = 3): Tensor3D {
+  if (numChannels > 4) {
+    throw new Error(
+        'Cannot construct Tensor with more than 4 channels from pixels.');
+  }
+  return ENV.engine.fromPixels(pixels, numChannels);
+}
+
+/**
+ * Draws a `tf.Tensor` of pixel values to a byte array or optionally a
+ * canvas.
+ *
+ * When the dtype of the input is 'float32', we assume values in the range
+ * [0-1]. Otherwise, when input is 'int32', we assume values in the range
+ * [0-255].
+ *
+ * Returns a promise that resolves when the canvas has been drawn to.
+ *
+ * @param img A rank-2 or rank-3 tensor. If rank-2, draws grayscale. If
+ *     rank-3, must have depth of 1, 3 or 4. When depth of 1, draws
+ * grayscale. When depth of 3, we draw with the first three components of
+ * the depth dimension corresponding to r, g, b and alpha = 1. When depth of
+ * 4, all four components of the depth dimension correspond to r, g, b, a.
+ * @param canvas The canvas to draw to.
+ */
+/** @doc {heading: 'Browser', namespace: 'browser'} */
+export async function toPixels(
+    img: Tensor2D|Tensor3D|TensorLike,
+    canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
+  let $img = convertToTensor(img, 'img', 'toPixels');
+  if (!(img instanceof Tensor)) {
+    // Assume int32 if user passed a native array.
+    $img = $img.toInt();
+  }
+  if ($img.rank !== 2 && $img.rank !== 3) {
+    throw new Error(
+        `toPixels only supports rank 2 or 3 tensors, got rank ${$img.rank}.`);
+  }
+  const [height, width] = $img.shape.slice(0, 2);
+  const depth = $img.rank === 2 ? 1 : $img.shape[2];
+
+  if (depth > 4 || depth === 2) {
+    throw new Error(
+        `toPixels only supports depth of size ` +
+        `1, 3 or 4 but got ${depth}`);
+  }
+
+  const minTensor = $img.min();
+  const maxTensor = $img.max();
+  const min = (await minTensor.data())[0];
+  const max = (await maxTensor.data())[0];
+  minTensor.dispose();
+  maxTensor.dispose();
+  if ($img.dtype === 'float32') {
+    if (min < 0 || max > 1) {
+      throw new Error(
+          `Tensor values for a float32 Tensor must be in the ` +
+          `range [0 - 1] but got range [${min} - ${max}].`);
+    }
+  } else if ($img.dtype === 'int32') {
+    if (min < 0 || max > 255) {
+      throw new Error(
+          `Tensor values for a int32 Tensor must be in the ` +
+          `range [0 - 255] but got range [${min} - ${max}].`);
+    }
+  } else {
+    throw new Error(
+        `Unsupported type for toPixels: ${$img.dtype}.` +
+        ` Please use float32 or int32 tensors.`);
+  }
+
+  const data = await $img.data();
+  const multiplier = $img.dtype === 'float32' ? 255 : 1;
+  const bytes = new Uint8ClampedArray(width * height * 4);
+
+  for (let i = 0; i < height * width; ++i) {
+    let r, g, b, a;
+    if (depth === 1) {
+      r = data[i] * multiplier;
+      g = data[i] * multiplier;
+      b = data[i] * multiplier;
+      a = 255;
+    } else if (depth === 3) {
+      r = data[i * 3] * multiplier;
+      g = data[i * 3 + 1] * multiplier;
+      b = data[i * 3 + 2] * multiplier;
+      a = 255;
+    } else if (depth === 4) {
+      r = data[i * 4] * multiplier;
+      g = data[i * 4 + 1] * multiplier;
+      b = data[i * 4 + 2] * multiplier;
+      a = data[i * 4 + 3] * multiplier;
+    }
+
+    const j = i * 4;
+    bytes[j + 0] = Math.round(r);
+    bytes[j + 1] = Math.round(g);
+    bytes[j + 2] = Math.round(b);
+    bytes[j + 3] = Math.round(a);
+  }
+
+  if (canvas != null) {
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    const imageData = new ImageData(bytes, width, height);
+    ctx.putImageData(imageData, 0, 0);
+  }
+  if ($img !== img) {
+    $img.dispose();
+  }
+  return bytes;
+}
+
+export const fromPixels = op({fromPixels_});


### PR DESCRIPTION
This is a cherry pick to 0.15.x of https://github.com/tensorflow/tfjs-core/pull/1540

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1545)
<!-- Reviewable:end -->
