### PR TITLE
Make defaultValue optional in sparseToDense

### DIFF
--- a/src/ops/sparse_to_dense.ts
+++ b/src/ops/sparse_to_dense.ts
@@ -23,7 +23,6 @@ import {Rank, ScalarLike, ShapeMap, TensorLike} from '../types';
 
 import {op} from './operation';
 
-
 /**
  * Converts a sparse representation into a dense tensor.
  *

--- a/src/ops/sparse_to_dense.ts
+++ b/src/ops/sparse_to_dense.ts
@@ -19,9 +19,10 @@ import {ENV} from '../environment';
 import * as sparse_to_dense from '../ops/sparse_to_dense_util';
 import {Scalar, Tensor} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
-import {Rank, ShapeMap, TensorLike} from '../types';
+import {Rank, ScalarLike, ShapeMap, TensorLike} from '../types';
 
 import {op} from './operation';
+
 
 /**
  * Converts a sparse representation into a dense tensor.
@@ -59,7 +60,7 @@ import {op} from './operation';
 /** @doc {heading: 'Operations', subheading: 'Normalization'} */
 function sparseToDense_<R extends Rank>(
     sparseIndices: Tensor|TensorLike, sparseValues: Tensor|TensorLike,
-    outputShape: ShapeMap[R], defaultValue: Scalar|TensorLike): Tensor<R> {
+    outputShape: ShapeMap[R], defaultValue: Scalar|ScalarLike = 0): Tensor<R> {
   const $sparseIndices =
       convertToTensor(sparseIndices, 'sparseIndices', 'sparseToDense', 'int32');
   const $sparseValues =

--- a/src/ops/sparse_to_dense_test.ts
+++ b/src/ops/sparse_to_dense_test.ts
@@ -80,6 +80,16 @@ describeWithFlags('sparseToDense', ALL_ENVS, () => {
     expectArraysClose(result, [1, 5, 1, 6]);
   });
 
+  it('no default value passed', () => {
+    const indices = tensor2d([0, 1, 1, 1], [2, 2], 'int32');
+    const values = tensor1d([5, 6], 'float32');
+    const shape = [2, 2];
+    const result = sparseToDense(indices, values, shape);
+    expect(result.shape).toEqual(shape);
+    expect(result.dtype).toEqual(values.dtype);
+    expectArraysClose(result, [0, 5, 0, 6]);
+  });
+
   it('should support TensorLike inputs', () => {
     const indices = [[0, 1], [1, 1]];
     const values = [5, 6];


### PR DESCRIPTION
I'm not sure I have all the context on this op but it looks like defaultValue should be an optional parameter https://www.tensorflow.org/api_docs/python/tf/sparse_to_dense.  If it's required then the example in the docs should be updated since it currently throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1560)
<!-- Reviewable:end -->
