### PR TITLE
Cherry pick to 0.15.x: Remove Tensor.get(). Make tensor.buffer() async. Add tensor.array() 

### DIFF
--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -20,7 +20,7 @@ import {describeWithFlags} from './jasmine_util';
 import {MathBackendCPU} from './kernels/backend_cpu';
 import {MathBackendWebGL} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
-import {ALL_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, expectNumbersClose, WEBGL_ENVS} from './test_util';
+import {ALL_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, WEBGL_ENVS} from './test_util';
 
 describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
   it('debug mode does not error when no nans', () => {
@@ -200,7 +200,7 @@ describeWithFlags('valueAndGradients', ALL_ENVS, () => {
           return tf.sum(y);
         })([a, b]);
 
-    expectNumbersClose(value.get(), 10);
+    expectArraysClose(value, 10);
 
     // de/dy = 1
     // dy/dm = step(m)
@@ -235,7 +235,7 @@ describeWithFlags('valueAndGradients', ALL_ENVS, () => {
           });
         })([a, b]);
 
-    expectNumbersClose(value.get(), 10);
+    expectArraysClose(value, 10);
 
     // de/dy = 1
     // dy/dm = step(m)

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -187,7 +187,7 @@ describeWithFlags('epsilon', {}, () => {
   });
 
   it('abs(epsilon) > 0', () => {
-    expect(tf.abs(ENV.get('EPSILON')).get()).toBeGreaterThan(0);
+    expect(tf.abs(ENV.get('EPSILON')).arraySync()).toBeGreaterThan(0);
   });
 });
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -262,10 +262,11 @@ export class MathBackendCPU implements KernelBackend {
     }
 
     const buffer = ops.buffer(size, x.dtype);
+    const xBuf = x.bufferSync();
     for (let i = 0; i < buffer.size; ++i) {
       const loc = buffer.indexToLoc(i);
       const xLoc = loc.map((idx, j) => idx + begin[j]);
-      buffer.values[i] = x.get(...xLoc);
+      buffer.values[i] = xBuf.get(...xLoc);
     }
     return buffer.toTensor() as T;
   }
@@ -287,7 +288,7 @@ export class MathBackendCPU implements KernelBackend {
     }
 
     const buffer = ops.buffer(size, x.dtype);
-
+    const xBuf = x.bufferSync();
     for (let i = 0; i < buffer.size; i++) {
       const loc = buffer.indexToLoc(i);
 
@@ -295,7 +296,7 @@ export class MathBackendCPU implements KernelBackend {
       for (let j = 0; j < newLoc.length; j++) {
         newLoc[j] = loc[j] * strides[j] + beginIndex[j];
       }
-      buffer.set(x.get(...newLoc), ...loc);
+      buffer.set(xBuf.get(...newLoc), ...loc);
     }
 
     return buffer.toTensor().reshape(shape) as T;
@@ -326,13 +327,13 @@ export class MathBackendCPU implements KernelBackend {
     this.assertNotComplex(x, 'reverse');
 
     const buffer = ops.buffer(x.shape, x.dtype);
-    const xBuffer = x.buffer();
+    const xBuf = x.bufferSync();
 
     for (let i = 0; i < buffer.size; i++) {
       const outLoc = buffer.indexToLoc(i);
       const inLoc = outLoc.slice();
       axis.forEach(ax => inLoc[ax] = x.shape[ax] - 1 - inLoc[ax]);
-      buffer.set(xBuffer.get(...inLoc), ...outLoc);
+      buffer.set(xBuf.get(...inLoc), ...outLoc);
     }
 
     return buffer.toTensor() as T;
@@ -1720,7 +1721,8 @@ export class MathBackendCPU implements KernelBackend {
 
     const leftPad = convInfo.padInfo.left;
     const topPad = convInfo.padInfo.top;
-
+    const xBuf = x.bufferSync();
+    const dyBuf = dy.bufferSync();
     for (let wR = 0; wR < filterHeight; ++wR) {
       const yRMin = Math.max(0, Math.ceil((topPad - wR) / strideHeight));
       const yRMax = Math.min(
@@ -1740,7 +1742,7 @@ export class MathBackendCPU implements KernelBackend {
                 const xR = wR + yR * strideHeight - topPad;
                 for (let yC = yCMin; yC < yCMax; ++yC) {
                   const xC = wC + yC * strideWidth - leftPad;
-                  dotProd += x.get(b, xR, xC, d1) * dy.get(b, yR, yC, d2);
+                  dotProd += xBuf.get(b, xR, xC, d1) * dyBuf.get(b, yR, yC, d2);
                 }
               }
             }
@@ -1971,6 +1973,8 @@ export class MathBackendCPU implements KernelBackend {
     const topPad = convInfo.padInfo.top;
     const chMul = convInfo.outChannels / convInfo.inChannels;
 
+    const xBuf = x.bufferSync();
+    const dyBuf = dy.bufferSync();
     for (let wR = 0; wR < filterHeight; ++wR) {
       const yRMin = Math.max(0, Math.ceil((topPad - wR) / strideHeight));
       const yRMax = Math.min(
@@ -1991,7 +1995,7 @@ export class MathBackendCPU implements KernelBackend {
               const xR = wR + yR * strideHeight - topPad;
               for (let yC = yCMin; yC < yCMax; ++yC) {
                 const xC = wC + yC * strideWidth - leftPad;
-                dotProd += x.get(b, xR, xC, d1) * dy.get(b, yR, yC, d2);
+                dotProd += xBuf.get(b, xR, xC, d1) * dyBuf.get(b, yR, yC, d2);
               }
             }
           }
@@ -2010,7 +2014,7 @@ export class MathBackendCPU implements KernelBackend {
       newShape[i] = x.shape[i] * reps[i];
     }
     const result = ops.buffer(newShape, x.dtype);
-    const xBuf = x.buffer();
+    const xBuf = x.bufferSync();
     for (let i = 0; i < result.values.length; ++i) {
       const newLoc = result.indexToLoc(i);
 
@@ -2033,7 +2037,7 @@ export class MathBackendCPU implements KernelBackend {
     const outShape = paddings.map(
         (p, i) => p[0] /* beforePad */ + x.shape[i] + p[1] /* afterPad */);
     const start = paddings.map(p => p[0]);
-    const xBuffer = x.buffer();
+    const xBuffer = x.bufferSync();
     const buffer = ops.buffer(outShape, x.dtype as 'float32');
     if (constantValue !== 0) {
       buffer.values.fill(constantValue);
@@ -2042,7 +2046,7 @@ export class MathBackendCPU implements KernelBackend {
     for (let i = 0; i < x.size; i++) {
       const coords = xBuffer.indexToLoc(i);
       const outCoords = coords.map((c, i) => c + start[i]);
-      buffer.set(x.get(...coords), ...outCoords);
+      buffer.set(xBuffer.get(...coords), ...outCoords);
     }
     return buffer.toTensor() as T;
   }
@@ -2057,7 +2061,7 @@ export class MathBackendCPU implements KernelBackend {
     const values = x.dataSync();
     const result = buffer(newShape, x.dtype);
 
-    const xBuf = x.buffer();
+    const xBuf = x.bufferSync();
     for (let i = 0; i < x.size; ++i) {
       const loc = xBuf.indexToLoc(i);
 
@@ -2080,7 +2084,7 @@ export class MathBackendCPU implements KernelBackend {
     const indicesValues = indices.dataSync();
     newShape[axis] = indicesValues.length;
     const result = buffer(newShape, x.dtype);
-    const xBuf = x.buffer();
+    const xBuf = x.bufferSync();
 
     for (let i = 0; i < result.size; ++i) {
       const newLoc = result.indexToLoc(i);
@@ -2227,6 +2231,7 @@ export class MathBackendCPU implements KernelBackend {
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
 
+    const xBuf = x.bufferSync();
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
         for (let yR = 0; yR < convInfo.outHeight; ++yR) {
@@ -2253,7 +2258,7 @@ export class MathBackendCPU implements KernelBackend {
               const wR = xR - xRCorner;
               for (let xC = xCMin; xC < xCMax; xC += dilationWidth) {
                 const wC = xC - xCCorner;
-                const pixel = x.get(b, xR, xC, d);
+                const pixel = xBuf.get(b, xR, xC, d);
                 if (pixel > maxValue) {
                   maxValue = pixel;
                   maxPosition = wR * effectiveFilterWidth + wC;
@@ -2283,6 +2288,9 @@ export class MathBackendCPU implements KernelBackend {
     const padTop = effectiveFilterHeight - 1 - convInfo.padInfo.top;
     const dx = ops.buffer<Rank.R4>(x.shape, 'float32');
 
+    const maxPosBuf = maxPositions.bufferSync();
+    const dyBuf = dy.bufferSync();
+
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
         for (let dxR = 0; dxR < convInfo.inHeight; ++dxR) {
@@ -2304,7 +2312,7 @@ export class MathBackendCPU implements KernelBackend {
                   continue;
                 }
                 const maxPos = effectiveFilterHeight * effectiveFilterWidth -
-                    1 - maxPositions.get(b, dyR, dyC, d);
+                    1 - maxPosBuf.get(b, dyR, dyC, d);
                 const curPos = wR * effectiveFilterWidth + wC;
 
                 const mask = maxPos === curPos ? 1 : 0;
@@ -2312,7 +2320,7 @@ export class MathBackendCPU implements KernelBackend {
                   continue;
                 }
 
-                const pixel = dy.get(b, dyR, dyC, d);
+                const pixel = dyBuf.get(b, dyR, dyC, d);
                 dotProd += pixel * mask;
               }
             }
@@ -2341,6 +2349,8 @@ export class MathBackendCPU implements KernelBackend {
 
     const avgMultiplier = 1 / (filterHeight * filterWidth);
 
+    const dyBuf = dy.bufferSync();
+
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
         for (let dxR = 0; dxR < convInfo.inHeight; ++dxR) {
@@ -2362,7 +2372,7 @@ export class MathBackendCPU implements KernelBackend {
                   continue;
                 }
 
-                const pixel = dy.get(b, dyR, dyC, d);
+                const pixel = dyBuf.get(b, dyR, dyC, d);
                 dotProd += pixel;
               }
             }
@@ -2843,10 +2853,11 @@ export class MathBackendCPU implements KernelBackend {
 
     const res = new Float32Array(indices.size * depth);
     res.fill(offValue);
+    const indicesVal = indices.dataSync();
 
     for (let event = 0; event < indices.size; ++event) {
-      if (indices.get(event) >= 0 && indices.get(event) < depth) {
-        res[event * depth + indices.get(event)] = onValue;
+      if (indicesVal[event] >= 0 && indicesVal[event] < depth) {
+        res[event * depth + indicesVal[event]] = onValue;
       }
     }
     return ops.tensor2d(res, [indices.size, depth], 'int32');
@@ -3041,8 +3052,8 @@ export class MathBackendCPU implements KernelBackend {
         resVals[i] = op(aVals[i % aVals.length], bVals[i % bVals.length]);
       }
     } else {
-      const aBuf = a.buffer();
-      const bBuf = b.buffer();
+      const aBuf = a.bufferSync();
+      const bBuf = b.bufferSync();
       for (let i = 0; i < resVals.length; ++i) {
         const loc = result.indexToLoc(i);
 
@@ -3091,8 +3102,8 @@ export class MathBackendCPU implements KernelBackend {
         imagVals[i] = result.imag;
       }
     } else {
-      const aRealBuf = this.data.get(a.dataId).complexTensors.real.buffer();
-      const bRealBuf = this.data.get(b.dataId).complexTensors.real.buffer();
+      const aRealBuf = this.data.get(a.dataId).complexTensors.real.bufferSync();
+      const bRealBuf = this.data.get(b.dataId).complexTensors.real.bufferSync();
       for (let i = 0; i < realVals.length; i++) {
         const loc = realResult.indexToLoc(i);
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2187,10 +2187,10 @@ export class MathBackendWebGL implements KernelBackend {
       // trying to upload a small value.
       const debugFlag = ENV.get('DEBUG');
       ENV.set('DEBUG', false);
-      const underflowCheckVluae = this.abs(scalar(1e-8)).get();
+      const underflowCheckValue = this.abs(scalar(1e-8)).dataSync()[0];
       ENV.set('DEBUG', debugFlag);
 
-      if (underflowCheckVluae > 0) {
+      if (underflowCheckValue > 0) {
         return 32;
       }
       return 16;

--- a/src/ops/arithmetic_test.ts
+++ b/src/ops/arithmetic_test.ts
@@ -457,11 +457,11 @@ describeWithFlags('mul', ALL_ENVS, () => {
 
     expect(da.shape).toEqual(a.shape);
     expect(da.dtype).toEqual('float32');
-    expectArraysClose(da, [b.get() * dy.get()]);
+    expectArraysClose(da, b.mul(dy));
 
     expect(db.shape).toEqual(b.shape);
     expect(db.dtype).toEqual('float32');
-    expectArraysClose(db, [a.get() * dy.get()]);
+    expectArraysClose(db, a.mul(dy));
   });
 
   it('gradient: Tensor1D', () => {

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -80,36 +80,39 @@ describeWithFlags('batchNormalization', WEBGL_ENVS, () => {
 });
 
 describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
-  it('simple batchnorm4D, no offset or scale, 2x1x1x2', () => {
-    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
+  it('simple batchnorm4D, no offset or scale, 2x1x1x2', async () => {
+    const xT = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+        xT, meanT, varianceT, varianceEpsilon, undefined, undefined);
 
+    const x = await xT.array() as number[][][][];
+    const mean = await meanT.array() as number[];
+    const variance = await varianceT.array() as number[];
     expectArraysClose(result, [
-      (x.get(0, 0, 0, 0) - mean.get(0)) * 1 /
-          Math.sqrt(variance.get(0) + varianceEpsilon),
-      (x.get(0, 0, 0, 1) - mean.get(1)) * 1 /
-          Math.sqrt(variance.get(1) + varianceEpsilon),
-      (x.get(1, 0, 0, 0) - mean.get(0)) * 1 /
-          Math.sqrt(variance.get(0) + varianceEpsilon),
-      (x.get(1, 0, 0, 1) - mean.get(1)) * 1 /
-          Math.sqrt(variance.get(1) + varianceEpsilon)
+      (x[0][0][0][0] - mean[0]) * 1 / Math.sqrt(variance[0] + varianceEpsilon),
+      (x[0][0][0][1] - mean[1]) * 1 / Math.sqrt(variance[1] + varianceEpsilon),
+      (x[1][0][0][0] - mean[0]) * 1 / Math.sqrt(variance[0] + varianceEpsilon),
+      (x[1][0][0][1] - mean[1]) * 1 / Math.sqrt(variance[1] + varianceEpsilon)
     ]);
   });
 
-  it('simple batchnorm4D, no offset, 2x1x1x2', () => {
-    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const scale = tf.tensor1d([4, 5]);
+  it('simple batchnorm4D, no offset, 2x1x1x2', async () => {
+    const xT = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const scaleT = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, undefined);
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const scale = await scaleT.buffer();
 
     expectArraysClose(result, [
       (x.get(0, 0, 0, 0) - mean.get(0)) * scale.get(0) /
@@ -123,16 +126,20 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
     ]);
   });
 
-  it('simple batchnorm4D, no scale, 2x1x1x2', () => {
-    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([4, 5]);
+  it('simple batchnorm4D, no scale, 2x1x1x2', async () => {
+    const xT = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+        xT, meanT, varianceT, varianceEpsilon, undefined, offsetT);
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const offset = await offsetT.buffer();
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -150,17 +157,22 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
     ]);
   });
 
-  it('simple batchnorm4D, 2x1x1x2', () => {
-    const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([3, 4]);
-    const scale = tf.tensor1d([4, 5]);
+  it('simple batchnorm4D, 2x1x1x2', async () => {
+    const xT = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([3, 4]);
+    const scaleT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const scale = await scaleT.buffer();
+    const offset = await offsetT.buffer();
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -277,15 +289,17 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 });
 
 describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
-  it('simple batchnorm3D, no offset or scale, 2x1x2', () => {
-    const x = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
+  it('simple batchnorm3D, no offset or scale, 2x1x2', async () => {
+    const xT = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
-
+        xT, meanT, varianceT, varianceEpsilon, undefined, undefined);
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
     expectArraysClose(result, [
       (x.get(0, 0, 0) - mean.get(0)) * 1 /
           Math.sqrt(variance.get(0) + varianceEpsilon),
@@ -298,16 +312,20 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     ]);
   });
 
-  it('simple batchnorm3D, no offset, 2x1x2', () => {
-    const x = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const scale = tf.tensor1d([4, 5]);
+  it('simple batchnorm3D, no offset, 2x1x2', async () => {
+    const xT = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const scaleT = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, undefined);
 
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const scale = await scaleT.buffer();
     expectArraysClose(result, [
       (x.get(0, 0, 0) - mean.get(0)) * scale.get(0) /
           Math.sqrt(variance.get(0) + varianceEpsilon),
@@ -320,17 +338,21 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     ]);
   });
 
-  it('simple batchnorm3D, no scale, 2x1x2', () => {
-    const x = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([4, 5]);
+  it('simple batchnorm3D, no scale, 2x1x2', async () => {
+    const xT = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+        xT, meanT, varianceT, varianceEpsilon, undefined, offsetT);
 
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const offset = await offsetT.buffer();
     expectArraysClose(result, [
       offset.get(0) +
           (x.get(0, 0, 0) - mean.get(0)) * 1 /
@@ -347,17 +369,22 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     ]);
   });
 
-  it('simple batchnorm3D, 2x1x2', () => {
-    const x = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([3, 4]);
-    const scale = tf.tensor1d([4, 5]);
+  it('simple batchnorm3D, 2x1x2', async () => {
+    const xT = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([3, 4]);
+    const scaleT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const offset = await offsetT.buffer();
+    const scale = await scaleT.buffer();
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -403,19 +430,24 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     ]);
   });
 
-  it('batchnorm3D, x,mean,var,offset,scale are all 3D', () => {
+  it('batchnorm3D, x,mean,var,offset,scale are all 3D', async () => {
     const shape: [number, number, number] = [2, 1, 2];
-    const x = tf.tensor3d([2, 4, 9, 23], shape);
-    const mean = tf.tensor3d([1, 2, 3, 4], shape);
-    const variance = tf.tensor3d([2, 3, 4, 5], shape);
-    const offset = tf.tensor3d([3, 4, 5, 6], shape);
-    const scale = tf.tensor3d([4, 5, 6, 7], shape);
+    const xT = tf.tensor3d([2, 4, 9, 23], shape);
+    const meanT = tf.tensor3d([1, 2, 3, 4], shape);
+    const varianceT = tf.tensor3d([2, 3, 4, 5], shape);
+    const offsetT = tf.tensor3d([3, 4, 5, 6], shape);
+    const scaleT = tf.tensor3d([4, 5, 6, 7], shape);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
 
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const offset = await offsetT.buffer();
+    const scale = await scaleT.buffer();
     expectArraysClose(result, [
       offset.get(0, 0, 0) +
           (x.get(0, 0, 0) - mean.get(0, 0, 0)) * scale.get(0, 0, 0) /
@@ -528,15 +560,18 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 });
 
 describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
-  it('simple batchnorm2D, no offset or scale, 2x2', () => {
-    const x = tf.tensor2d([2, 4, 9, 23], [2, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
+  it('simple batchnorm2D, no offset or scale, 2x2', async () => {
+    const xT = tf.tensor2d([2, 4, 9, 23], [2, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+        xT, meanT, varianceT, varianceEpsilon, undefined, undefined);
 
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
     expectArraysClose(result, [
       (x.get(0, 0) - mean.get(0)) * 1 /
           Math.sqrt(variance.get(0) + varianceEpsilon),
@@ -548,16 +583,20 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
           Math.sqrt(variance.get(1) + varianceEpsilon)
     ]);
   });
-  it('simple batchnorm2D, no offset, 2x2', () => {
-    const x = tf.tensor2d([2, 4, 9, 23], [2, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const scale = tf.tensor1d([4, 5]);
+  it('simple batchnorm2D, no offset, 2x2', async () => {
+    const xT = tf.tensor2d([2, 4, 9, 23], [2, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const scaleT = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, undefined);
 
+    const x = await xT.buffer();
+    const mean = await meanT.buffer();
+    const variance = await varianceT.buffer();
+    const scale = await scaleT.buffer();
     expectArraysClose(result, [
       (x.get(0, 0) - mean.get(0)) * scale.get(0) /
           Math.sqrt(variance.get(0) + varianceEpsilon),
@@ -571,57 +610,64 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
   });
 
   it('simple batchnorm2D, no scale, 2x2', () => {
-    const x = tf.tensor2d([2, 4, 9, 23], [2, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([4, 5]);
+    const xT = tf.tensor2d([2, 4, 9, 23], [2, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+        xT, meanT, varianceT, varianceEpsilon, undefined, offsetT);
+
+    const offset = offsetT.arraySync() as number[];
+    const mean = meanT.arraySync() as number[];
+    const variance = varianceT.arraySync() as number[];
+    const x = xT.arraySync() as number[][];
 
     expectArraysClose(result, [
-      offset.get(0) +
-          (x.get(0, 0) - mean.get(0)) * 1 /
-              Math.sqrt(variance.get(0) + varianceEpsilon),
-      offset.get(1) +
-          (x.get(0, 1) - mean.get(1)) * 1 /
-              Math.sqrt(variance.get(1) + varianceEpsilon),
-      offset.get(0) +
-          (x.get(1, 0) - mean.get(0)) * 1 /
-              Math.sqrt(variance.get(0) + varianceEpsilon),
-      offset.get(1) +
-          (x.get(1, 1) - mean.get(1)) * 1 /
-              Math.sqrt(variance.get(1) + varianceEpsilon)
+      offset[0] +
+          (x[0][0] - mean[0]) * 1 / Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[0][1] - mean[1]) * 1 / Math.sqrt(variance[1] + varianceEpsilon),
+      offset[0] +
+          (x[1][0] - mean[0]) * 1 / Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[1][1] - mean[1]) * 1 / Math.sqrt(variance[1] + varianceEpsilon)
     ]);
   });
 
   it('simple batchnorm2D, 2x2', () => {
-    const x = tf.tensor2d([2, 4, 9, 23], [2, 2]);
-    const mean = tf.tensor1d([1, 2]);
-    const variance = tf.tensor1d([2, 3]);
-    const offset = tf.tensor1d([3, 4]);
-    const scale = tf.tensor1d([4, 5]);
+    const xT = tf.tensor2d([2, 4, 9, 23], [2, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([3, 4]);
+    const scaleT = tf.tensor1d([4, 5]);
 
     const varianceEpsilon = .001;
 
     const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
+
+    const offset = offsetT.arraySync() as number[];
+    const mean = meanT.arraySync() as number[];
+    const variance = varianceT.arraySync() as number[];
+    const scale = scaleT.arraySync() as number[];
+    const x = xT.arraySync() as number[][];
 
     expectArraysClose(result, [
-      offset.get(0) +
-          (x.get(0, 0) - mean.get(0)) * scale.get(0) /
-              Math.sqrt(variance.get(0) + varianceEpsilon),
-      offset.get(1) +
-          (x.get(0, 1) - mean.get(1)) * scale.get(1) /
-              Math.sqrt(variance.get(1) + varianceEpsilon),
-      offset.get(0) +
-          (x.get(1, 0) - mean.get(0)) * scale.get(0) /
-              Math.sqrt(variance.get(0) + varianceEpsilon),
-      offset.get(1) +
-          (x.get(1, 1) - mean.get(1)) * scale.get(1) /
-              Math.sqrt(variance.get(1) + varianceEpsilon)
+      offset[0] +
+          (x[0][0] - mean[0]) * scale[0] /
+              Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[0][1] - mean[1]) * scale[1] /
+              Math.sqrt(variance[1] + varianceEpsilon),
+      offset[0] +
+          (x[1][0] - mean[0]) * scale[0] /
+              Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[1][1] - mean[1]) * scale[1] /
+              Math.sqrt(variance[1] + varianceEpsilon)
     ]);
   });
 

--- a/src/ops/loss_ops_test.ts
+++ b/src/ops/loss_ops_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {ALL_ENVS, expectArraysClose, expectNumbersClose} from '../test_util';
+import {ALL_ENVS, expectArraysClose} from '../test_util';
 
 describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
   it('1D - no weights', () => {
@@ -26,7 +26,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 + 2 + 3) / 3);
+    expectArraysClose(y, (1 + 2 + 3) / 3);
   });
 
   it('1D - no weights - Reduction.NONE', () => {
@@ -46,7 +46,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
         tf.losses.computeWeightedLoss(losses, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 + 2 + 3) / 3);
+    expectArraysClose(y, (1 + 2 + 3) / 3);
   });
 
   it('1D - no weights - Reduction.SUM', () => {
@@ -56,7 +56,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
         tf.losses.computeWeightedLoss(losses, undefined, tf.Reduction.SUM);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 + 2 + 3));
+    expectArraysClose(y, (1 + 2 + 3));
   });
 
   it('1D - weights', () => {
@@ -66,7 +66,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 * 0.1 + 2 * 0 + 3 * 0.3) / 2);
+    expectArraysClose(y, (1 * 0.1 + 2 * 0 + 3 * 0.3) / 2);
   });
 
   it('2D - weights - broadcast', () => {
@@ -76,7 +76,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.06666667);
+    expectArraysClose(y, 0.06666667);
   });
 
   it('1D - weights - Reduction.NONE', () => {
@@ -96,7 +96,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 * 0.1 + 2 * 0.2 + 3 * 0.3) / 0.6);
+    expectArraysClose(y, (1 * 0.1 + 2 * 0.2 + 3 * 0.3) / 0.6);
   });
 
   it('1D - weights - Reduction.SUM', () => {
@@ -106,7 +106,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights, tf.Reduction.SUM);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 * 0.1 + 2 * 0.2 + 3 * 0.3));
+    expectArraysClose(y, (1 * 0.1 + 2 * 0.2 + 3 * 0.3));
   });
 
   it('2D - no weights', () => {
@@ -115,7 +115,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (4 + 8 + 12 + 8 + 1 + 3) / 6);
+    expectArraysClose(y, (4 + 8 + 12 + 8 + 1 + 3) / 6);
   });
 
   it('2D - weights', () => {
@@ -125,8 +125,8 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(), (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6) / 4);
+    expectArraysClose(
+        y, (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6) / 4);
   });
 
   it('2D - no weights - Reduction.MEAN', () => {
@@ -136,7 +136,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
         tf.losses.computeWeightedLoss(losses, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (4 + 8 + 12 + 8 + 1 + 3) / 6);
+    expectArraysClose(y, (4 + 8 + 12 + 8 + 1 + 3) / 6);
   });
 
   it('2D - weights - Reduction.MEAN', () => {
@@ -146,8 +146,8 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(), (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6) / 4);
+    expectArraysClose(
+        y, (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6) / 4);
   });
 
   it('2D - weights - broadcast - MEAN', () => {
@@ -157,7 +157,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (0.3 + 0.1 + 0.2) / (3 * 0.6));
+    expectArraysClose(y, (0.3 + 0.1 + 0.2) / (3 * 0.6));
   });
 
   it('2D - no weights - Reduction.SUM', () => {
@@ -167,7 +167,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
         tf.losses.computeWeightedLoss(losses, undefined, tf.Reduction.SUM);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (4 + 8 + 12 + 8 + 1 + 3));
+    expectArraysClose(y, (4 + 8 + 12 + 8 + 1 + 3));
   });
 
   it('2D - weights - Reduction.SUM', () => {
@@ -177,8 +177,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights, tf.Reduction.SUM);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(), (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6));
+    expectArraysClose(y, (4 * 1 + 8 * 0 + 12 * 2 + (8 * -5) + 1 * 0 + 3 * 6));
   });
 
   it('2D - no weights - Reduction.NONE', () => {
@@ -229,7 +228,7 @@ describeWithFlags('computeWeightedLoss', ALL_ENVS, () => {
     const y = tf.losses.computeWeightedLoss(losses, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 * 0.1 + 2 * 0 + 3 * 0.3) / 2);
+    expectArraysClose(y, (1 * 0.1 + 2 * 0 + 3 * 0.3) / 2);
   });
 });
 
@@ -241,8 +240,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
     const y = tf.losses.absoluteDifference(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(1 - 0.3) + Math.abs(2 - (-0.6)) + Math.abs(3 - (-0.1))) / 3);
   });
 
@@ -254,8 +253,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
     const y = tf.losses.absoluteDifference(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(1 - 0.3) * 0.1 + Math.abs(2 - (-0.6)) * 0.2 +
          Math.abs(3 - (-0.1)) * 0.3) /
             3);
@@ -284,8 +283,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
         label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(1 - 0.3) + Math.abs(2 - (-0.6)) + Math.abs(3 - (-0.1))) / 3);
   });
 
@@ -298,8 +297,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
         label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((Math.abs(1 - 0.3) * 0.1) + (Math.abs(2 - (-0.6)) * 0.2) +
          (Math.abs(3 - (-0.1)) * 0.3)) /
             0.6);
@@ -312,8 +311,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
     const y = tf.losses.absoluteDifference(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(4 - 1) + Math.abs(8 - 9) + Math.abs(12 - 2) +
          Math.abs(8 - (-5)) + Math.abs(1 - (-2)) + Math.abs(3 - 6)) /
             6);
@@ -327,8 +326,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
     const y = tf.losses.absoluteDifference(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(4 - 1) * 3 + Math.abs(8 - 9) * 0 + Math.abs(12 - 2) * 5 +
          Math.abs(8 - (-5)) * 0 + Math.abs(1 - (-2)) * 4 +
          Math.abs(3 - 6) * 2) /
@@ -358,8 +357,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
         label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(4 - 1) + Math.abs(8 - 9) + Math.abs(12 - 2) +
          Math.abs(8 - (-5)) + Math.abs(1 - (-2)) + Math.abs(3 - 6)) /
             6);
@@ -374,8 +373,8 @@ describeWithFlags('absoluteDifference', ALL_ENVS, () => {
         label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (Math.abs(4 - 1) * 3 + Math.abs(8 - 9) * 6 + Math.abs(12 - 2) * 5 +
          Math.abs(8 - (-5)) * 0 + Math.abs(1 - (-2)) * 4 +
          Math.abs(3 - 6) * 2) /
@@ -443,8 +442,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
     const y = tf.losses.meanSquaredError(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - 0.3) * (1 - 0.3) + (2 - (-0.6)) * (2 - (-0.6)) +
          (3 - (-0.1)) * (3 - (-0.1))) /
             3);
@@ -458,8 +457,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
     const y = tf.losses.meanSquaredError(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - 0.3) * (1 - 0.3) * 0.1 + (2 - (-0.6)) * (2 - (-0.6)) * 0.2 +
          (3 - (-0.1)) * (3 - (-0.1)) * 0.3) /
             3);
@@ -488,8 +487,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
         label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - 0.3) * (1 - 0.3) + (2 - (-0.6)) * (2 - (-0.6)) +
          (3 - (-0.1)) * (3 - (-0.1))) /
             3);
@@ -504,8 +503,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
         label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         (((1 - 0.3) * (1 - 0.3) * 0.1) + ((2 - (-0.6)) * (2 - (-0.6)) * 0.2) +
          ((3 - (-0.1)) * (3 - (-0.1)) * 0.3)) /
             0.6);
@@ -518,8 +517,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
     const y = tf.losses.meanSquaredError(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((4 - 1) * (4 - 1) + (8 - 9) * (8 - 9) + (12 - 2) * (12 - 2) +
          (8 - (-5)) * (8 - (-5)) + (1 - (-2)) * (1 - (-2)) +
          (3 - 6) * (3 - 6)) /
@@ -534,8 +533,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
     const y = tf.losses.meanSquaredError(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((4 - 1) * (4 - 1) * 3 + (8 - 9) * (8 - 9) * 0 +
          (12 - 2) * (12 - 2) * 5 + (8 - (-5)) * (8 - (-5)) * 0 +
          (1 - (-2)) * (1 - (-2)) * 4 + (3 - 6) * (3 - 6) * 2) /
@@ -566,8 +565,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
         label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((4 - 1) * (4 - 1) + (8 - 9) * (8 - 9) + (12 - 2) * (12 - 2) +
          (8 - (-5)) * (8 - (-5)) + (1 - (-2)) * (1 - (-2)) +
          (3 - 6) * (3 - 6)) /
@@ -583,8 +582,8 @@ describeWithFlags('meanSquaredError', ALL_ENVS, () => {
         label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((4 - 1) * (4 - 1) * 3 + (8 - 9) * (8 - 9) * 6 +
          (12 - 2) * (12 - 2) * 5 + (8 - (-5)) * (8 - (-5)) * 0 +
          (1 - (-2)) * (1 - (-2)) * 4 + (3 - 6) * (3 - 6) * 2) /
@@ -651,7 +650,7 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
     const y = tf.losses.cosineDistance(label, predictions, 0);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1));
+    expectArraysClose(y, 1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1));
   });
 
   it('1D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -662,7 +661,7 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
     const y = tf.losses.cosineDistance(label, predictions, 0, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)) * 0.1);
+    expectArraysClose(y, (1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)) * 0.1);
   });
 
   it('1D - weighted - Reduction.NONE', () => {
@@ -685,7 +684,7 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
         label, predictions, 0, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), (1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)));
+    expectArraysClose(y, (1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)));
   });
 
   it('1D - weighted - Reduction.MEAN', () => {
@@ -697,8 +696,7 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
         label, predictions, 0, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(), ((1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)) * 0.1) / 0.1);
+    expectArraysClose(y, ((1 - (1 * 0.3 + 2 * -0.6 + 3 * -0.1)) * 0.1) / 0.1);
   });
 
   it('2D', () => {
@@ -708,8 +706,8 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
     const y = tf.losses.cosineDistance(label, predictions, 1);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - (4 * 1 + 8 * 9 + 12 * 2)) + (1 - (8 * -5 + 1 * -2 + 3 * 6))) / 2);
   });
 
@@ -721,8 +719,8 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
     const y = tf.losses.cosineDistance(label, predictions, 1, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - (4 * 1 + 8 * 9 + 12 * 2)) * 3 +
          (1 - (8 * -5 + 1 * -2 + 3 * 6)) * 0) /
             1);
@@ -750,8 +748,8 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
         label, predictions, 1, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - (4 * 1 + 8 * 9 + 12 * 2)) + (1 - (8 * -5 + 1 * -2 + 3 * 6))) / 2);
   });
 
@@ -764,8 +762,8 @@ describeWithFlags('cosineDistance', ALL_ENVS, () => {
         label, predictions, 1, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         ((1 - (4 * 1 + 8 * 9 + 12 * 2)) * 3 +
          (1 - (8 * -5 + 1 * -2 + 3 * 6)) * 0) /
             3);
@@ -827,7 +825,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
     const y = tf.losses.hingeLoss(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.0);
+    expectArraysClose(y, 1.0);
   });
 
   it('1D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -838,7 +836,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
     const y = tf.losses.hingeLoss(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.225);
+    expectArraysClose(y, 0.225);
   });
 
   it('1D - weighted - Reduction.NONE', () => {
@@ -861,7 +859,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
         tf.losses.hingeLoss(label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.0);
+    expectArraysClose(y, 1.0);
   });
 
   it('1D - weighted - Reduction.MEAN', () => {
@@ -873,7 +871,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
         tf.losses.hingeLoss(label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.9);
+    expectArraysClose(y, 0.9);
   });
 
   it('2D', () => {
@@ -883,7 +881,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
     const y = tf.losses.hingeLoss(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.8333333);
+    expectArraysClose(y, 0.8333333);
   });
 
   it('2D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -894,7 +892,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
     const y = tf.losses.hingeLoss(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.26666668);
+    expectArraysClose(y, 0.26666668);
   });
 
   it('2D - weighted - Reduction.NONE', () => {
@@ -917,7 +915,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
         tf.losses.hingeLoss(label, predictions, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.8333333);
+    expectArraysClose(y, 0.8333333);
   });
 
   it('2D - weighted - Reduction.MEAN', () => {
@@ -929,7 +927,7 @@ describeWithFlags('hingeLoss', ALL_ENVS, () => {
         tf.losses.hingeLoss(label, predictions, weights, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.76190484);
+    expectArraysClose(y, 0.76190484);
   });
 
   it('throws when passed label as a non-tensor', () => {
@@ -988,7 +986,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
     const y = tf.losses.logLoss(labels, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 2.668788);
+    expectArraysClose(y, 2.668788);
   });
 
   it('1D - Check for negative values', () => {
@@ -998,7 +996,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
     const y = tf.losses.logLoss(labels, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), NaN);
+    expectArraysClose(y, NaN);
   });
 
   it('1D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1009,7 +1007,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
     const y = tf.losses.logLoss(labels, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.7168596);
+    expectArraysClose(y, 0.7168596);
   });
 
   it('1D - weighted - Reduction.NONE', () => {
@@ -1032,7 +1030,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
         labels, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 2.668788);
+    expectArraysClose(y, 2.668788);
   });
 
   it('1D - weighted - Reduction.MEAN', () => {
@@ -1044,7 +1042,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
         labels, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 3.5842977);
+    expectArraysClose(y, 3.5842977);
   });
 
   it('2D', () => {
@@ -1054,7 +1052,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
     const y = tf.losses.logLoss(labels, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.60019904);
+    expectArraysClose(y, 0.60019904);
   });
 
   it('2D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1065,7 +1063,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
     const y = tf.losses.logLoss(labels, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.8866577);
+    expectArraysClose(y, 1.8866577);
   });
 
   it('2D - weighted - Reduction.NONE', () => {
@@ -1088,7 +1086,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
         labels, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.60019904);
+    expectArraysClose(y, 0.60019904);
   });
 
   it('2D - weighted - Reduction.MEAN', () => {
@@ -1100,7 +1098,7 @@ describeWithFlags('logLoss', ALL_ENVS, () => {
         labels, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.53904504);
+    expectArraysClose(y, 0.53904504);
   });
 
   it('throws when passed label as a non-tensor', () => {
@@ -1159,7 +1157,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
     const y = tf.losses.huberLoss(labels, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.1816667);
+    expectArraysClose(y, 1.1816667);
   });
 
   it('1D - delta', () => {
@@ -1170,7 +1168,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
     const y = tf.losses.huberLoss(labels, predictions, undefined, delta);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.58666664);
+    expectArraysClose(y, 0.58666664);
   });
 
   it('1D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1181,7 +1179,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
     const y = tf.losses.huberLoss(labels, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.30816665);
+    expectArraysClose(y, 0.30816665);
   });
 
   it('1D - weighted - Reduction.NONE', () => {
@@ -1204,7 +1202,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
         labels, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.1816667);
+    expectArraysClose(y, 1.1816667);
   });
 
   it('1D - weighted - Reduction.MEAN', () => {
@@ -1216,7 +1214,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
         labels, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.5408332);
+    expectArraysClose(y, 1.5408332);
   });
 
   it('2D', () => {
@@ -1226,7 +1224,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
     const y = tf.losses.huberLoss(labels, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.01795);
+    expectArraysClose(y, 0.01795);
   });
 
   it('2D - weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1237,7 +1235,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
     const y = tf.losses.huberLoss(labels, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.040875003);
+    expectArraysClose(y, 0.040875003);
   });
 
   it('2D - weighted - Reduction.NONE', () => {
@@ -1260,7 +1258,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
         labels, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.01795);
+    expectArraysClose(y, 0.01795);
   });
 
   it('2D - weighted - Reduction.MEAN', () => {
@@ -1272,7 +1270,7 @@ describeWithFlags('huberLoss', ALL_ENVS, () => {
         labels, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0.011678572);
+    expectArraysClose(y, 0.011678572);
   });
 
   it('throws when passed label as a non-tensor', () => {
@@ -1333,7 +1331,7 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.sigmoidCrossEntropy(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 6.6667123);
+    expectArraysClose(y, 6.6667123);
   });
 
   it('All right', () => {
@@ -1345,7 +1343,7 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.sigmoidCrossEntropy(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0);
+    expectArraysClose(y, 0);
   });
 
   it('Weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1359,7 +1357,7 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.sigmoidCrossEntropy(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 1.3333424);
+    expectArraysClose(y, 1.3333424);
   });
 
   it('Weighted - Reduction.NONE', () => {
@@ -1389,7 +1387,7 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
         label, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 6.6667123);
+    expectArraysClose(y, 6.6667123);
   });
 
   it('Weighted - Reduction.MEAN', () => {
@@ -1403,8 +1401,8 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
         label, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         6.666712284088135,
     );
   });
@@ -1421,7 +1419,7 @@ describeWithFlags('sigmoidCrossEntropy', ALL_ENVS, () => {
         label, predictions, weights, labelSmoothing, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 6.1667128);
+    expectArraysClose(y, 6.1667128);
   });
 
   it('throws when multiClassLabels and logits are of different shapes', () => {
@@ -1489,7 +1487,7 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.softmaxCrossEntropy(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 20);
+    expectArraysClose(y, 20);
   });
 
   it('All right', () => {
@@ -1501,7 +1499,7 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.softmaxCrossEntropy(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 0);
+    expectArraysClose(y, 0);
   });
 
   it('Weighted - Reduction.SUM_BY_NONZERO_WEIGHTS', () => {
@@ -1516,7 +1514,7 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.softmaxCrossEntropy(label, predictions, weights);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 4);
+    expectArraysClose(y, 4);
   });
 
   it('Weighted - Reduction.NONE', () => {
@@ -1543,7 +1541,7 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
         label, predictions, undefined, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 20);
+    expectArraysClose(y, 20);
   });
 
   it('Weighted - Reduction.MEAN', () => {
@@ -1557,8 +1555,8 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
         label, predictions, weights, undefined, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(
-        y.get(),
+    expectArraysClose(
+        y,
         20,
     );
   });
@@ -1575,7 +1573,7 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
         label, predictions, weights, labelSmoothing, tf.Reduction.MEAN);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 18);
+    expectArraysClose(y, 18);
   });
 
   it('throws when multiClassLabels and logits are of different shapes', () => {
@@ -1640,6 +1638,6 @@ describeWithFlags('softmaxCrossEntropy', ALL_ENVS, () => {
     const y = tf.losses.softmaxCrossEntropy(label, predictions);
 
     expect(y.shape).toEqual([]);
-    expectNumbersClose(y.get(), 20);
+    expectArraysClose(y, 20);
   });
 });

--- a/src/ops/lrn_test.ts
+++ b/src/ops/lrn_test.ts
@@ -48,74 +48,77 @@ describeWithFlags('localResponseNormalization with Tensor3D', ALL_ENVS, () => {
   });
 
   it('computes simple normalization across channels', () => {
-    const x = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
+    const xT = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
     const radius = 1;
     const bias = 1;
     const alpha = 1;
     const beta = 0.5;
 
-    const result = x.localResponseNormalization(radius, bias, alpha, beta);
+    const result = xT.localResponseNormalization(radius, bias, alpha, beta);
 
     const f = (...vals: number[]) =>
         Math.pow(bias + alpha * sumArr(sqArr(vals)), -beta);
 
+    const x = xT.arraySync();
     expectArraysClose(result, [
-      x.get(0, 0, 0) * f(x.get(0, 0, 0), x.get(0, 0, 1)),
-      x.get(0, 0, 1) * f(x.get(0, 0, 0), x.get(0, 0, 1), x.get(0, 0, 2)),
-      x.get(0, 0, 2) * f(x.get(0, 0, 1), x.get(0, 0, 2), x.get(0, 0, 3)),
-      x.get(0, 0, 3) * f(x.get(0, 0, 2), x.get(0, 0, 3)),
+      x[0][0][0] * f(x[0][0][0], x[0][0][1]),
+      x[0][0][1] * f(x[0][0][0], x[0][0][1], x[0][0][2]),
+      x[0][0][2] * f(x[0][0][1], x[0][0][2], x[0][0][3]),
+      x[0][0][3] * f(x[0][0][2], x[0][0][3]),
     ]);
   });
 
   it('uses beta = 1.0 to test GPU optimization', () => {
-    const x = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
+    const xT = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
     const radius = 1;
     const bias = 1;
     const alpha = 1;
     const beta = 1.0;
 
-    const result = x.localResponseNormalization(radius, bias, alpha, beta);
+    const result = xT.localResponseNormalization(radius, bias, alpha, beta);
 
     const f = (...vals: number[]) =>
         Math.pow(bias + alpha * sumArr(sqArr(vals)), -beta);
 
+    const x = xT.arraySync();
     expectArraysClose(result, [
-      x.get(0, 0, 0) * f(x.get(0, 0, 0), x.get(0, 0, 1)),
-      x.get(0, 0, 1) * f(x.get(0, 0, 0), x.get(0, 0, 1), x.get(0, 0, 2)),
-      x.get(0, 0, 2) * f(x.get(0, 0, 1), x.get(0, 0, 2), x.get(0, 0, 3)),
-      x.get(0, 0, 3) * f(x.get(0, 0, 2), x.get(0, 0, 3)),
+      x[0][0][0] * f(x[0][0][0], x[0][0][1]),
+      x[0][0][1] * f(x[0][0][0], x[0][0][1], x[0][0][2]),
+      x[0][0][2] * f(x[0][0][1], x[0][0][2], x[0][0][3]),
+      x[0][0][3] * f(x[0][0][2], x[0][0][3]),
     ]);
   });
 
   it('uses beta = 0.75 to test GPU optimization', () => {
-    const x = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
+    const xT = tf.tensor3d([1, 20, 300, 4], [1, 1, 4]);
     const radius = 1;
     const bias = 1;
     const alpha = 1;
     const beta = 0.75;
 
-    const result = x.localResponseNormalization(radius, bias, alpha, beta);
+    const result = xT.localResponseNormalization(radius, bias, alpha, beta);
 
     const f = (...vals: number[]) =>
         Math.pow(bias + alpha * sumArr(sqArr(vals)), -beta);
 
+    const x = xT.arraySync();
     expectArraysClose(result, [
-      x.get(0, 0, 0) * f(x.get(0, 0, 0), x.get(0, 0, 1)),
-      x.get(0, 0, 1) * f(x.get(0, 0, 0), x.get(0, 0, 1), x.get(0, 0, 2)),
-      x.get(0, 0, 2) * f(x.get(0, 0, 1), x.get(0, 0, 2), x.get(0, 0, 3)),
-      x.get(0, 0, 3) * f(x.get(0, 0, 2), x.get(0, 0, 3)),
+      x[0][0][0] * f(x[0][0][0], x[0][0][1]),
+      x[0][0][1] * f(x[0][0][0], x[0][0][1], x[0][0][2]),
+      x[0][0][2] * f(x[0][0][1], x[0][0][2], x[0][0][3]),
+      x[0][0][3] * f(x[0][0][2], x[0][0][3]),
     ]);
   });
 
   it('computes complex normalization across channels', () => {
-    const x = tf.tensor3d(
+    const xT = tf.tensor3d(
         [1, 20, 300, 4, 5, 15, 24, 200, 1, 20, 300, 4, 5, 15, 24, 200],
         [2, 2, 4]);
     const radius = 1;
     const bias = 1;
     const alpha = 1;
     const beta = 0.5;
-    const result = x.localResponseNormalization(radius, bias, alpha, beta);
+    const result = xT.localResponseNormalization(radius, bias, alpha, beta);
 
     const f = (...vals: number[]) =>
         Math.pow(bias + alpha * sumArr(sqArr(vals)), -beta);
@@ -124,30 +127,31 @@ describeWithFlags('localResponseNormalization with Tensor3D', ALL_ENVS, () => {
     // ------- | ------- | ------- | -------
     // o x . . | x o x . | . x o x | . . x o
 
+    const x = xT.arraySync();
     expectArraysClose(result, [
       // 1 - 4
-      x.get(0, 0, 0) * f(x.get(0, 0, 0), x.get(0, 0, 1)),
-      x.get(0, 0, 1) * f(x.get(0, 0, 0), x.get(0, 0, 1), x.get(0, 0, 2)),
-      x.get(0, 0, 2) * f(x.get(0, 0, 1), x.get(0, 0, 2), x.get(0, 0, 3)),
-      x.get(0, 0, 3) * f(x.get(0, 0, 2), x.get(0, 0, 3)),
+      x[0][0][0] * f(x[0][0][0], x[0][0][1]),
+      x[0][0][1] * f(x[0][0][0], x[0][0][1], x[0][0][2]),
+      x[0][0][2] * f(x[0][0][1], x[0][0][2], x[0][0][3]),
+      x[0][0][3] * f(x[0][0][2], x[0][0][3]),
 
       // 1 - 4
-      x.get(0, 1, 0) * f(x.get(0, 1, 0), x.get(0, 1, 1)),
-      x.get(0, 1, 1) * f(x.get(0, 1, 0), x.get(0, 1, 1), x.get(0, 1, 2)),
-      x.get(0, 1, 2) * f(x.get(0, 1, 1), x.get(0, 1, 2), x.get(0, 1, 3)),
-      x.get(0, 1, 3) * f(x.get(0, 1, 2), x.get(0, 1, 3)),
+      x[0][1][0] * f(x[0][1][0], x[0][1][1]),
+      x[0][1][1] * f(x[0][1][0], x[0][1][1], x[0][1][2]),
+      x[0][1][2] * f(x[0][1][1], x[0][1][2], x[0][1][3]),
+      x[0][1][3] * f(x[0][1][2], x[0][1][3]),
 
       // 1 - 4
-      x.get(1, 0, 0) * f(x.get(1, 0, 0), x.get(1, 0, 1)),
-      x.get(1, 0, 1) * f(x.get(1, 0, 0), x.get(1, 0, 1), x.get(1, 0, 2)),
-      x.get(1, 0, 2) * f(x.get(1, 0, 1), x.get(1, 0, 2), x.get(1, 0, 3)),
-      x.get(1, 0, 3) * f(x.get(1, 0, 2), x.get(1, 0, 3)),
+      x[1][0][0] * f(x[1][0][0], x[1][0][1]),
+      x[1][0][1] * f(x[1][0][0], x[1][0][1], x[1][0][2]),
+      x[1][0][2] * f(x[1][0][1], x[1][0][2], x[1][0][3]),
+      x[1][0][3] * f(x[1][0][2], x[1][0][3]),
 
       // 1 - 4
-      x.get(1, 1, 0) * f(x.get(1, 1, 0), x.get(1, 1, 1)),
-      x.get(1, 1, 1) * f(x.get(1, 1, 0), x.get(1, 1, 1), x.get(1, 1, 2)),
-      x.get(1, 1, 2) * f(x.get(1, 1, 1), x.get(1, 1, 2), x.get(1, 1, 3)),
-      x.get(1, 1, 3) * f(x.get(1, 1, 2), x.get(1, 1, 3)),
+      x[1][1][0] * f(x[1][1][0], x[1][1][1]),
+      x[1][1][1] * f(x[1][1][0], x[1][1][1], x[1][1][2]),
+      x[1][1][2] * f(x[1][1][1], x[1][1][2], x[1][1][3]),
+      x[1][1][3] * f(x[1][1][2], x[1][1][3]),
     ]);
   });
 
@@ -299,13 +303,13 @@ describeWithFlags('localResponseNormalization with Tensor4D', ALL_ENVS, () => {
   });
 
   it('computes simple normalization across channels', () => {
-    const x = tf.tensor4d([1, 20, 300, 4, 1, 20, 300, 4], [2, 1, 1, 4]);
+    const xT = tf.tensor4d([1, 20, 300, 4, 1, 20, 300, 4], [2, 1, 1, 4]);
     const radius = 1;
     const bias = 1;
     const alpha = 1;
     const beta = 0.5;
 
-    const result = x.localResponseNormalization(radius, bias, alpha, beta);
+    const result = xT.localResponseNormalization(radius, bias, alpha, beta);
 
     const f = (...vals: number[]) =>
         Math.pow(bias + alpha * sumArr(sqArr(vals)), -beta);
@@ -313,21 +317,17 @@ describeWithFlags('localResponseNormalization with Tensor4D', ALL_ENVS, () => {
     // Easier to read using these vars
     const b0 = 0;
     const b1 = 1;
-
+    const x = xT.arraySync();
     expectArraysClose(result, [
-      x.get(b0, 0, 0, 0) * f(x.get(b0, 0, 0, 0), x.get(b0, 0, 0, 1)),
-      x.get(b0, 0, 0, 1) *
-          f(x.get(b0, 0, 0, 0), x.get(b0, 0, 0, 1), x.get(b0, 0, 0, 2)),
-      x.get(b0, 0, 0, 2) *
-          f(x.get(b0, 0, 0, 1), x.get(b0, 0, 0, 2), x.get(b0, 0, 0, 3)),
-      x.get(b0, 0, 0, 3) * f(x.get(b0, 0, 0, 2), x.get(b0, 0, 0, 3)),
+      x[b0][0][0][0] * f(x[b0][0][0][0], x[b0][0][0][1]),
+      x[b0][0][0][1] * f(x[b0][0][0][0], x[b0][0][0][1], x[b0][0][0][2]),
+      x[b0][0][0][2] * f(x[b0][0][0][1], x[b0][0][0][2], x[b0][0][0][3]),
+      x[b0][0][0][3] * f(x[b0][0][0][2], x[b0][0][0][3]),
 
-      x.get(b1, 0, 0, 0) * f(x.get(b1, 0, 0, 0), x.get(b1, 0, 0, 1)),
-      x.get(b1, 0, 0, 1) *
-          f(x.get(b1, 0, 0, 0), x.get(b1, 0, 0, 1), x.get(b1, 0, 0, 2)),
-      x.get(b1, 0, 0, 2) *
-          f(x.get(b1, 0, 0, 1), x.get(b1, 0, 0, 2), x.get(b1, 0, 0, 3)),
-      x.get(b1, 0, 0, 3) * f(x.get(b1, 0, 0, 2), x.get(b1, 0, 0, 3)),
+      x[b1][0][0][0] * f(x[b1][0][0][0], x[b1][0][0][1]),
+      x[b1][0][0][1] * f(x[b1][0][0][0], x[b1][0][0][1], x[b1][0][0][2]),
+      x[b1][0][0][2] * f(x[b1][0][0][1], x[b1][0][0][2], x[b1][0][0][3]),
+      x[b1][0][0][3] * f(x[b1][0][0][2], x[b1][0][0][3]),
     ]);
   });
 

--- a/src/ops/lstm_test.ts
+++ b/src/ops/lstm_test.ts
@@ -81,8 +81,10 @@ describeWithFlags('lstm', ALL_ENVS, () => {
     const batchedH = tf.concat2d([h, h], 0);  // 2x1
     const [newC, newH] = tf.basicLSTMCell(
         forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);
-    expect(newC.get(0, 0)).toEqual(newC.get(1, 0));
-    expect(newH.get(0, 0)).toEqual(newH.get(1, 0));
+    const newCVals = newC.arraySync();
+    const newHVals = newH.arraySync();
+    expect(newCVals[0][0]).toEqual(newCVals[1][0]);
+    expect(newHVals[0][0]).toEqual(newHVals[1][0]);
   });
 
   it('basicLSTMCell accepts a tensor-like object', () => {
@@ -98,8 +100,10 @@ describeWithFlags('lstm', ALL_ENVS, () => {
     const batchedH = tf.concat2d([h, h], 0);           // 2x1
     const [newC, newH] = tf.basicLSTMCell(
         forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);
-    expect(newC.get(0, 0)).toEqual(newC.get(1, 0));
-    expect(newH.get(0, 0)).toEqual(newH.get(1, 0));
+    const newCVals = newC.arraySync();
+    const newHVals = newH.arraySync();
+    expect(newCVals[0][0]).toEqual(newCVals[1][0]);
+    expect(newHVals[0][0]).toEqual(newHVals[1][0]);
   });
 });
 

--- a/src/ops/matmul_test.ts
+++ b/src/ops/matmul_test.ts
@@ -18,7 +18,7 @@
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {MATMUL_SHARED_DIM_THRESHOLD} from '../kernels/backend_webgl';
-import {ALL_ENVS, expectArraysClose, expectNumbersClose, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
+import {ALL_ENVS, expectArraysClose, expectArraysEqual, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
 import {Rank} from '../types';
 
 describeWithFlags('matmul', PACKED_ENVS, () => {
@@ -484,14 +484,14 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     const v2 = tf.tensor1d([2, 1]);
     const result = tf.dot(v1, v2);
 
-    expectNumbersClose(result.get(), 7);
+    expectArraysClose(result, [7]);
   });
 
   it('Dot product propagates NaNs', () => {
     const v1 = tf.tensor1d([2, NaN]);
     const v2 = tf.tensor1d([2, 1]);
     const result = tf.dot(v1, v2);
-    expect(result.get()).toEqual(NaN);
+    expectArraysEqual(result, [NaN]);
   });
 
   it('Dot product throws when vectors are different size', () => {
@@ -521,10 +521,10 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     expectArraysClose(result, expected);
   });
 
-  it('gradients: A * B', () => {
-    const a = tf.tensor2d([1, 2, 3, 10, 20, 30], [2, 3]);
-    const b = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
-    const dy = tf.tensor2d([1, 10, 20, 30], [2, 2]);
+  it('gradients: A * B', async () => {
+    const aT = tf.tensor2d([1, 2, 3, 10, 20, 30], [2, 3]);
+    const bT = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
+    const dyT = tf.tensor2d([1, 10, 20, 30], [2, 2]);
 
     const transposeA = false;
     const transposeB = false;
@@ -532,10 +532,14 @@ describeWithFlags('matmul', ALL_ENVS, () => {
 
         (a: tf.Tensor2D, b: tf.Tensor2D) =>
             tf.matMul(a, b, transposeA, transposeB));
-    const [da, db] = grads([a, b], dy);
+    const [da, db] = grads([aT, bT], dyT);
 
     // da = dy * bT
-    expect(da.shape).toEqual(a.shape);
+    expect(da.shape).toEqual(aT.shape);
+
+    const a = await aT.buffer();
+    const dy = await dyT.buffer();
+    const b = await bT.buffer();
     expectArraysClose(
         da,
         [
@@ -560,10 +564,10 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     ]);
   });
 
-  it('gradients: a * bT', () => {
-    const a = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
-    const b = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
-    const dy = tf.tensor2d([1, 10, 20, 30, 40, 50, 60, 70, 80], [3, 3]);
+  it('gradients: a * bT', async () => {
+    const aT = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
+    const bT = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
+    const dyT = tf.tensor2d([1, 10, 20, 30, 40, 50, 60, 70, 80], [3, 3]);
 
     const transposeA = false;
     const transposeB = true;
@@ -571,10 +575,13 @@ describeWithFlags('matmul', ALL_ENVS, () => {
 
         (a: tf.Tensor2D, b: tf.Tensor2D) =>
             tf.matMul(a, b, transposeA, transposeB));
-    const [da, db] = grads([a, b], dy);
+    const [da, db] = grads([aT, bT], dyT);
 
     // da = dy * b
-    expect(da.shape).toEqual(a.shape);
+    expect(da.shape).toEqual(aT.shape);
+    const a = await aT.buffer();
+    const dy = await dyT.buffer();
+    const b = await bT.buffer();
     expectArraysClose(da, [
       dy.get(0, 0) * b.get(0, 0) + dy.get(0, 1) * b.get(1, 0) +
           dy.get(0, 2) * b.get(2, 0),
@@ -608,10 +615,10 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     ]);
   });
 
-  it('gradients: aT * b', () => {
-    const a = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
-    const b = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
-    const dy = tf.tensor2d([1, 10, 20, 30], [2, 2]);
+  it('gradients: aT * b', async () => {
+    const aT = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
+    const bT = tf.tensor2d([2, 3, 4, 1, 2, 3], [3, 2]);
+    const dyT = tf.tensor2d([1, 10, 20, 30], [2, 2]);
 
     const transposeA = true;
     const transposeB = false;
@@ -619,10 +626,13 @@ describeWithFlags('matmul', ALL_ENVS, () => {
 
         (a: tf.Tensor2D, b: tf.Tensor2D) =>
             tf.matMul(a, b, transposeA, transposeB));
-    const [da, db] = grads([a, b], dy);
+    const [da, db] = grads([aT, bT], dyT);
 
     // da = b * dyT
-    expect(da.shape).toEqual(a.shape);
+    expect(da.shape).toEqual(aT.shape);
+    const a = await aT.buffer();
+    const dy = await dyT.buffer();
+    const b = await bT.buffer();
     expectArraysClose(da, [
       dy.get(0, 0) * b.get(0, 0) + dy.get(0, 1) * b.get(0, 1),
       dy.get(1, 0) * b.get(0, 0) + dy.get(1, 1) * b.get(0, 1),
@@ -644,10 +654,10 @@ describeWithFlags('matmul', ALL_ENVS, () => {
     ]);
   });
 
-  it('gradients: aT * bT', () => {
-    const a = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
-    const b = tf.tensor2d([2, 3, 4, 1, 2, 3], [2, 3]);
-    const dy = tf.tensor2d([1, 10, 20, 30], [2, 2]);
+  it('gradients: aT * bT', async () => {
+    const aT = tf.tensor2d([1, 2, 3, 10, 20, 30], [3, 2]);
+    const bT = tf.tensor2d([2, 3, 4, 1, 2, 3], [2, 3]);
+    const dyT = tf.tensor2d([1, 10, 20, 30], [2, 2]);
 
     const transposeA = true;
     const transposeB = true;
@@ -655,10 +665,13 @@ describeWithFlags('matmul', ALL_ENVS, () => {
 
         (a: tf.Tensor2D, b: tf.Tensor2D) =>
             tf.matMul(a, b, transposeA, transposeB));
-    const [da, db] = grads([a, b], dy);
+    const [da, db] = grads([aT, bT], dyT);
 
     // da = bT * dyT
-    expect(da.shape).toEqual(a.shape);
+    expect(da.shape).toEqual(aT.shape);
+    const a = await aT.buffer();
+    const dy = await dyT.buffer();
+    const b = await bT.buffer();
     expectArraysClose(da, [
       dy.get(0, 0) * b.get(0, 0) + dy.get(0, 1) * b.get(1, 0),
       dy.get(1, 0) * b.get(0, 0) + dy.get(1, 1) * b.get(1, 0),

--- a/src/ops/reduction_ops_test.ts
+++ b/src/ops/reduction_ops_test.ts
@@ -17,29 +17,29 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {ALL_ENVS, expectArraysClose, expectArraysEqual, expectNumbersClose} from '../test_util';
+import {ALL_ENVS, expectArraysClose, expectArraysEqual} from '../test_util';
 
 import * as reduce_util from './reduce_util';
 
 describeWithFlags('Reduction: min', ALL_ENVS, () => {
   it('Tensor1D', () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2]);
-    expectNumbersClose(tf.min(a).get(), -7);
+    expectArraysClose(tf.min(a), -7);
   });
 
   it('ignores NaNs', () => {
     const a = tf.tensor1d([3, NaN, 2]);
-    expect(tf.min(a).get()).toEqual(2);
+    expectArraysEqual(tf.min(a), 2);
   });
 
   it('2D', () => {
     const a = tf.tensor2d([3, -1, 0, 100, -7, 2], [2, 3]);
-    expectNumbersClose(tf.min(a).get(), -7);
+    expectArraysClose(tf.min(a), -7);
   });
 
   it('2D axis=[0,1]', () => {
     const a = tf.tensor2d([3, -1, 0, 100, -7, 2], [2, 3]);
-    expectNumbersClose(tf.min(a, [0, 1]).get(), -7);
+    expectArraysClose(tf.min(a, [0, 1]), -7);
   });
 
   it('2D, axis=0', () => {
@@ -82,7 +82,7 @@ describeWithFlags('Reduction: min', ALL_ENVS, () => {
   });
 
   it('accepts a tensor-like object', () => {
-    expectNumbersClose(tf.min([3, -1, 0, 100, -7, 2]).get(), -7);
+    expectArraysClose(tf.min([3, -1, 0, 100, -7, 2]), -7);
   });
 
   it('min gradient: Scalar', () => {
@@ -209,8 +209,7 @@ describeWithFlags('Reduction: min', ALL_ENVS, () => {
 
   it('throws error for string tensor', () => {
     expect(() => tf.min(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'min' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'min' must be numeric tensor/);
   });
 });
 
@@ -218,27 +217,27 @@ describeWithFlags('Reduction: max', ALL_ENVS, () => {
   it('with one element dominating', () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2]);
     const r = tf.max(a);
-    expectNumbersClose(r.get(), 100);
+    expectArraysClose(r, 100);
   });
 
   it('with all elements being the same', () => {
     const a = tf.tensor1d([3, 3, 3]);
     const r = tf.max(a);
-    expectNumbersClose(r.get(), 3);
+    expectArraysClose(r, 3);
   });
 
   it('ignores NaNs', () => {
-    expectNumbersClose(tf.max(tf.tensor1d([3, NaN, 2])).get(), 3);
+    expectArraysClose(tf.max(tf.tensor1d([3, NaN, 2])), 3);
   });
 
   it('2D', () => {
     const a = tf.tensor2d([3, -1, 0, 100, -7, 2], [2, 3]);
-    expectNumbersClose(tf.max(a).get(), 100);
+    expectArraysClose(tf.max(a), 100);
   });
 
   it('2D axis=[0,1]', () => {
     const a = tf.tensor2d([3, -1, 0, 100, -7, 2], [2, 3]);
-    expectNumbersClose(tf.max(a, [0, 1]).get(), 100);
+    expectArraysClose(tf.max(a, [0, 1]), 100);
   });
 
   it('2D, axis=0', () => {
@@ -292,7 +291,7 @@ describeWithFlags('Reduction: max', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const r = tf.max([3, -1, 0, 100, -7, 2]);
-    expectNumbersClose(r.get(), 100);
+    expectArraysClose(r, 100);
   });
 
   it('max gradient: Scalar', () => {
@@ -419,8 +418,7 @@ describeWithFlags('Reduction: max', ALL_ENVS, () => {
 
   it('throws error for string tensor', () => {
     expect(() => tf.max(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'max' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'max' must be numeric tensor/);
   });
 });
 
@@ -429,14 +427,14 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
     const a = tf.tensor1d([1, 0, 3, 2]);
     const result = tf.argMax(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(2);
+    expectArraysEqual(result, 2);
   });
 
   it('one value', () => {
     const a = tf.tensor1d([10]);
     const result = tf.argMax(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(0);
+    expectArraysEqual(result, 0);
   });
 
   it('N > than parallelization threshold', () => {
@@ -448,7 +446,7 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
     const a = tf.tensor1d(values);
     const result = tf.argMax(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(n - 1);
+    expectArraysEqual(result, n - 1);
   });
 
   it('max index corresponds to start of a non-initial window', () => {
@@ -460,14 +458,14 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
     const a = tf.tensor1d(values);
     const result = tf.argMax(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(index);
+    expectArraysEqual(result, index);
   });
 
   it('ignores NaNs', () => {
     const a = tf.tensor1d([0, 3, 5, NaN, 3]);
     const res = tf.argMax(a);
     expect(res.dtype).toBe('int32');
-    expect(res.get()).toBe(2);
+    expectArraysEqual(res, 2);
   });
 
   it('2D, no axis specified', () => {
@@ -506,14 +504,14 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
   it('accepts a tensor-like object', () => {
     const result = tf.argMax([1, 0, 3, 2]);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(2);
+    expectArraysEqual(result, 2);
   });
 
   it('accepts tensor with bool values', () => {
     const t = tf.tensor1d([0, 1], 'bool');
     const result = tf.argMax(t);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(1);
+    expectArraysEqual(result, 1);
   });
 
   it('has gradient', () => {
@@ -528,8 +526,7 @@ describeWithFlags('Reduction: argmax', ALL_ENVS, () => {
 
   it('throws error for string tensor', () => {
     expect(() => tf.argMax(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'argMax' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'argMax' must be numeric tensor/);
   });
 });
 
@@ -537,13 +534,13 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
   it('Tensor1D', () => {
     const a = tf.tensor1d([1, 0, 3, 2]);
     const result = tf.argMin(a);
-    expect(result.get()).toBe(1);
+    expectArraysEqual(result, 1);
   });
 
   it('one value', () => {
     const a = tf.tensor1d([10]);
     const result = tf.argMin(a);
-    expect(result.get()).toBe(0);
+    expectArraysEqual(result, 0);
   });
 
   it('N > than parallelization threshold', () => {
@@ -555,7 +552,7 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
     const a = tf.tensor1d(values);
     const result = tf.argMin(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(n - 1);
+    expectArraysEqual(result, n - 1);
   });
 
   it('min index corresponds to start of a non-initial window', () => {
@@ -567,13 +564,13 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
     const a = tf.tensor1d(values);
     const result = tf.argMin(a);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(index);
+    expectArraysEqual(result, index);
   });
 
   it('ignores NaNs', () => {
     const a = tf.tensor1d([5, 0, NaN, -1, 3]);
     const res = tf.argMin(a);
-    expect(res.get()).toBe(3);
+    expectArraysEqual(res, 3);
   });
 
   it('2D, no axis specified', () => {
@@ -609,14 +606,14 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const result = tf.argMin([1, 0, 3, 2]);
-    expect(result.get()).toBe(1);
+    expectArraysEqual(result, 1);
   });
 
   it('accepts tensor with bool values', () => {
     const t = tf.tensor1d([0, 1], 'bool');
     const result = tf.argMin(t);
     expect(result.dtype).toBe('int32');
-    expect(result.get()).toBe(0);
+    expectArraysEqual(result, 0);
   });
 
   it('has gradient', () => {
@@ -631,8 +628,7 @@ describeWithFlags('Reduction: argmin', ALL_ENVS, () => {
 
   it('throws error for string tensor', () => {
     expect(() => tf.argMin(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'argMin' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'argMin' must be numeric tensor/);
   });
 });
 
@@ -640,21 +636,21 @@ describeWithFlags('Reduction: logSumExp', ALL_ENVS, () => {
   it('0', () => {
     const a = tf.scalar(0);
     const result = tf.logSumExp(a);
-    expectNumbersClose(result.get(), 0);
+    expectArraysClose(result, 0);
   });
 
   it('basic', () => {
     const a = tf.tensor1d([1, 2, -3]);
     const result = tf.logSumExp(a);
 
-    expectNumbersClose(
-        result.get(), Math.log(Math.exp(1) + Math.exp(2) + Math.exp(-3)));
+    expectArraysClose(
+        result, Math.log(Math.exp(1) + Math.exp(2) + Math.exp(-3)));
   });
 
   it('propagates NaNs', () => {
     const a = tf.tensor1d([1, 2, NaN]);
     const result = tf.logSumExp(a);
-    expect(result.get()).toEqual(NaN);
+    expectArraysEqual(result, NaN);
   });
 
   it('axes=0 in 2D array', () => {
@@ -737,8 +733,8 @@ describeWithFlags('Reduction: logSumExp', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const result = tf.logSumExp([1, 2, -3]);
-    expectNumbersClose(
-        result.get(), Math.log(Math.exp(1) + Math.exp(2) + Math.exp(-3)));
+    expectArraysClose(
+        result, Math.log(Math.exp(1) + Math.exp(2) + Math.exp(-3)));
   });
 
   it('throws error for string tensor', () => {
@@ -752,24 +748,24 @@ describeWithFlags('Reduction: sum', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor2d([1, 2, 3, 0, 0, 1], [3, 2]);
     const result = tf.sum(a);
-    expectNumbersClose(result.get(), 7);
+    expectArraysClose(result, 7);
   });
 
   it('propagates NaNs', () => {
     const a = tf.tensor2d([1, 2, 3, NaN, 0, 1], [3, 2]);
-    expect(tf.sum(a).get()).toEqual(NaN);
+    expectArraysEqual(tf.sum(a), NaN);
   });
 
   it('sum over dtype int32', () => {
     const a = tf.tensor1d([1, 5, 7, 3], 'int32');
     const sum = tf.sum(a);
-    expect(sum.get()).toBe(16);
+    expectArraysEqual(sum, 16);
   });
 
   it('sum over dtype bool', () => {
     const a = tf.tensor1d([true, false, false, true, true], 'bool');
     const sum = tf.sum(a);
-    expect(sum.get()).toBe(3);
+    expectArraysEqual(sum, 3);
   });
 
   it('sums all values in 2D array with keep dim', () => {
@@ -878,13 +874,12 @@ describeWithFlags('Reduction: sum', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const result = tf.sum([[1, 2], [3, 0], [0, 1]]);
-    expectNumbersClose(result.get(), 7);
+    expectArraysClose(result, 7);
   });
 
   it('throws error for string tensor', () => {
     expect(() => tf.sum(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'sum' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'sum' must be numeric tensor/);
   });
 });
 
@@ -892,24 +887,24 @@ describeWithFlags('Reduction: prod', ALL_ENVS, () => {
   it('basic', () => {
     const a = tf.tensor2d([1, 2, 3, 0, 0, 1], [3, 2]);
     const result = tf.prod(a);
-    expectNumbersClose(result.get(), 0);
+    expectArraysClose(result, 0);
   });
 
   it('propagates NaNs', () => {
     const a = tf.tensor2d([1, 2, 3, NaN, 0, 1], [3, 2]);
-    expect(tf.prod(a).get()).toEqual(NaN);
+    expectArraysEqual(tf.prod(a), NaN);
   });
 
   it('prod over dtype int32', () => {
     const a = tf.tensor1d([1, 5, 7, 3], 'int32');
     const prod = tf.prod(a);
-    expect(prod.get()).toBe(105);
+    expectArraysEqual(prod, 105);
   });
 
   it('prod over dtype bool', () => {
     const a = tf.tensor1d([true, false, false, true, true], 'bool');
     const prod = tf.prod(a);
-    expect(prod.get()).toBe(0);
+    expectArraysEqual(prod, 0);
   });
 
   it('prods all values in 2D array with keep dim', () => {
@@ -917,7 +912,7 @@ describeWithFlags('Reduction: prod', ALL_ENVS, () => {
     const res = tf.prod(a, null, true /* keepDims */);
 
     expect(res.shape).toEqual([1, 1]);
-    expectArraysClose(res, [0]);
+    expectArraysClose(res, 0);
   });
 
   it('prods across axis=0 in 2D array', () => {
@@ -983,13 +978,12 @@ describeWithFlags('Reduction: prod', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const result = tf.prod([[1, 2], [3, 1], [1, 1]]);
-    expectNumbersClose(result.get(), 6);
+    expectArraysClose(result, 6);
   });
 
   it('throws error for string tensor', () => {
     expect(() => tf.prod(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'prod' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'prod' must be numeric tensor/);
   });
 });
 
@@ -999,7 +993,7 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const r = tf.mean(a);
 
     expect(r.dtype).toBe('float32');
-    expectNumbersClose(r.get(), 7 / 6);
+    expectArraysClose(r, 7 / 6);
   });
 
   it('propagates NaNs', () => {
@@ -1007,7 +1001,7 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const r = tf.mean(a);
 
     expect(r.dtype).toBe('float32');
-    expect(r.get()).toEqual(NaN);
+    expectArraysEqual(r, NaN);
   });
 
   it('mean(int32) => float32', () => {
@@ -1015,7 +1009,7 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const r = tf.mean(a);
 
     expect(r.dtype).toBe('float32');
-    expectNumbersClose(r.get(), 4);
+    expectArraysClose(r, 4);
   });
 
   it('mean(bool) => float32', () => {
@@ -1023,7 +1017,7 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const r = tf.mean(a);
 
     expect(r.dtype).toBe('float32');
-    expectNumbersClose(r.get(), 3 / 5);
+    expectArraysClose(r, 3 / 5);
   });
 
   it('2D array with keep dim', () => {
@@ -1094,11 +1088,11 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const dy = tf.scalar(1.5);
 
     const da = tf.grad(a => a.mean())(a, dy);
-
+    const dyVal = dy.arraySync();
     expect(da.shape).toEqual(a.shape);
     expectArraysClose(da, [
-      dy.get() / a.size, dy.get() / a.size, dy.get() / a.size,
-      dy.get() / a.size, dy.get() / a.size, dy.get() / a.size
+      dyVal / a.size, dyVal / a.size, dyVal / a.size, dyVal / a.size,
+      dyVal / a.size, dyVal / a.size
     ]);
   });
 
@@ -1118,13 +1112,12 @@ describeWithFlags('Reduction: mean', ALL_ENVS, () => {
     const r = tf.mean([[1, 2, 3], [0, 0, 1]]);
 
     expect(r.dtype).toBe('float32');
-    expectNumbersClose(r.get(), 7 / 6);
+    expectArraysClose(r, 7 / 6);
   });
 
   it('throws error for string tensor', () => {
     expect(() => tf.mean(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'mean' must be numeric tensor/);
+        .toThrowError(/Argument 'x' passed to 'mean' must be numeric tensor/);
   });
 });
 
@@ -1135,8 +1128,8 @@ describeWithFlags('Reduction: moments', ALL_ENVS, () => {
 
     expect(mean.dtype).toBe('float32');
     expect(variance.dtype).toBe('float32');
-    expectNumbersClose(mean.get(), 7 / 6);
-    expectNumbersClose(variance.get(), 1.1389);
+    expectArraysClose(mean, 7 / 6);
+    expectArraysClose(variance, 1.1389);
   });
 
   it('propagates NaNs', () => {
@@ -1145,8 +1138,8 @@ describeWithFlags('Reduction: moments', ALL_ENVS, () => {
 
     expect(mean.dtype).toBe('float32');
     expect(variance.dtype).toBe('float32');
-    expect(mean.get()).toEqual(NaN);
-    expect(variance.get()).toEqual(NaN);
+    expectArraysEqual(mean, NaN);
+    expectArraysEqual(variance, NaN);
   });
 
   it('moments(int32) => float32', () => {
@@ -1155,8 +1148,8 @@ describeWithFlags('Reduction: moments', ALL_ENVS, () => {
 
     expect(mean.dtype).toBe('float32');
     expect(variance.dtype).toBe('float32');
-    expectNumbersClose(mean.get(), 4);
-    expectNumbersClose(variance.get(), 5);
+    expectArraysClose(mean, 4);
+    expectArraysClose(variance, 5);
   });
 
   it('moments(bool) => float32', () => {
@@ -1165,8 +1158,8 @@ describeWithFlags('Reduction: moments', ALL_ENVS, () => {
 
     expect(mean.dtype).toBe('float32');
     expect(variance.dtype).toBe('float32');
-    expectNumbersClose(mean.get(), 3 / 5);
-    expectNumbersClose(variance.get(), 0.23999998);
+    expectArraysClose(mean, 3 / 5);
+    expectArraysClose(variance, 0.23999998);
   });
 
   it('2D array with keep dim', () => {
@@ -1251,8 +1244,8 @@ describeWithFlags('Reduction: moments', ALL_ENVS, () => {
 
     expect(mean.dtype).toBe('float32');
     expect(variance.dtype).toBe('float32');
-    expectNumbersClose(mean.get(), 7 / 6);
-    expectNumbersClose(variance.get(), 1.1389);
+    expectArraysClose(mean, 7 / 6);
+    expectArraysClose(variance, 1.1389);
   });
 });
 
@@ -1262,7 +1255,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 22);
+    expectArraysClose(norm, 22);
   });
 
   it('vector inf norm', () => {
@@ -1270,7 +1263,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, Infinity);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 4);
+    expectArraysClose(norm, 4);
   });
 
   it('vector -inf norm', () => {
@@ -1278,7 +1271,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, -Infinity);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 1);
+    expectArraysClose(norm, 1);
   });
 
   it('vector 1 norm', () => {
@@ -1286,7 +1279,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 1);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 10);
+    expectArraysClose(norm, 10);
   });
 
   it('vector euclidean norm', () => {
@@ -1294,7 +1287,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 'euclidean');
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 5.4772);
+    expectArraysClose(norm, 5.4772);
   });
 
   it('vector 2-norm', () => {
@@ -1302,7 +1295,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 2);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 5.4772);
+    expectArraysClose(norm, 5.4772);
   });
 
   it('vector >2-norm to throw error', () => {
@@ -1315,7 +1308,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, Infinity, [0, 1]);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 4);
+    expectArraysClose(norm, 4);
   });
 
   it('matrix -inf norm', () => {
@@ -1323,7 +1316,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, -Infinity, [0, 1]);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 1);
+    expectArraysClose(norm, 1);
   });
 
   it('matrix 1 norm', () => {
@@ -1331,7 +1324,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 1, [0, 1]);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 5);
+    expectArraysClose(norm, 5);
   });
 
   it('matrix euclidean norm', () => {
@@ -1339,7 +1332,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 'euclidean', [0, 1]);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 4.123);
+    expectArraysClose(norm, 4.123);
   });
 
   it('matrix fro norm', () => {
@@ -1347,7 +1340,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a, 'fro', [0, 1]);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 4.123);
+    expectArraysClose(norm, 4.123);
   });
 
   it('matrix other norm to throw error', () => {
@@ -1360,7 +1353,7 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm(a);
 
     expect(norm.dtype).toBe('float32');
-    expect(norm.get()).toEqual(NaN);
+    expectArraysEqual(norm, NaN);
   });
 
   it('axis=null in 2D array norm', () => {
@@ -1517,41 +1510,41 @@ describeWithFlags('Reduction: norm', ALL_ENVS, () => {
     const norm = tf.norm([1, -2, 3, -4], 1);
 
     expect(norm.dtype).toBe('float32');
-    expectNumbersClose(norm.get(), 10);
+    expectArraysClose(norm, 10);
   });
 
   it('throws error for string tensors', () => {
-    expect(() => tf.norm(['a', 'b']))
-        .toThrowError(
-            /Argument 'x' passed to 'norm' must be numeric tensor/);
+    expect(() => tf.norm([
+      'a', 'b'
+    ])).toThrowError(/Argument 'x' passed to 'norm' must be numeric tensor/);
   });
 });
 
 describeWithFlags('Reduction: all', ALL_ENVS, () => {
   it('Tensor1D', () => {
     let a = tf.tensor1d([0, 0, 0], 'bool');
-    expectNumbersClose(tf.all(a).get(), 0);
+    expectArraysClose(tf.all(a), 0);
 
     a = tf.tensor1d([1, 0, 1], 'bool');
-    expectNumbersClose(tf.all(a).get(), 0);
+    expectArraysClose(tf.all(a), 0);
 
     a = tf.tensor1d([1, 1, 1], 'bool');
-    expectNumbersClose(tf.all(a).get(), 1);
+    expectArraysClose(tf.all(a), 1);
   });
 
   it('ignores NaNs', () => {
     const a = tf.tensor1d([1, NaN, 1], 'bool');
-    expect(tf.all(a).get()).toEqual(1);
+    expectArraysEqual(tf.all(a), 1);
   });
 
   it('2D', () => {
     const a = tf.tensor2d([1, 1, 0, 0], [2, 2], 'bool');
-    expectNumbersClose(tf.all(a).get(), 0);
+    expectArraysClose(tf.all(a), 0);
   });
 
   it('2D axis=[0,1]', () => {
     const a = tf.tensor2d([1, 1, 0, 0, 1, 0], [2, 3], 'bool');
-    expectNumbersClose(tf.all(a, [0, 1]).get(), 0);
+    expectArraysClose(tf.all(a, [0, 1]), 0);
   });
 
   it('2D, axis=0', () => {
@@ -1607,7 +1600,7 @@ describeWithFlags('Reduction: all', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const a = [0, 0, 0];
-    expectNumbersClose(tf.all(a).get(), 0);
+    expectArraysClose(tf.all(a), 0);
   });
 
   it('throws error for string tensor', () => {
@@ -1620,28 +1613,28 @@ describeWithFlags('Reduction: all', ALL_ENVS, () => {
 describeWithFlags('Reduction: any', ALL_ENVS, () => {
   it('Tensor1D', () => {
     let a = tf.tensor1d([0, 0, 0], 'bool');
-    expectNumbersClose(tf.any(a).get(), 0);
+    expectArraysClose(tf.any(a), 0);
 
     a = tf.tensor1d([1, 0, 1], 'bool');
-    expectNumbersClose(tf.any(a).get(), 1);
+    expectArraysClose(tf.any(a), 1);
 
     a = tf.tensor1d([1, 1, 1], 'bool');
-    expectNumbersClose(tf.any(a).get(), 1);
+    expectArraysClose(tf.any(a), 1);
   });
 
   it('ignores NaNs', () => {
     const a = tf.tensor1d([1, NaN, 0], 'bool');
-    expect(tf.any(a).get()).toEqual(1);
+    expectArraysEqual(tf.any(a), 1);
   });
 
   it('2D', () => {
     const a = tf.tensor2d([1, 1, 0, 0], [2, 2], 'bool');
-    expectNumbersClose(tf.any(a).get(), 1);
+    expectArraysClose(tf.any(a), 1);
   });
 
   it('2D axis=[0,1]', () => {
     const a = tf.tensor2d([1, 1, 0, 0, 1, 0], [2, 3], 'bool');
-    expectNumbersClose(tf.any(a, [0, 1]).get(), 1);
+    expectArraysClose(tf.any(a, [0, 1]), 1);
   });
 
   it('2D, axis=0', () => {
@@ -1697,12 +1690,11 @@ describeWithFlags('Reduction: any', ALL_ENVS, () => {
 
   it('accepts a tensor-like object', () => {
     const a = [0, 0, 0];
-    expectNumbersClose(tf.any(a).get(), 0);
+    expectArraysClose(tf.any(a), 0);
   });
 
   it('throws error for string tensor', () => {
     expect(() => tf.any(['a']))
-        .toThrowError(
-            /Argument 'x' passed to 'any' must be bool tensor/);
+        .toThrowError(/Argument 'x' passed to 'any' must be bool tensor/);
   });
 });

--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
-import {ALL_ENVS, expectArraysClose, expectNumbersClose, WEBGL_ENVS} from '../test_util';
+import {ALL_ENVS, expectArraysClose, WEBGL_ENVS} from '../test_util';
 import {Rank} from '../types';
 
 describeWithFlags('slice1d', ALL_ENVS, () => {
@@ -26,7 +26,7 @@ describeWithFlags('slice1d', ALL_ENVS, () => {
     const result = tf.slice1d(a, 0, 1);
 
     expect(result.shape).toEqual([1]);
-    expectNumbersClose(result.get(0), 5);
+    expectArraysClose(result, 5);
   });
 
   it('slices 5x1 into shape 2x1 starting at 3', () => {
@@ -57,7 +57,7 @@ describeWithFlags('slice1d', ALL_ENVS, () => {
     const a = [5];
     const result = tf.slice1d(a, 0, 1);
     expect(result.shape).toEqual([1]);
-    expectNumbersClose(result.get(0), 5);
+    expectArraysClose(result, 5);
   });
 });
 

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -545,8 +545,8 @@ export class Tensor<R extends Rank = Rank> {
 
   /** Returns a promise of `tf.TensorBuffer` that holds the underlying data. */
   /** @doc {heading: 'Tensors', subheading: 'Classes'} */
-  async buffer<D extends DataType = 'float32'>(): Promise<TensorBuffer<R, D>> {
-    return opHandler.buffer(this.shape, this.dtype as D, await this.data());
+  buffer<D extends DataType = 'float32'>(): TensorBuffer<R, D> {
+    return opHandler.buffer(this.shape, this.dtype as D, this.dataSync());
   }
 
   /** Returns a `tf.TensorBuffer` that holds the underlying data. */

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -16,9 +16,9 @@
  */
 
 import {tensorToString} from './tensor_format';
-import {DataType, DataTypeMap, DataValues, NumericDataType, Rank, ShapeMap, SingleValueMap, TensorLike, TensorLike1D, TensorLike3D, TensorLike4D, TypedArray} from './types';
+import {ArrayMap, DataType, DataTypeMap, DataValues, NumericDataType, Rank, ShapeMap, SingleValueMap, TensorLike, TensorLike1D, TensorLike3D, TensorLike4D, TypedArray} from './types';
 import * as util from './util';
-import {computeStrides} from './util';
+import {computeStrides, toNestedArray} from './util';
 
 export interface TensorData<D extends DataType> {
   dataId?: DataId;
@@ -543,35 +543,36 @@ export class Tensor<R extends Rank = Rank> {
     return this.shape.length;
   }
 
-  /**
-   * Returns the value in the tensor at the provided location.
-   * If using WebGL backend, this is a blocking call.
-   * Prefer calling the `async data()[flatIndex]` method instead.
-   *
-   * @param locs The location indices.
-   */
-  get(...locs: number[]) {
-    util.assert(
-        locs.length === this.rank,
-        'Number of coordinates in get() must match the rank of the tensor');
-    util.assert(
-        this.dtype !== 'complex64',
-        'Tensor.get() is not supported for complex64 tensors yet.');
-    this.throwIfDisposed();
-    if (locs.length === 0) {
-      locs = [0];
-    }
-    let index = locs[locs.length - 1];
-    for (let i = 0; i < locs.length - 1; ++i) {
-      index += this.strides[i] * locs[i];
-    }
-    return this.dataSync()[index];
+  /** Returns a promise of `tf.TensorBuffer` that holds the underlying data. */
+  /** @doc {heading: 'Tensors', subheading: 'Classes'} */
+  async buffer<D extends DataType = 'float32'>(): Promise<TensorBuffer<R, D>> {
+    return opHandler.buffer(this.shape, this.dtype as D, await this.data());
   }
 
   /** Returns a `tf.TensorBuffer` that holds the underlying data. */
   /** @doc {heading: 'Tensors', subheading: 'Classes'} */
-  buffer<D extends DataType>(): TensorBuffer<R, D> {
+  bufferSync<D extends DataType = 'float32'>(): TensorBuffer<R, D> {
     return opHandler.buffer(this.shape, this.dtype as D, this.dataSync());
+  }
+
+  /**
+   * Returns the tensor data as a nested array. The transfer of data is done
+   * asynchronously.
+   */
+  /** @doc {heading: 'Tensors', subheading: 'Classes'} */
+  // tslint:disable-next-line:no-any
+  async array(): Promise<ArrayMap[R]> {
+    return toNestedArray(this.shape, await this.data());
+  }
+
+  /**
+   * Returns the tensor data as a nested array. The transfer of data is done
+   * synchronously.
+   */
+  /** @doc {heading: 'Tensors', subheading: 'Classes'} */
+  // tslint:disable-next-line:no-any
+  arraySync(): ArrayMap[R] {
+    return toNestedArray(this.shape, this.dataSync());
   }
 
   /**

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -28,16 +28,12 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(t.rank).toBe(1);
     expect(t.size).toBe(3);
     expectArraysClose(t, [1, 2, 3]);
-    // Out of bounds indexing.
-    expect(t.get(4)).toBeUndefined();
 
     // [[1, 2, 3]]
     t = tf.tensor2d([1, 2, 3], [1, 3]);
     expect(t.rank).toBe(2);
     expect(t.size).toBe(3);
     expectArraysClose(t, [1, 2, 3]);
-    // Out of bounds indexing.
-    expect(t.get(0, 4)).toBeUndefined();
 
     // [[1, 2, 3],
     //  [4, 5, 6]]
@@ -47,9 +43,6 @@ describeWithFlags('tensor', ALL_ENVS, () => {
 
     expectArraysClose(t, [1, 2, 3, 4, 5, 6]);
 
-    // Out of bounds indexing.
-    expect(t.get(5, 3)).toBeUndefined();
-
     // Shape mismatch with the values.
     expect(() => tf.tensor2d([1], [1, 2])).toThrowError();
   });
@@ -58,44 +51,28 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const t = tf.tensor1d([5, 3, 2]);
     expect(t.rank).toBe(1);
     expect(t.shape).toEqual([3]);
-    expectNumbersClose(t.get(1), 3);
 
     // tslint:disable-next-line:no-any
     expect(() => tf.tensor3d([1, 2], [1, 2, 3, 5] as any)).toThrowError();
 
     const t4 = tf.tensor4d([1, 2, 3, 4], [1, 2, 1, 2]);
-    expectNumbersClose(t4.get(0, 0, 0, 0), 1);
-    expectNumbersClose(t4.get(0, 0, 0, 1), 2);
-    expectNumbersClose(t4.get(0, 1, 0, 0), 3);
-    expectNumbersClose(t4.get(0, 1, 0, 1), 4);
+    expectArraysClose(t4, [1, 2, 3, 4]);
 
     // Tensor of ones.
     const x = tf.ones<Rank.R3>([3, 4, 2]);
     expect(x.rank).toBe(3);
     expect(x.size).toBe(24);
-    for (let i = 0; i < 3; i++) {
-      for (let j = 0; j < 4; j++) {
-        for (let k = 0; k < 2; k++) {
-          expectNumbersClose(x.get(i, j, k), 1);
-        }
-      }
-    }
+    expectArraysClose(x, [
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    ]);
 
     // Tensor of zeros.
     const z = tf.zeros<Rank.R3>([3, 4, 2]);
     expect(z.rank).toBe(3);
     expect(z.size).toBe(24);
-    for (let i = 0; i < 3; i++) {
-      for (let j = 0; j < 4; j++) {
-        for (let k = 0; k < 2; k++) {
-          expectNumbersClose(z.get(i, j, k), 0);
-        }
-      }
-    }
-
-    // Reshaping tensors.
-    const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
-    expectNumbersClose(a.get(1, 2), 6);
+    expectArraysClose(z, [
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
   });
 
   it('Tensor dataSync CPU --> GPU', () => {
@@ -116,35 +93,34 @@ describeWithFlags('tensor', ALL_ENVS, () => {
 
   it('Scalar basic methods', () => {
     const a = tf.scalar(5);
-    expectNumbersClose(a.get(), 5);
     expectArraysClose(a, [5]);
     expect(a.rank).toBe(0);
     expect(a.size).toBe(1);
     expect(a.shape).toEqual([]);
   });
 
-  it('indexToLoc Scalar', () => {
-    const a = tf.scalar(0).buffer();
+  it('indexToLoc Scalar', async () => {
+    const a = await tf.scalar(0).buffer();
     expect(a.indexToLoc(0)).toEqual([]);
 
-    const b = tf.zeros<Rank.R0>([]).buffer();
+    const b = await tf.zeros<Rank.R0>([]).buffer();
     expect(b.indexToLoc(0)).toEqual([]);
   });
 
-  it('indexToLoc Tensor1D', () => {
-    const a = tf.zeros([3]).buffer();
+  it('indexToLoc Tensor1D', async () => {
+    const a = await tf.zeros([3]).buffer();
     expect(a.indexToLoc(0)).toEqual([0]);
     expect(a.indexToLoc(1)).toEqual([1]);
     expect(a.indexToLoc(2)).toEqual([2]);
 
-    const b = tf.zeros<Rank.R1>([3]).buffer();
+    const b = await tf.zeros<Rank.R1>([3]).buffer();
     expect(b.indexToLoc(0)).toEqual([0]);
     expect(b.indexToLoc(1)).toEqual([1]);
     expect(b.indexToLoc(2)).toEqual([2]);
   });
 
-  it('indexToLoc Tensor2D', () => {
-    const a = tf.zeros([3, 2]).buffer();
+  it('indexToLoc Tensor2D', async () => {
+    const a = await tf.zeros([3, 2]).buffer();
     expect(a.indexToLoc(0)).toEqual([0, 0]);
     expect(a.indexToLoc(1)).toEqual([0, 1]);
     expect(a.indexToLoc(2)).toEqual([1, 0]);
@@ -152,7 +128,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(a.indexToLoc(4)).toEqual([2, 0]);
     expect(a.indexToLoc(5)).toEqual([2, 1]);
 
-    const b = tf.zeros<Rank.R2>([3, 2]).buffer();
+    const b = await tf.zeros<Rank.R2>([3, 2]).buffer();
     expect(b.indexToLoc(0)).toEqual([0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 1]);
     expect(b.indexToLoc(2)).toEqual([1, 0]);
@@ -161,8 +137,8 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.indexToLoc(5)).toEqual([2, 1]);
   });
 
-  it('indexToLoc Tensor3D', () => {
-    const a = tf.zeros([3, 2, 2]).buffer();
+  it('indexToLoc Tensor3D', async () => {
+    const a = await tf.zeros([3, 2, 2]).buffer();
     expect(a.indexToLoc(0)).toEqual([0, 0, 0]);
     expect(a.indexToLoc(1)).toEqual([0, 0, 1]);
     expect(a.indexToLoc(2)).toEqual([0, 1, 0]);
@@ -171,7 +147,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(a.indexToLoc(5)).toEqual([1, 0, 1]);
     expect(a.indexToLoc(11)).toEqual([2, 1, 1]);
 
-    const b = tf.zeros<Rank.R3>([3, 2, 2]).buffer();
+    const b = await tf.zeros<Rank.R3>([3, 2, 2]).buffer();
     expect(b.indexToLoc(0)).toEqual([0, 0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 0, 1]);
     expect(b.indexToLoc(2)).toEqual([0, 1, 0]);
@@ -181,37 +157,37 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.indexToLoc(11)).toEqual([2, 1, 1]);
   });
 
-  it('indexToLoc Tensor 5D', () => {
+  it('indexToLoc Tensor 5D', async () => {
     const values = new Float32Array([1, 2, 3, 4]);
-    const a = Tensor.make([2, 1, 1, 1, 2], {values}).buffer();
+    const a = await Tensor.make([2, 1, 1, 1, 2], {values}).buffer();
     expect(a.indexToLoc(0)).toEqual([0, 0, 0, 0, 0]);
     expect(a.indexToLoc(1)).toEqual([0, 0, 0, 0, 1]);
     expect(a.indexToLoc(2)).toEqual([1, 0, 0, 0, 0]);
     expect(a.indexToLoc(3)).toEqual([1, 0, 0, 0, 1]);
   });
 
-  it('locToIndex Scalar', () => {
-    const a = tf.scalar(0).buffer();
+  it('locToIndex Scalar', async () => {
+    const a = await tf.scalar(0).buffer();
     expect(a.locToIndex([])).toEqual(0);
 
-    const b = tf.zeros<Rank.R0>([]).buffer();
+    const b = await tf.zeros<Rank.R0>([]).buffer();
     expect(b.locToIndex([])).toEqual(0);
   });
 
-  it('locToIndex Tensor1D', () => {
-    const a = tf.zeros<Rank.R1>([3]).buffer();
+  it('locToIndex Tensor1D', async () => {
+    const a = await tf.zeros<Rank.R1>([3]).buffer();
     expect(a.locToIndex([0])).toEqual(0);
     expect(a.locToIndex([1])).toEqual(1);
     expect(a.locToIndex([2])).toEqual(2);
 
-    const b = tf.zeros<Rank.R1>([3]).buffer();
+    const b = await tf.zeros<Rank.R1>([3]).buffer();
     expect(b.locToIndex([0])).toEqual(0);
     expect(b.locToIndex([1])).toEqual(1);
     expect(b.locToIndex([2])).toEqual(2);
   });
 
-  it('locToIndex Tensor2D', () => {
-    const a = tf.zeros<Rank.R2>([3, 2]).buffer();
+  it('locToIndex Tensor2D', async () => {
+    const a = await tf.zeros<Rank.R2>([3, 2]).buffer();
     expect(a.locToIndex([0, 0])).toEqual(0);
     expect(a.locToIndex([0, 1])).toEqual(1);
     expect(a.locToIndex([1, 0])).toEqual(2);
@@ -219,7 +195,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(a.locToIndex([2, 0])).toEqual(4);
     expect(a.locToIndex([2, 1])).toEqual(5);
 
-    const b = tf.zeros<Rank.R2>([3, 2]).buffer();
+    const b = await tf.zeros<Rank.R2>([3, 2]).buffer();
     expect(b.locToIndex([0, 0])).toEqual(0);
     expect(b.locToIndex([0, 1])).toEqual(1);
     expect(b.locToIndex([1, 0])).toEqual(2);
@@ -228,8 +204,8 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.locToIndex([2, 1])).toEqual(5);
   });
 
-  it('locToIndex Tensor3D', () => {
-    const a = tf.zeros<Rank.R3>([3, 2, 2]).buffer();
+  it('locToIndex Tensor3D', async () => {
+    const a = await tf.zeros<Rank.R3>([3, 2, 2]).buffer();
     expect(a.locToIndex([0, 0, 0])).toEqual(0);
     expect(a.locToIndex([0, 0, 1])).toEqual(1);
     expect(a.locToIndex([0, 1, 0])).toEqual(2);
@@ -238,7 +214,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(a.locToIndex([1, 0, 1])).toEqual(5);
     expect(a.locToIndex([2, 1, 1])).toEqual(11);
 
-    const b = tf.zeros<Rank.R3>([3, 2, 2]).buffer();
+    const b = await tf.zeros<Rank.R3>([3, 2, 2]).buffer();
     expect(b.locToIndex([0, 0, 0])).toEqual(0);
     expect(b.locToIndex([0, 0, 1])).toEqual(1);
     expect(b.locToIndex([0, 1, 0])).toEqual(2);
@@ -443,70 +419,70 @@ describeWithFlags('tensor', ALL_ENVS, () => {
   it('default dtype', () => {
     const a = tf.scalar(3);
     expect(a.dtype).toBe('float32');
-    expectArraysClose(a, [3]);
+    expectArraysClose(a, 3);
   });
 
   it('float32 dtype', () => {
     const a = tf.scalar(3, 'float32');
     expect(a.dtype).toBe('float32');
-    expectArraysClose(a, [3]);
+    expectArraysClose(a, 3);
   });
 
   it('int32 dtype', () => {
     const a = tf.scalar(3, 'int32');
     expect(a.dtype).toBe('int32');
-    expectArraysEqual(a, [3]);
+    expectArraysEqual(a, 3);
   });
 
   it('int32 dtype, 3.9 => 3, like numpy', () => {
     const a = tf.scalar(3.9, 'int32');
     expect(a.dtype).toBe('int32');
-    expectArraysEqual(a, [3]);
+    expectArraysEqual(a, 3);
   });
 
   it('int32 dtype, -3.9 => -3, like numpy', () => {
     const a = tf.scalar(-3.9, 'int32');
     expect(a.dtype).toBe('int32');
-    expectArraysEqual(a, [-3]);
+    expectArraysEqual(a, -3);
   });
 
   it('bool dtype, 3 => true, like numpy', () => {
     const a = tf.scalar(3, 'bool');
     expect(a.dtype).toBe('bool');
-    expect(a.get()).toBe(1);
+    expectArraysEqual(a, 1);
   });
 
   it('bool dtype, -2 => true, like numpy', () => {
     const a = tf.scalar(-2, 'bool');
     expect(a.dtype).toBe('bool');
-    expect(a.get()).toBe(1);
+    expectArraysEqual(a, 1);
   });
 
   it('bool dtype, 0 => false, like numpy', () => {
     const a = tf.scalar(0, 'bool');
     expect(a.dtype).toBe('bool');
-    expect(a.get()).toBe(0);
+    expectArraysEqual(a, 0);
   });
 
   it('bool dtype from boolean', () => {
     const a = tf.scalar(false, 'bool');
-    expect(a.get()).toBe(0);
+    expectArraysEqual(a, 0);
     expect(a.dtype).toBe('bool');
 
     const b = tf.scalar(true, 'bool');
-    expect(b.get()).toBe(1);
+    expectArraysEqual(a, 0);
     expect(b.dtype).toBe('bool');
   });
 
   it('int32 dtype from boolean', () => {
     const a = tf.scalar(true, 'int32');
-    expect(a.get()).toBe(1);
+    expectArraysEqual(a, 1);
     expect(a.dtype).toBe('int32');
   });
 
   it('default dtype from boolean', () => {
     const a = tf.scalar(false);
-    expectNumbersClose(a.get(), 0);
+    expectArraysEqual(a, 0);
     expect(a.dtype).toBe('bool');
   });
 
@@ -549,10 +525,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = tf.tensor1d([1, -2, 0, 3], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([4]);
-    expect(a.get(0)).toBe(1);
-    expect(a.get(1)).toBe(1);
-    expect(a.get(2)).toBe(0);
-    expect(a.get(3)).toBe(1);
+    expectArraysEqual(a, [1, 1, 0, 1]);
   });
 
   it('default dtype from boolean[]', () => {
@@ -725,10 +698,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = tf.tensor2d([1, -2, 0, 3], [2, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2]);
-    expect(a.get(0, 0)).toBe(1);
-    expect(a.get(0, 1)).toBe(1);
-    expect(a.get(1, 0)).toBe(0);
-    expect(a.get(1, 1)).toBe(1);
+    expectArraysEqual(a, [1, 1, 0, 1]);
   });
 
   it('default dtype from boolean[]', () => {
@@ -794,10 +764,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = tf.tensor3d([1, -2, 0, 3], [2, 2, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 1]);
-    expect(a.get(0, 0, 0)).toBe(1);
-    expect(a.get(0, 1, 0)).toBe(1);
-    expect(a.get(1, 0, 0)).toBe(0);
-    expect(a.get(1, 1, 0)).toBe(1);
+    expectArraysEqual(a, [1, 1, 0, 1]);
   });
 
   it('default dtype from boolean[]', () => {
@@ -867,10 +834,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     const a = tf.tensor4d([1, -2, 0, 3], [2, 2, 1, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 1, 1]);
-    expect(a.get(0, 0, 0, 0)).toBe(1);
-    expect(a.get(0, 1, 0, 0)).toBe(1);
-    expect(a.get(1, 0, 0, 0)).toBe(0);
-    expect(a.get(1, 1, 0, 0)).toBe(1);
+    expectArraysEqual(a, [1, 1, 0, 1]);
   });
 
   it('default dtype from boolean[]', () => {
@@ -1292,7 +1256,7 @@ describeWithFlags('tensor', ALL_ENVS, () => {
   it('scalar bool -> int32', () => {
     const a = tf.scalar(true, 'bool').toInt();
     expect(a.dtype).toBe('int32');
-    expect(a.get()).toBe(1);
+    expectArraysEqual(a, 1);
   });
 
   it('Tensor1D float32 -> int32', () => {
@@ -1304,19 +1268,13 @@ describeWithFlags('tensor', ALL_ENVS, () => {
   it('Tensor2D float32 -> bool', () => {
     const a = tf.tensor2d([1.1, 3.9, -2.9, 0], [2, 2]).asType('bool');
     expect(a.dtype).toBe('bool');
-    expect(a.get(0, 0)).toBe(1);
-    expect(a.get(0, 1)).toBe(1);
-    expect(a.get(1, 0)).toBe(1);
-    expect(a.get(1, 1)).toBe(0);
+    expectArraysEqual(a, [1, 1, 1, 0]);
   });
 
   it('Tensor2D int32 -> bool', () => {
     const a = tf.tensor2d([1, 3, 0, -1], [2, 2], 'int32').toBool();
     expect(a.dtype).toBe('bool');
-    expect(a.get(0, 0)).toBe(1);
-    expect(a.get(0, 1)).toBe(1);
-    expect(a.get(1, 0)).toBe(0);
-    expect(a.get(1, 1)).toBe(1);
+    expectArraysEqual(a, [1, 1, 0, 1]);
   });
 
   it('Tensor3D bool -> float32', () => {

--- a/src/tensor_util_test.ts
+++ b/src/tensor_util_test.ts
@@ -21,7 +21,7 @@ import {Tensor} from './tensor';
 import {NamedTensorMap} from './tensor_types';
 import {flattenNameArrayMap, getTensorsInContainer, isTensorInList, unflattenToNameArrayMap} from './tensor_util';
 import {convertToTensor} from './tensor_util_env';
-import {ALL_ENVS, expectArraysClose, expectNumbersClose} from './test_util';
+import {ALL_ENVS, expectArraysClose, expectArraysEqual} from './test_util';
 
 describe('tensor_util.isTensorInList', () => {
   it('not in list', () => {
@@ -111,35 +111,35 @@ describeWithFlags('convertToTensor', ALL_ENVS, () => {
     const b = convertToTensor(NaN, 'b', 'test', 'int32');
     expect(b.rank).toBe(0);
     expect(b.dtype).toBe('int32');
-    expectNumbersClose(b.get(), 0);
+    expectArraysClose(b, 0);
   });
 
   it('primitive number', () => {
     const a = convertToTensor(3, 'a', 'test');
     expect(a.rank).toBe(0);
     expect(a.dtype).toBe('float32');
-    expectNumbersClose(a.get(), 3);
+    expectArraysClose(a, 3);
   });
 
   it('primitive integer, NaN converts to zero', () => {
     const a = convertToTensor(NaN, 'a', 'test', 'int32');
     expect(a.rank).toBe(0);
     expect(a.dtype).toBe('int32');
-    expectNumbersClose(a.get(), 0);
+    expectArraysClose(a, 0);
   });
 
   it('primitive boolean, parsed as bool tensor', () => {
     const a = convertToTensor(true, 'a', 'test');
     expect(a.rank).toBe(0);
     expect(a.dtype).toBe('bool');
-    expectNumbersClose(a.get(), 1);
+    expectArraysClose(a, 1);
   });
 
   it('primitive boolean, forced to be parsed as bool tensor', () => {
     const a = convertToTensor(true, 'a', 'test', 'bool');
     expect(a.rank).toBe(0);
     expect(a.dtype).toBe('bool');
-    expect(a.get()).toBe(1);
+    expectArraysEqual(a, 1);
   });
 
   it('array1d', () => {

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -46,12 +46,16 @@ export const ALL_ENVS: Features = {};
 
 export function expectArraysClose(
     actual: Tensor|TypedArray|number[],
-    expected: Tensor|TypedArray|number[]|boolean[], epsilon?: number) {
+    expected: Tensor|TypedArray|number[]|boolean[]|number|boolean,
+    epsilon?: number) {
   if (epsilon == null) {
     epsilon = ENV.get('TEST_EPSILON');
   }
+  const exp = typeof expected === 'number' || typeof expected === 'boolean' ?
+      [expected] as number[] :
+      expected as number[];
   return expectArraysPredicate(
-      actual, expected, (a, b) => areClose(a as number, Number(b), epsilon));
+      actual, exp, (a, b) => areClose(a as number, Number(b), epsilon));
 }
 
 function expectArraysPredicate(
@@ -124,13 +128,18 @@ export function expectPromiseToFail(fn: () => Promise<{}>, done: DoneFn): void {
 
 export function expectArraysEqual(
     actual: Tensor|TypedArray|number[]|string[],
-    expected: Tensor|TypedArray|number[]|boolean[]|string[]) {
+    expected: Tensor|TypedArray|number[]|boolean[]|string[]|number|boolean|
+    string) {
+  const exp = typeof expected === 'string' || typeof expected === 'number' ||
+          typeof expected === 'boolean' ?
+      [expected] as number[] :
+      expected as number[];
   if (actual instanceof Tensor && actual.dtype === 'string' ||
       expected instanceof Tensor && expected.dtype === 'string' ||
       Array.isArray(actual) && isString(actual[0]) ||
       Array.isArray(expected) && isString(expected[0])) {
     // tslint:disable-next-line:triple-equals
-    return expectArraysPredicate(actual, expected, (a, b) => a == b);
+    return expectArraysPredicate(actual, exp, (a, b) => a == b);
   }
   return expectArraysClose(actual as Tensor, expected as Tensor, 0);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,17 @@ export interface ShapeMap {
   R6: [number, number, number, number, number, number];
 }
 
+/** @docalias number[] */
+export interface ArrayMap {
+  R0: number;
+  R1: number[];
+  R2: number[][];
+  R3: number[][][];
+  R4: number[][][][];
+  R5: number[][][][][];
+  R6: number[][][][][][];
+}
+
 export interface DataTypeMap {
   float32: Float32Array;
   int32: Int32Array;

--- a/src/util.ts
+++ b/src/util.ts
@@ -538,8 +538,8 @@ function createNestedArray(offset: number, shape: number[], a: TypedArray) {
 // Provide a nested array of TypedArray in given shape.
 export function toNestedArray(shape: number[], a: TypedArray) {
   if (shape.length === 0) {
-    // Scalar type should be empty list.
-    return [];
+    // Scalar type should return a single number.
+    return a[0];
   }
   const size = shape.reduce((acc, c) => acc * c);
   if (size === 0) {

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -488,7 +488,7 @@ describe('util.toNestedArray', () => {
 
   it('scalar to nested array', () => {
     const x = scalar(1);
-    expect(util.toNestedArray(x.shape, x.dataSync())).toEqual([]);
+    expect(util.toNestedArray(x.shape, x.dataSync())).toEqual(1);
   });
 
   it('tensor with zero shape', () => {


### PR DESCRIPTION
Cherry pick of https://github.com/tensorflow/tfjs-core/pull/1537

The one thing I didn't cherry pick here is making buffer async. Tensor.buffer() is still sync so not to break the API.

FEATURE
BREAKING
- Remove `tensor.get(...)` and remove all usage in tfjs-core
- Make `tensor.buffer()` async and introduce `tensor.bufferSync()`
- Introduce `tensor.array()` and `tensor.arraySync()` which return the data as a nested array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1548)
<!-- Reviewable:end -->
