### PR TITLE
Add fill kernel in backend

### DIFF
--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -583,6 +583,12 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
       defaultValue: Scalar): Tensor<R> {
     throw new Error('Not yet implemented');
   }
+
+  fill<R extends Rank>(
+      shape: ShapeMap[R], value: number|string, dtype?: DataType): Tensor<R> {
+    throw new Error('Not yet implemented.');
+  }
+
   /**
    * Sets the data mover for this backend. Backends should use the mover to
    * move data from other backends to this backend.

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -35,7 +35,7 @@ import {computeFlatOffset, getStridedSlicedInfo, isSliceContinous} from '../ops/
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer} from '../tensor';
 import {DataType, DataTypeMap, DataValues, NumericDataType, Rank, ShapeMap, TypedArray, upcastType} from '../types';
 import * as util from '../util';
-import {now} from '../util';
+import {getArrayFromDType, inferDtype, now, sizeFromShape} from '../util';
 
 import {BackendTimingInfo, DataMover, DataStorage, KernelBackend} from './backend';
 import * as backend_util from './backend_util';
@@ -3327,6 +3327,14 @@ export class MathBackendCPU implements KernelBackend {
     return this.scatter(
         indices, updates, shape, outputSize, sliceSize, numUpdates, sliceRank,
         strides, defaultValue, sumDupeIndices);
+  }
+
+  fill<R extends Rank>(
+    shape: ShapeMap[R], value: number|string, dtype?: DataType): Tensor<R> {
+    dtype = dtype || inferDtype(value);
+    const values = getArrayFromDType(dtype, sizeFromShape(shape)) as TypedArray;
+    values.fill(value as number);
+    return Tensor.make(shape, {values}, dtype);
   }
 
   private scatter<R extends Rank>(

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2092,7 +2092,9 @@ export class MathBackendWebGL implements KernelBackend {
     } else {
       const input = scalar(value);
       const program = new FillProgram(shape, value as number);
-      return this.compileAndRun(program, [input]) as Tensor<R>;
+      const customSetup = program.getCustomSetupFunc(value as number);
+      return this.compileAndRun(program, [input], null,
+        customSetup) as Tensor<R>;
     }
   }
 

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2090,11 +2090,10 @@ export class MathBackendWebGL implements KernelBackend {
       values.fill(value as string);
       return Tensor.make(shape, {values}, dtype);
     } else {
-      const input = scalar(value);
       const program = new FillProgram(shape, value as number);
       const customSetup = program.getCustomSetupFunc(value as number);
-      return this.compileAndRun(program, [input], null,
-        customSetup) as Tensor<R>;
+      const output = this.makeOutputArray(shape, dtype) as Tensor<R>;
+      return this.compileAndRun(program, [], output, customSetup) as Tensor<R>;
     }
   }
 

--- a/src/kernels/webgl/fill_gpu.ts
+++ b/src/kernels/webgl/fill_gpu.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {GPGPUProgram} from './gpgpu_math';
+
+export class FillProgram implements GPGPUProgram {
+  variableNames: string[];
+  outputShape: number[] = [];
+  userCode: string;
+
+  constructor(shape: number[], value: number) {
+    this.variableNames = ['x'];
+    this.outputShape = shape;
+
+    this.userCode = `
+      void main() {
+        // Input value can be embedded directly to avoid overhead.
+        float v = float(${value});
+        setOutput(v);
+      }
+    `;
+  }
+}

--- a/src/ops/tensor_ops.ts
+++ b/src/ops/tensor_ops.ts
@@ -18,9 +18,9 @@
 import {ENV} from '../environment';
 import {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D} from '../tensor';
 import {convertToTensor, inferShape} from '../tensor_util_env';
-import {TensorLike, TensorLike1D, TensorLike2D, TensorLike3D, TensorLike4D, TensorLike5D, TensorLike6D, TypedArray} from '../types';
+import {TensorLike, TensorLike1D, TensorLike2D, TensorLike3D, TensorLike4D, TensorLike5D, TensorLike6D} from '../types';
 import {DataType, Rank, ShapeMap} from '../types';
-import {assert, assertNonNull, flatten, getArrayFromDType, inferDtype, isTypedArray, makeOnesTypedArray, makeZerosTypedArray, sizeFromShape, toTypedArray} from '../util';
+import {assert, assertNonNull, flatten, inferDtype, isTypedArray, makeOnesTypedArray, makeZerosTypedArray, sizeFromShape, toTypedArray} from '../util';
 
 import {complex} from './complex_ops';
 import {op} from './operation';
@@ -428,10 +428,8 @@ function zeros<R extends Rank>(
 /** @doc {heading: 'Tensors', subheading: 'Creation'} */
 function fill<R extends Rank>(
     shape: ShapeMap[R], value: number|string, dtype?: DataType): Tensor<R> {
-  dtype = dtype || inferDtype(value);
-  const values = getArrayFromDType(dtype, sizeFromShape(shape)) as TypedArray;
-  values.fill(value as number);
-  return Tensor.make(shape, {values}, dtype);
+  return ENV.engine.runKernel(backend =>
+    backend.fill(shape, value, dtype), {});
 }
 
 /**


### PR DESCRIPTION
PERF

That is necessary in order to make use of TensorFlow core via tfjs-node.
Fill op in tfjs-core can change the backend kernel to optimize the performance.

And we can improve the performance by itself. Here is the result of micro benchmark I ran. Using GPU for fill kernel is slightly faster along with the size of tensor is increasing.

Environment
- macOS: 10.13.6
- Chrome: 71.0.3578.98

```js
const nums = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
const results = nums.map(n => {
  const tensors = [];
  const start = performance.now();
  for (let i = 0; i < 100; i++) {
    const res = tf.ones([n * n, n * n]);
    res.dataSync();
  }
  return performance.now() - start;
});
```

<img width="773" alt="screen shot 2019-02-09 at 11 26 49" src="https://user-images.githubusercontent.com/1713047/52515355-ab5b9f80-2c5d-11e9-823c-f995ac1dfc7b.png">


See: https://github.com/tensorflow/tfjs/issues/1211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1558)
<!-- Reviewable:end -->
