### PR TITLE
Fix wrong paging accounting for pointwise conv2D

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2219,8 +2219,8 @@ export class MathBackendWebGL implements KernelBackend {
       let numBytesToPage = this.numBytesInGPU - numBytesBeforePaging;
       while (numBytesToPage > 0 && this.lruDataGPU.length > 0) {
         const dataId = this.lruDataGPU.shift();
-        const {texShape, dtype, isPacked} = this.texData.get(dataId);
-        numBytesToPage -= this.computeBytes(texShape, dtype, isPacked);
+        const {texShape, dtype} = this.texData.get(dataId);
+        numBytesToPage -= this.computeBytes(texShape, dtype);
         this.read(dataId);
       }
     }
@@ -2364,7 +2364,7 @@ export class MathBackendWebGL implements KernelBackend {
         this.lruDataGPU.splice(idx, 1);
       }
     }
-    this.numBytesInGPU -= this.computeBytes(texShape, dtype, isPacked);
+    this.numBytesInGPU -= this.computeBytes(texShape, dtype);
     this.textureManager.releaseTexture(texture, texShape, texType, isPacked);
   }
 
@@ -2374,12 +2374,11 @@ export class MathBackendWebGL implements KernelBackend {
     if (ENV.get('WEBGL_NUM_MB_BEFORE_PAGING') < Number.POSITIVE_INFINITY) {
       this.lruDataGPU.push(dataId);
     }
-    this.numBytesInGPU += this.computeBytes(texShape, dtype, isPacked);
+    this.numBytesInGPU += this.computeBytes(texShape, dtype);
     return this.textureManager.acquireTexture(texShape, texType, isPacked);
   }
 
-  private computeBytes(
-      shape: [number, number], dtype: DataType, isPacked: boolean) {
+  private computeBytes(shape: [number, number], dtype: DataType) {
     return shape[0] * shape[1] * util.bytesPerElement(dtype);
   }
 }

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -2380,11 +2380,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   private computeBytes(
       shape: [number, number], dtype: DataType, isPacked: boolean) {
-    let bytes = shape[0] * shape[1] * util.bytesPerElement(dtype);
-    if (isPacked) {
-      bytes /= 4;
-    }
-    return bytes;
+    return shape[0] * shape[1] * util.bytesPerElement(dtype);
   }
 }
 

--- a/src/ops/conv2d_test.ts
+++ b/src/ops/conv2d_test.ts
@@ -341,7 +341,7 @@ describeWithFlags('conv2d webgl', WEBGL_ENVS, () => {
 
     const webglLazilyUnpackFlagSaved = tf.ENV.get('WEBGL_LAZILY_UNPACK');
     tf.ENV.set('WEBGL_LAZILY_UNPACK', true);
-    const webglLazilyPackBinaryOperationsFlagSaved =
+    const webglPackBinaryOperationsFlagSaved =
         tf.ENV.get('WEBGL_PACK_BINARY_OPERATIONS');
     tf.ENV.set('WEBGL_PACK_BINARY_OPERATIONS', true);
 
@@ -352,8 +352,7 @@ describeWithFlags('conv2d webgl', WEBGL_ENVS, () => {
 
     tf.ENV.set('WEBGL_LAZILY_UNPACK', webglLazilyUnpackFlagSaved);
     tf.ENV.set(
-        'WEBGL_PACK_BINARY_OPERATIONS',
-        webglLazilyPackBinaryOperationsFlagSaved);
+        'WEBGL_PACK_BINARY_OPERATIONS', webglPackBinaryOperationsFlagSaved);
 
     expectArraysClose(result, [7, 10, 15, 22]);
     expectArraysClose(result1, [37, 54, 81, 118]);
@@ -370,7 +369,7 @@ describeWithFlags('conv2d webgl', WEBGL_ENVS, () => {
 
     const webglLazilyUnpackFlagSaved = tf.ENV.get('WEBGL_LAZILY_UNPACK');
     tf.ENV.set('WEBGL_LAZILY_UNPACK', true);
-    const webglLazilyPackBinaryOperationsFlagSaved =
+    const webglPackBinaryOperationsFlagSaved =
         tf.ENV.get('WEBGL_PACK_BINARY_OPERATIONS');
     tf.ENV.set('WEBGL_PACK_BINARY_OPERATIONS', true);
 
@@ -379,8 +378,7 @@ describeWithFlags('conv2d webgl', WEBGL_ENVS, () => {
 
     tf.ENV.set('WEBGL_LAZILY_UNPACK', webglLazilyUnpackFlagSaved);
     tf.ENV.set(
-        'WEBGL_PACK_BINARY_OPERATIONS',
-        webglLazilyPackBinaryOperationsFlagSaved);
+        'WEBGL_PACK_BINARY_OPERATIONS', webglPackBinaryOperationsFlagSaved);
 
     expectArraysClose(result, [7, 10]);
     result.dispose();


### PR DESCRIPTION
- pointwise conv2D implementation caused wrong calculation of MathBackendWebGL.numBytesInGPU, in time increasing it and leading to unecessary paging activation.
- added unit test exposing the issue.
- simplify computeBytes computation to use texShape:
  - texShape is not equal to logical shape,
  - no need for call to generic utils.sizeFromShape
    since we always have texShape[0] * texShape[1]
- save one this.texData.get lookup per call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1559)
<!-- Reviewable:end -->
