### PR TITLE
0.15.x: Add deprecation warnings for Tensor.get, Tensor.buffer, tf.fromPixels, and tf.toPixels

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -500,7 +500,6 @@ export function disableDeprecationWarnings(): void {
 
 /** Warn users about deprecated functionality. */
 export function deprecationWarn(msg: string) {
-  console.log('warning about', msg, ENV.get('DEPRECATION_WARNINGS_ENABLED'));
   if (ENV.get('DEPRECATION_WARNINGS_ENABLED')) {
     console.warn(
         msg + ' You can disable deprecation warnings with ' +

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -500,6 +500,7 @@ export function disableDeprecationWarnings(): void {
 
 /** Warn users about deprecated functionality. */
 export function deprecationWarn(msg: string) {
+  console.log('warning about', msg, ENV.get('DEPRECATION_WARNINGS_ENABLED'));
   if (ENV.get('DEPRECATION_WARNINGS_ENABLED')) {
     console.warn(
         msg + ' You can disable deprecation warnings with ' +

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -224,6 +224,7 @@ describe('deprecation warnings', () => {
   beforeEach(() => {
     oldWarn = console.warn;
     spyOn(console, 'warn').and.callFake((msg: string): void => null);
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
   });
   afterEach(() => {
     console.warn = oldWarn;

--- a/src/jasmine_util.ts
+++ b/src/jasmine_util.ts
@@ -151,6 +151,8 @@ function executeTests(
       ENV.reset();
       ENV.setFeatures(testEnv.features);
       ENV.set('IS_TEST', true);
+      // Disable deprecation warnings for tests to not spam the console.
+      ENV.set('DEPRECATION_WARNINGS_ENABLED', false);
       ENV.registerBackend(backendName, testEnv.factory, 1000);
       Environment.setBackend(backendName);
     });

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {deprecationWarn, ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
 import {convertToTensor, convertToTensorArray} from '../tensor_util_env';
 import {DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike4D} from '../types';
@@ -27,6 +27,7 @@ import {concat} from './concat_split';
 import {op} from './operation';
 import {MPRandGauss} from './rand';
 import {zeros, zerosLike} from './tensor_ops';
+
 
 /**
  * Creates a new tensor with the same values and shape as the specified
@@ -320,6 +321,11 @@ function oneHot_(
 function fromPixels_(
     pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
     numChannels = 3): Tensor3D {
+  deprecationWarn(
+      `tf.fromPixels() is renamed to tf.browser.fromPixels(), please switch ` +
+      `to the new method as the old method will be removed in TensorFlow.js ` +
+      `1.0.`);
+
   return browserFromPixels(pixels, numChannels);
 }
 
@@ -337,6 +343,10 @@ function fromPixels_(
 async function toPixels(
     img: Tensor2D|Tensor3D|TensorLike,
     canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
+  deprecationWarn(
+      `tf.toPixels() is renamed to tf.browser.toPixels(), please switch to ` +
+      `the new method as the old method will be removed in TensorFlow.js 1.0.`);
+
   return browserToPixels(img, canvas);
 }
 
@@ -939,7 +949,7 @@ function expandDims_<R2 extends Rank>(
  * ```js
  * const x = tf.tensor4d([1, 2, 3, 4], [1, 1, 1, 4]);
  * const blockSize = 2;
- * const dataFormat = "NHWC";
+ * const dataFormat = 'NHWC';
  *
  * tf.depthToSpace(x, blockSize, dataFormat).print();
  * ```
@@ -962,11 +972,13 @@ function depthToSpace_(
       inputHeight * blockSize >= 0,
       `Negative dimension size caused by overflow when multiplying
       ${inputHeight} and ${blockSize}  for depthToSpace with input shape
-      ${$x.shape}`);
+      $ {
+        $x.shape
+      } `);
 
   util.assert(
       inputWidth * blockSize >= 0,
-      `Negative dimension size caused by overflow when multiplying
+      ` Negative dimension size caused by overflow when multiplying
       ${inputWidth} and ${blockSize} for depthToSpace with input shape
           ${$x.shape}`);
 

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -971,13 +971,11 @@ function depthToSpace_(
       inputHeight * blockSize >= 0,
       `Negative dimension size caused by overflow when multiplying
       ${inputHeight} and ${blockSize}  for depthToSpace with input shape
-      $ {
-        $x.shape
-      } `);
+      ${$x.shape}`);
 
   util.assert(
       inputWidth * blockSize >= 0,
-      ` Negative dimension size caused by overflow when multiplying
+      `Negative dimension size caused by overflow when multiplying
       ${inputWidth} and ${blockSize} for depthToSpace with input shape
           ${$x.shape}`);
 

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -28,7 +28,6 @@ import {op} from './operation';
 import {MPRandGauss} from './rand';
 import {zeros, zerosLike} from './tensor_ops';
 
-
 /**
  * Creates a new tensor with the same values and shape as the specified
  * tensor.

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -1272,6 +1272,56 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   });
 });
 
+describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
+  let oldWarn: (msg: string) => void;
+  beforeEach(() => {
+    oldWarn = console.warn;
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+  });
+  afterEach(() => {
+    console.warn = oldWarn;
+  });
+
+  it('tf.fromPixels', () => {
+    const pixels = new ImageData(1, 1);
+    pixels.data[0] = 0;
+    pixels.data[1] = 80;
+    pixels.data[2] = 160;
+    pixels.data[3] = 240;
+
+    const array = tf.fromPixels(pixels, 3);
+
+    expectArraysEqual(array, [0, 80, 160]);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `tf.fromPixels() is renamed to tf.browser.fromPixels(), please ` +
+            `switch to the new method as the old method will be removed in ` +
+            `TensorFlow.js 1.0. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+
+  it('tf.toPixels', async () => {
+    const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
+
+    const data = await tf.browser.toPixels(x);
+    const expected = new Uint8ClampedArray([
+      Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
+      Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
+    ]);
+    expect(data).toEqual(expected);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `tf.toPixels() is renamed to tf.browser.toPixels(), please ` +
+            `switch to the new method as the old method will be removed in ` +
+            `TensorFlow.js 1.0. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+});
+
 describeWithFlags('fromPixels', BROWSER_ENVS, () => {
   it('ImageData 1x1x3', () => {
     const pixels = new ImageData(1, 1);

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -20,6 +20,7 @@ import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, BROWSER_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, NODE_ENVS, WEBGL_ENVS} from '../test_util';
 import * as util from '../util';
 import {expectArrayInMeanStdRange, jarqueBeraNormalityTest} from './rand_util';
+import { ENV } from '../environment';
 
 describeWithFlags('zeros', ALL_ENVS, () => {
   it('1D default dtype', () => {
@@ -1272,14 +1273,10 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   });
 });
 
-describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
-  let oldWarn: (msg: string) => void;
+describeWithFlags('Deprecation warnings', BROWSER_ENVS, () => {
   beforeEach(() => {
-    oldWarn = console.warn;
     spyOn(console, 'warn').and.callFake((msg: string): void => null);
-  });
-  afterEach(() => {
-    console.warn = oldWarn;
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
   });
 
   it('tf.fromPixels', () => {
@@ -1305,7 +1302,7 @@ describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
   it('tf.toPixels', async () => {
     const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
 
-    const data = await tf.browser.toPixels(x);
+    const data = await tf.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
       Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -2114,7 +2114,6 @@ describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
     const t = tf.tensor1d([5, 3, 2]);
     expectNumbersClose(t.get(1), 3);
 
-    expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn)
         .toHaveBeenCalledWith(
             `Tensor.get() is deprecated. Use Tensor.array() and native array ` +

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -2124,7 +2124,7 @@ describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
 
   it('Tensor.buffer', () => {
     const t = tf.tensor1d([5, 3, 2]);
-    const buffer = t.bufferSync();
+    const buffer = t.buffer<'float32'>();
     expectNumbersClose(buffer.get(1), 3);
 
     expect(console.warn).toHaveBeenCalledTimes(1);

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -2102,3 +2102,40 @@ describeWithFlags('tensor with 0 in shape', ALL_ENVS, () => {
     expectArraysEqual(a, []);
   });
 });
+
+describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
+  let oldWarn: (msg: string) => void;
+  beforeEach(() => {
+    oldWarn = console.warn;
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+  });
+  afterEach(() => {
+    console.warn = oldWarn;
+  });
+
+  it('Tensor.get', () => {
+    const t = tf.tensor1d([5, 3, 2]);
+    expectNumbersClose(t.get(1), 3);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `Tensor.get() is deprecated. Use Tensor.array() and native array ` +
+            `indexing instead. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+
+  it('Tensor.buffer', () => {
+    const t = tf.tensor1d([5, 3, 2]);
+    const buffer = t.bufferSync();
+    expectNumbersClose(buffer.get(1), 3);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `Tensor.buffer() is renamed to Tensor.bufferSync() in ` +
+            `TensorFlow.js 1.0 and Tensor.buffer() will become an async ` +
+            `function. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+});

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from './environment';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
 import {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from './tensor';
@@ -2104,13 +2105,9 @@ describeWithFlags('tensor with 0 in shape', ALL_ENVS, () => {
 });
 
 describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
-  let oldWarn: (msg: string) => void;
   beforeEach(() => {
-    oldWarn = console.warn;
     spyOn(console, 'warn').and.callFake((msg: string): void => null);
-  });
-  afterEach(() => {
-    console.warn = oldWarn;
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
   });
 
   it('Tensor.get', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,17 @@ export interface ShapeMap {
   R6: [number, number, number, number, number, number];
 }
 
+/** @docalias number[] */
+export interface ArrayMap {
+  R0: number;
+  R1: number[];
+  R2: number[][];
+  R3: number[][][];
+  R4: number[][][][];
+  R5: number[][][][][];
+  R6: number[][][][][][];
+}
+
 export interface DataTypeMap {
   float32: Float32Array;
   int32: Int32Array;


### PR DESCRIPTION
Towards https://github.com/tensorflow/tfjs/issues/1210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1547)
<!-- Reviewable:end -->
