### PR TITLE
Fix reference issue in free-packed-reshape-conv2D approach

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1681,6 +1681,11 @@ export class MathBackendWebGL implements KernelBackend {
             [1, xShape[0] * xShape[1] * (xShape[2] + 1), convInfo.inChannels],
             {dataId: x.dataId}, x.dtype) as Tensor3D;
 
+    // xTexData.shape gets referenced from GPGPUBinary.inShapeInfos. Provide a
+    // copy to it with even row count. After the method, the original
+    // xTexData.shape needs to be restored.
+    const originalXTexDataShape = xTexData.shape;
+    xTexData.shape = xTexData.shape.slice();
     xTexData.shape[xTexData.shape.length - 2]++;
     util.assert(
         webgl_util.isReshapeFree(xTexData.shape, xReshaped.shape),
@@ -1695,8 +1700,8 @@ export class MathBackendWebGL implements KernelBackend {
     util.assert(
         pointwiseConvTexData.isPacked,
         'batchMatMul result is expected to be packed');
-    // Restore the input shape to odd number of rows.
-    xTexData.shape[xTexData.shape.length - 2]--;
+    // Restore the input shape to original.
+    xTexData.shape = originalXTexDataShape;
     // Set the output shape - there is no need for expensive reshape as data
     // layout is already correct.
     pointwiseConvTexData.shape = convInfo.outShape;


### PR DESCRIPTION
This fix relates to tensorflow/tfjs#949 and fix committed in PR #1495.

xTexData.shape gets referenced from GPGPUBinary.inShapeInfos. Decrementing
row count, after batchMatMul->...->compileProgram leads to invalid row
count within the reference in GPGPUBinary.inShapeInfos. Proper way would be
to provide a copy to GPGPUBinary.inShapeInfos but that would affect
all the program compilation - so, provide a  copy, with even row cound,
when calling batchMatMul->...->compileProgram and after that, the original
xTexData.shape is restored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1553)
<!-- Reviewable:end -->
