### PR TITLE
Validate non-integer shapes in Tensor.make.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-core",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "description": "Hardware-accelerated JavaScript library for machine intelligence",
   "private": false,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-core",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Hardware-accelerated JavaScript library for machine intelligence",
   "private": false,
   "main": "dist/index.js",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -30,8 +30,8 @@ BRANCH=`git rev-parse --abbrev-ref HEAD`
 ORIGIN=`git config --get remote.origin.url`
 CHANGES=`git status --porcelain`
 
-if [ "$BRANCH" != "master" ]; then
-  echo "Error: Switch to the master branch before publishing."
+if [ "$BRANCH" != "master" ] && [ "$BRANCH" != "0.15.x" ]; then
+  echo "Error: Switch to the master or a release branch before publishing."
   exit
 fi
 

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -38,6 +38,7 @@ function test () {
   echo 'Cloning node'
   git clone https://github.com/tensorflow/tfjs-node.git --depth 5
   cd tfjs-node
+  git checkout 0.3.x
   yarn && yarn link-local '@tensorflow/tfjs-core' && ./scripts/test-travis.sh
   NODE_EXIT_CODE=$?
 

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -30,6 +30,7 @@ function test () {
   echo 'Cloning layers'
   git clone https://github.com/tensorflow/tfjs-layers.git --depth 5
   cd tfjs-layers
+  git checkout 0.10.x
   yarn && yarn link-local '@tensorflow/tfjs-core' && ./scripts/test-travis.sh
   LAYERS_EXIT_CODE=$?
 
@@ -44,6 +45,7 @@ function test () {
   echo 'Cloning converter'
   git clone https://github.com/tensorflow/tfjs-converter.git --depth 5
   cd tfjs-converter
+  git checkout 0.8.x
   yarn && yarn link-local '@tensorflow/tfjs-core'
   yarn build && yarn lint && yarn test-travis
   CONVERTER_EXIT_CODE=$?

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -32,7 +32,7 @@ describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
       pixels.data[i] = 250;
     }
 
-    const a = tf.fromPixels(pixels, 4);
+    const a = tf.browser.fromPixels(pixels, 4);
     const b = tf.scalar(20, 'int32');
 
     const res = tf.add(a, b);
@@ -622,12 +622,12 @@ describeWithFlags('Switching WebGL + CPU backends', WEBGL_ENVS, () => {
 
   it('fromPixels with mixed backends works', () => {
     tf.setBackend('webgl1');
-    const a =
-        tf.fromPixels(new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
+    const a = tf.browser.fromPixels(
+        new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
 
     tf.setBackend('webgl2');
-    const b =
-        tf.fromPixels(new ImageData(new Uint8ClampedArray([5, 6, 7, 8]), 1, 1));
+    const b = tf.browser.fromPixels(
+        new ImageData(new Uint8ClampedArray([5, 6, 7, 8]), 1, 1));
 
     expectArraysClose(tf.add(a, b), [6, 8, 10]);
   });

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -19,7 +19,7 @@ import * as device_util from './device_util';
 import {Engine, MemoryInfo, ProfileInfo, ScopeFn, TimingInfo} from './engine';
 import {Features, getFeaturesFromURL, getMaxTexturesInShader, getNumMBBeforePaging, getWebGLDisjointQueryTimerVersion, getWebGLMaxTextureSize, isChrome, isDownloadFloatTextureEnabled, isRenderToFloatTextureEnabled, isWebGLFenceEnabled, isWebGLVersionEnabled} from './environment_util';
 import {KernelBackend} from './kernels/backend';
-import {DataId, setTensorTracker, Tensor, TensorTracker} from './tensor';
+import {DataId, setDeprecationWarningFn, setTensorTracker, Tensor, TensorTracker} from './tensor';
 import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
@@ -378,6 +378,8 @@ export class Environment {
       return false;
     } else if (feature === 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY') {
       return !this.get('PROD');
+    } else if (feature === 'DEPRECATION_WARNINGS_ENABLED') {
+      return true;
     }
     throw new Error(`Unknown feature ${feature}.`);
   }
@@ -489,5 +491,21 @@ function getOrMakeEnvironment(): Environment {
 export function enableProdMode(): void {
   ENV.set('PROD', true);
 }
+
+/** Globally disables deprecation warnings */
+export function disableDeprecationWarnings(): void {
+  ENV.set('DEPRECATION_WARNINGS_ENABLED', false);
+  console.warn(`TensorFlow.js deprecation warnings have been disabled.`);
+}
+
+/** Warn users about deprecated functionality. */
+export function deprecationWarn(msg: string) {
+  if (ENV.get('DEPRECATION_WARNINGS_ENABLED')) {
+    console.warn(
+        msg + ' You can disable deprecation warnings with ' +
+        'tf.disableDeprecationWarnings().');
+  }
+}
+setDeprecationWarningFn(deprecationWarn);
 
 export let ENV = getOrMakeEnvironment();

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -224,6 +224,7 @@ describe('deprecation warnings', () => {
   beforeEach(() => {
     oldWarn = console.warn;
     spyOn(console, 'warn').and.callFake((msg: string): void => null);
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
   });
   afterEach(() => {
     console.warn = oldWarn;

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -218,3 +218,35 @@ describeWithFlags('WEBGL_SIZE_UPLOAD_UNIFORM', WEBGL_ENVS, () => {
     expect(env.get('WEBGL_SIZE_UPLOAD_UNIFORM')).toBeGreaterThan(0);
   });
 });
+
+describe('deprecation warnings', () => {
+  let oldWarn: (msg: string) => void;
+  beforeEach(() => {
+    oldWarn = console.warn;
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+  });
+  afterEach(() => {
+    console.warn = oldWarn;
+  });
+
+  it('deprecationWarn warns', () => {
+    tf.deprecationWarn('xyz is deprecated.');
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            'xyz is deprecated. You can disable deprecation warnings with ' +
+            'tf.disableDeprecationWarnings().');
+  });
+
+  it('disableDeprecationWarnings called, deprecationWarn doesnt warn', () => {
+    tf.disableDeprecationWarnings();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            'TensorFlow.js deprecation warnings have been disabled.');
+
+    // deprecationWarn no longer warns.
+    tf.deprecationWarn('xyz is deprecated.');
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -92,6 +92,8 @@ export interface Features {
   // Whether to do sanity checks when inferring a shape from user-provided
   // values, used when creating a new tensor.
   'TENSORLIKE_CHECK_SHAPE_CONSISTENCY'?: boolean;
+  // Whether deprecation warnings are enabled.
+  'DEPRECATION_WARNINGS_ENABLED'?: boolean;
 }
 
 export enum Type {
@@ -126,6 +128,7 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'EPSILON', type: Type.NUMBER},
   {name: 'PROD', type: Type.BOOLEAN},
   {name: 'TENSORLIKE_CHECK_SHAPE_CONSISTENCY', type: Type.BOOLEAN},
+  {name: 'DEPRECATION_WARNINGS_ENABLED', type: Type.BOOLEAN},
 ];
 
 export interface URLProperty {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,7 @@ import './kernels/backend_cpu';
 
 import {nextFrame} from './browser_util';
 import * as environment from './environment';
-import {Environment, enableProdMode} from './environment';
-
+import {deprecationWarn, disableDeprecationWarnings, enableProdMode, Environment} from './environment';
 // Serialization.
 import * as io from './io/io';
 import * as math from './math';
@@ -67,10 +66,11 @@ export const disposeVariables = Environment.disposeVariables;
 export const memory = Environment.memory;
 export {version as version_core};
 
-export {nextFrame};
+// Top-level method exports.
+export {nextFrame, enableProdMode, disableDeprecationWarnings, deprecationWarn};
 
 // Second level exports.
-export {environment, io, math, serialization, test_util, util, webgl, enableProdMode};
+export {environment, io, math, serialization, test_util, util, webgl};
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {deprecationWarn, disableDeprecationWarnings, enableProdMode, Environment
 // Serialization.
 import * as io from './io/io';
 import * as math from './math';
+import * as browser from './ops/browser';
 import * as serialization from './serialization';
 import {setOpHandler} from './tensor';
 import * as test_util from './test_util';
@@ -70,7 +71,7 @@ export {version as version_core};
 export {nextFrame, enableProdMode, disableDeprecationWarnings, deprecationWarn};
 
 // Second level exports.
-export {environment, io, math, serialization, test_util, util, webgl};
+export {browser, environment, io, math, serialization, test_util, util, webgl};
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';

--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -27,6 +27,9 @@ import {IORouter, IORouterRegistry} from './router_registry';
 import {IOHandler, ModelArtifacts, SaveResult, WeightsManifestConfig, WeightsManifestEntry} from './types';
 import {loadWeightsAsArrayBuffer} from './weights_loader';
 
+const OCTET_STREAM_MIME_TYPE = 'application/octet-stream';
+const JSON_TYPE = 'application/json';
+
 export class BrowserHTTPRequest implements IOHandler {
   protected readonly path: string|string[];
   protected readonly requestInit: RequestInit;
@@ -108,14 +111,13 @@ export class BrowserHTTPRequest implements IOHandler {
         'model.json',
         new Blob(
             [JSON.stringify(modelTopologyAndWeightManifest)],
-            {type: 'application/json'}),
+            {type: JSON_TYPE}),
         'model.json');
 
     if (modelArtifacts.weightData != null) {
       init.body.append(
           'model.weights.bin',
-          new Blob(
-              [modelArtifacts.weightData], {type: 'application/octet-stream'}),
+          new Blob([modelArtifacts.weightData], {type: OCTET_STREAM_MIME_TYPE}),
           'model.weights.bin');
     }
 
@@ -150,10 +152,7 @@ export class BrowserHTTPRequest implements IOHandler {
    * Loads the model topology file and build the in memory graph of the model.
    */
   private async loadBinaryTopology(): Promise<ArrayBuffer> {
-    const response = await this.getFetchFunc()(
-        this.path[0], this.addAcceptHeader('application/octet-stream'));
-    this.verifyContentType(
-        response, 'model topology', 'application/octet-stream');
+    const response = await this.getFetchFunc()(this.path[0], this.requestInit);
 
     if (!response.ok) {
       throw new Error(`Request to ${this.path[0]} failed with error: ${
@@ -162,30 +161,10 @@ export class BrowserHTTPRequest implements IOHandler {
     return await response.arrayBuffer();
   }
 
-  private addAcceptHeader(mimeType: string): RequestInit {
-    const requestOptions = Object.assign({}, this.requestInit || {});
-    const headers = Object.assign({}, requestOptions.headers || {});
-    // tslint:disable-next-line:no-any
-    (headers as any)['Accept'] = mimeType;
-    requestOptions.headers = headers;
-    return requestOptions;
-  }
-
-  private verifyContentType(response: Response, target: string, type: string) {
-    const contentType = response.headers.get('content-type');
-    if (!contentType || contentType.indexOf(type) === -1) {
-      throw new Error(`Request to ${response.url} for ${
-          target} failed. Expected content type ${type} but got ${
-          contentType}.`);
-    }
-  }
-
   protected async loadBinaryModel(): Promise<ModelArtifacts> {
     const graphPromise = this.loadBinaryTopology();
-    const manifestPromise = await this.getFetchFunc()(
-        this.path[1], this.addAcceptHeader('application/json'));
-    this.verifyContentType(
-        manifestPromise, 'weights manifest', 'application/json');
+    const manifestPromise =
+        await this.getFetchFunc()(this.path[1], this.requestInit);
     if (!manifestPromise.ok) {
       throw new Error(`Request to ${this.path[1]} failed with error: ${
           manifestPromise.statusText}`);
@@ -208,10 +187,8 @@ export class BrowserHTTPRequest implements IOHandler {
   }
 
   protected async loadJSONModel(): Promise<ModelArtifacts> {
-    const modelConfigRequest = await this.getFetchFunc()(
-        this.path as string, this.addAcceptHeader('application/json'));
-    this.verifyContentType(
-        modelConfigRequest, 'model topology', 'application/json');
+    const modelConfigRequest =
+        await this.getFetchFunc()(this.path as string, this.requestInit);
 
     if (!modelConfigRequest.ok) {
       throw new Error(`Request to ${this.path} failed with error: ${

--- a/src/io/model_management_test.ts
+++ b/src/io/model_management_test.ts
@@ -90,7 +90,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
     });
   });
 
-  it('List models: 0 result', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('List models: 0 result', done => {
     // Before any model is saved, listModels should return empty result.
     tf.io.listModels()
         .then(out => {
@@ -100,7 +103,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
         .catch(err => done.fail(err.stack));
   });
 
-  it('List models: 1 result', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('List models: 1 result', done => {
     const url = 'localstorage://baz/QuxModel';
     const handler = tf.io.getSaveHandlers(url)[0];
     handler.save(artifacts1)
@@ -124,7 +130,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
         .catch(err => done.fail(err.stack));
   });
 
-  it('Manager: List models: 2 results in 2 mediums', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('Manager: List models: 2 results in 2 mediums', done => {
     const url1 = 'localstorage://QuxModel';
     const url2 = 'indexeddb://QuxModel';
 
@@ -173,7 +182,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
         .catch(err => done.fail(err.stack));
   });
 
-  it('Successful removeModel', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('Successful removeModel', done => {
     // First, save a model.
     const handler1 = tf.io.getSaveHandlers('localstorage://QuxModel')[0];
     handler1.save(artifacts1)
@@ -217,7 +229,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
         .catch(err => done.fail(err.stack));
   });
 
-  it('Successful copyModel between mediums', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('Successful copyModel between mediums', done => {
     const url1 = 'localstorage://a1/FooModel';
     const url2 = 'indexeddb://a1/FooModel';
     // First, save a model.
@@ -266,7 +281,10 @@ describeWithFlags('ModelManagement', CHROME_ENVS, () => {
         .catch(err => done.fail(err.stack));
   });
 
-  it('Successful moveModel between mediums', done => {
+  // TODO(cais): Reenable this test once we fix
+  // https://github.com/tensorflow/tfjs/issues/1198
+  // tslint:disable-next-line:ban
+  xit('Successful moveModel between mediums', done => {
     const url1 = 'localstorage://a1/FooModel';
     const url2 = 'indexeddb://a1/FooModel';
     // First, save a model.

--- a/src/io/weights_loader.ts
+++ b/src/io/weights_loader.ts
@@ -21,12 +21,6 @@ import * as util from '../util';
 import {decodeWeights} from './io_utils';
 import {DTYPE_VALUE_SIZE_MAP, WeightsManifestConfig, WeightsManifestEntry} from './types';
 
-type RequestHeader = {
-  [key: string]: string
-};
-
-const OCTET_STREAM_TYPE = 'application/octet-stream';
-const CONTENT_TYPE = 'Content-type';
 /**
  * Reads binary weights data from a number of URLs.
  *
@@ -45,12 +39,6 @@ export async function loadWeightsAsArrayBuffer(
     fetchFunc = fetch;
   }
 
-  // Add accept header
-  requestOptions = requestOptions || {};
-  const headers = (requestOptions.headers || {}) as RequestHeader;
-  headers['Accept'] = OCTET_STREAM_TYPE;
-  requestOptions.headers = headers;
-
   // Create the requests for all of the weights in parallel.
   const requests =
       fetchURLs.map(fetchURL => fetchFunc(fetchURL, requestOptions));
@@ -64,19 +52,6 @@ export async function loadWeightsAsArrayBuffer(
   }
 
   const responses = await Promise.all(requests);
-  const badContentType = responses.filter(response => {
-    const contentType = response.headers.get(CONTENT_TYPE);
-    return !contentType || contentType.indexOf(OCTET_STREAM_TYPE) === -1;
-  });
-  if (badContentType.length > 0) {
-    throw new Error(
-        badContentType
-            .map(
-                resp => `Request to ${resp.url} for weight file failed.` +
-                    ` Expected content type ${OCTET_STREAM_TYPE} but got ${
-                            resp.headers.get(CONTENT_TYPE)}.`)
-            .join('\n'));
-  }
   const bufferPromises = responses.map(response => response.arrayBuffer());
 
   const bufferStartFraction = 0.5;

--- a/src/io/weights_loader_test.ts
+++ b/src/io/weights_loader_test.ts
@@ -471,8 +471,7 @@ describeWithFlags('loadWeights', BROWSER_ENVS, () => {
         .then(weights => {
           expect((window.fetch as jasmine.Spy).calls.count()).toBe(1);
           expect(window.fetch).toHaveBeenCalledWith('./weightfile0', {
-            credentials: 'include',
-            headers: {'Accept': 'application/octet-stream'}
+            credentials: 'include'
           });
         })
         .then(done)

--- a/src/jasmine_util.ts
+++ b/src/jasmine_util.ts
@@ -151,6 +151,8 @@ function executeTests(
       ENV.reset();
       ENV.setFeatures(testEnv.features);
       ENV.set('IS_TEST', true);
+      // Disable deprecation warnings for tests to not spam the console.
+      ENV.set('DEPRECATION_WARNINGS_ENABLED', false);
       ENV.registerBackend(backendName, testEnv.factory, 1000);
       Environment.setBackend(backendName);
     });

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -115,7 +115,8 @@ export class MathBackendCPU implements KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('pixels passed to tf.fromPixels() can not be null');
+      throw new Error(
+          'pixels passed to tf.browser.fromPixels() can not be null');
     }
     let vals: Uint8ClampedArray;
     // tslint:disable-next-line:no-any
@@ -150,7 +151,7 @@ export class MathBackendCPU implements KernelBackend {
                  .data;
     } else {
       throw new Error(
-          'pixels passed to tf.fromPixels() must be either an ' +
+          'pixels passed to tf.browser.fromPixels() must be either an ' +
           `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
           `ImageData, but was ${(pixels as {}).constructor.name}`);
     }

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -2684,8 +2684,7 @@ export class MathBackendCPU implements KernelBackend {
       x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,
       varianceEpsilon: number, scale?: Tensor4D|Tensor1D,
       offset?: Tensor4D|Tensor1D): Tensor4D {
-    this.assertNotComplex(
-        [x, mean, variance, scale, offset], 'batchNormalization');
+    this.assertNotComplex([x, mean, variance, scale, offset], 'batchNorm');
 
     const xVals = x.dataSync();
     const mVals = mean.dataSync();

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -205,7 +205,8 @@ export class MathBackendWebGL implements KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('pixels passed to tf.fromPixels() can not be null');
+      throw new Error(
+          'pixels passed to tf.browser.fromPixels() can not be null');
     }
     const texShape: [number, number] = [pixels.height, pixels.width];
     const outShape = [pixels.height, pixels.width, numChannels];
@@ -215,7 +216,7 @@ export class MathBackendWebGL implements KernelBackend {
         !(pixels instanceof HTMLCanvasElement) &&
         !(pixels instanceof ImageData)) {
       throw new Error(
-          'pixels passed to tf.fromPixels() must be either an ' +
+          'pixels passed to tf.browser.fromPixels() must be either an ' +
           `HTMLVideoElement, HTMLImageElement, HTMLCanvasElement or ` +
           `ImageData, but was ${(pixels as {}).constructor.name}`);
     }

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -518,9 +518,8 @@ export class GPGPUContext {
   private itemsToPoll: PollItem[] = [];
 
   pollItems(): void {
-    // Find the last query that has finished using binary search.
-    // All other queries before it are also done.
-    const index = binSearchLastTrue(this.itemsToPoll.map(x => x.isDoneFn));
+    // Find the last query that has finished.
+    const index = linearSearchLastTrue(this.itemsToPoll.map(x => x.isDoneFn));
     for (let i = 0; i <= index; ++i) {
       const {resolveFn} = this.itemsToPoll[i];
       resolveFn();
@@ -614,22 +613,18 @@ type PollItem = {
 };
 
 /**
- * Finds the index of the last true element using binary search where
- * evaluation of an entry is expensive.
+ * Finds the index of the last true element using linear search.
+ * Note: We can't do binary search because Chrome expects us to explicitly
+ * test all fences before download:
+ * https://github.com/tensorflow/tfjs/issues/1145
  */
-export function binSearchLastTrue(arr: Array<() => boolean>): number {
-  let start = 0;
-  let end = arr.length - 1;
-  let best = -1;
-  while (start <= end) {
-    const mid = (start + end) >> 1;
-    const isDone = arr[mid]();
-    if (isDone) {
-      best = mid;
-      start = mid + 1;
-    } else {
-      end = mid - 1;
+export function linearSearchLastTrue(arr: Array<() => boolean>): number {
+  let i = 0;
+  for (; i < arr.length; ++i) {
+    const isDone = arr[i]();
+    if (!isDone) {
+      break;
     }
   }
-  return best;
+  return i - 1;
 }

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -18,7 +18,7 @@
 import {describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose, expectNumbersClose} from '../../test_util';
 import {getGlslDifferences} from './glsl_version';
-import {binSearchLastTrue, GPGPUContext} from './gpgpu_context';
+import {GPGPUContext, linearSearchLastTrue} from './gpgpu_context';
 import * as tex_util from './tex_util';
 
 const DOWNLOAD_FLOAT_ENVS = {
@@ -316,88 +316,88 @@ describeWithFlags('GPGPUContext', DOWNLOAD_FLOAT_ENVS, () => {
   });
 });
 
-describe('gpgpu_context binSearchLastTrue', () => {
+describe('gpgpu_context linearSearchLastTrue', () => {
   it('[false]', () => {
     const a: boolean[] = [false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(-1);
+    expect(linearSearchLastTrue(arr)).toBe(-1);
   });
 
   it('[true]', () => {
     const a: boolean[] = [true];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(0);
+    expect(linearSearchLastTrue(arr)).toBe(0);
   });
 
   it('[false, false]', () => {
     const a: boolean[] = [false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(-1);
+    expect(linearSearchLastTrue(arr)).toBe(-1);
   });
 
   it('[true, false]', () => {
     const a: boolean[] = [true, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(0);
+    expect(linearSearchLastTrue(arr)).toBe(0);
   });
 
   it('[true, true]', () => {
     const a: boolean[] = [true, true];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(1);
+    expect(linearSearchLastTrue(arr)).toBe(1);
   });
 
   it('[false, false, false]', () => {
     const a: boolean[] = [false, false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(-1);
+    expect(linearSearchLastTrue(arr)).toBe(-1);
   });
 
   it('[true, false, false]', () => {
     const a: boolean[] = [true, false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(0);
+    expect(linearSearchLastTrue(arr)).toBe(0);
   });
 
   it('[true, true, false]', () => {
     const a: boolean[] = [true, true, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(1);
+    expect(linearSearchLastTrue(arr)).toBe(1);
   });
 
   it('[true, true, true]', () => {
     const a: boolean[] = [true, true, true];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(2);
+    expect(linearSearchLastTrue(arr)).toBe(2);
   });
 
   it('[false, false, false, false]', () => {
     const a: boolean[] = [false, false, false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(-1);
+    expect(linearSearchLastTrue(arr)).toBe(-1);
   });
 
   it('[true, false, false, false]', () => {
     const a: boolean[] = [true, false, false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(0);
+    expect(linearSearchLastTrue(arr)).toBe(0);
   });
 
   it('[true, true, false, false]', () => {
     const a: boolean[] = [true, true, false, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(1);
+    expect(linearSearchLastTrue(arr)).toBe(1);
   });
 
   it('[true, true, true, false]', () => {
     const a: boolean[] = [true, true, true, false];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(2);
+    expect(linearSearchLastTrue(arr)).toBe(2);
   });
 
   it('[true, true, true, true]', () => {
     const a: boolean[] = [true, true, true, true];
     const arr = a.map(x => () => x);
-    expect(binSearchLastTrue(arr)).toBe(3);
+    expect(linearSearchLastTrue(arr)).toBe(3);
   });
 });

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -20,7 +20,9 @@ import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../t
 import {convertToTensor, convertToTensorArray} from '../tensor_util_env';
 import {DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike4D} from '../types';
 import * as util from '../util';
+
 import {getAxesPermutation, getInnerMostAxes} from './axis_util';
+import {fromPixels as browserFromPixels, toPixels as browserToPixels} from './browser';
 import {concat} from './concat_split';
 import {op} from './operation';
 import {MPRandGauss} from './rand';
@@ -306,17 +308,7 @@ function oneHot_(
 }
 
 /**
- * Creates a `tf.Tensor` from an image.
- *
- * ```js
- * const image = new ImageData(1, 1);
- * image.data[0] = 100;
- * image.data[1] = 150;
- * image.data[2] = 200;
- * image.data[3] = 255;
- *
- * tf.fromPixels(image).print();
- * ```
+ * Deprecated. Use `tf.browser.fromPixels`.
  *
  * @param pixels The input image to construct the tensor from. The
  * supported image types are all 4-channel.
@@ -328,22 +320,11 @@ function oneHot_(
 function fromPixels_(
     pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
     numChannels = 3): Tensor3D {
-  if (numChannels > 4) {
-    throw new Error(
-        'Cannot construct Tensor with more than 4 channels from pixels.');
-  }
-  return ENV.engine.fromPixels(pixels, numChannels);
+  return browserFromPixels(pixels, numChannels);
 }
 
 /**
- * Draws a `tf.Tensor` of pixel values to a byte array or optionally a
- * canvas.
- *
- * When the dtype of the input is 'float32', we assume values in the range
- * [0-1]. Otherwise, when input is 'int32', we assume values in the range
- * [0-255].
- *
- * Returns a promise that resolves when the canvas has been drawn to.
+ * Deprecated. Use `tf.browser.toPixels`.
  *
  * @param img A rank-2 or rank-3 tensor. If rank-2, draws grayscale. If
  *     rank-3, must have depth of 1, 3 or 4. When depth of 1, draws
@@ -356,89 +337,7 @@ function fromPixels_(
 async function toPixels(
     img: Tensor2D|Tensor3D|TensorLike,
     canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
-  let $img = convertToTensor(img, 'img', 'toPixels');
-  if (!(img instanceof Tensor)) {
-    // Assume int32 if user passed a native array.
-    $img = $img.toInt();
-  }
-  if ($img.rank !== 2 && $img.rank !== 3) {
-    throw new Error(
-        `toPixels only supports rank 2 or 3 tensors, got rank ${$img.rank}.`);
-  }
-  const [height, width] = $img.shape.slice(0, 2);
-  const depth = $img.rank === 2 ? 1 : $img.shape[2];
-
-  if (depth > 4 || depth === 2) {
-    throw new Error(
-        `toPixels only supports depth of size ` +
-        `1, 3 or 4 but got ${depth}`);
-  }
-
-  const minTensor = $img.min();
-  const maxTensor = $img.max();
-  const min = (await minTensor.data())[0];
-  const max = (await maxTensor.data())[0];
-  minTensor.dispose();
-  maxTensor.dispose();
-  if ($img.dtype === 'float32') {
-    if (min < 0 || max > 1) {
-      throw new Error(
-          `Tensor values for a float32 Tensor must be in the ` +
-          `range [0 - 1] but got range [${min} - ${max}].`);
-    }
-  } else if ($img.dtype === 'int32') {
-    if (min < 0 || max > 255) {
-      throw new Error(
-          `Tensor values for a int32 Tensor must be in the ` +
-          `range [0 - 255] but got range [${min} - ${max}].`);
-    }
-  } else {
-    throw new Error(
-        `Unsupported type for toPixels: ${$img.dtype}.` +
-        ` Please use float32 or int32 tensors.`);
-  }
-
-  const data = await $img.data();
-  const multiplier = $img.dtype === 'float32' ? 255 : 1;
-  const bytes = new Uint8ClampedArray(width * height * 4);
-
-  for (let i = 0; i < height * width; ++i) {
-    let r, g, b, a;
-    if (depth === 1) {
-      r = data[i] * multiplier;
-      g = data[i] * multiplier;
-      b = data[i] * multiplier;
-      a = 255;
-    } else if (depth === 3) {
-      r = data[i * 3] * multiplier;
-      g = data[i * 3 + 1] * multiplier;
-      b = data[i * 3 + 2] * multiplier;
-      a = 255;
-    } else if (depth === 4) {
-      r = data[i * 4] * multiplier;
-      g = data[i * 4 + 1] * multiplier;
-      b = data[i * 4 + 2] * multiplier;
-      a = data[i * 4 + 3] * multiplier;
-    }
-
-    const j = i * 4;
-    bytes[j + 0] = Math.round(r);
-    bytes[j + 1] = Math.round(g);
-    bytes[j + 2] = Math.round(b);
-    bytes[j + 3] = Math.round(a);
-  }
-
-  if (canvas != null) {
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    const imageData = new ImageData(bytes, width, height);
-    ctx.putImageData(imageData, 0, 0);
-  }
-  if ($img !== img) {
-    $img.dispose();
-  }
-  return bytes;
+  return browserToPixels(img, canvas);
 }
 
 /**
@@ -1207,7 +1106,7 @@ export const cumsum = op({cumsum_});
 export const depthToSpace = op({depthToSpace_});
 export const expandDims = op({expandDims_});
 export const eye = op({eye_});
-export const fromPixels = op({fromPixels_});
+export const fromPixels = fromPixels_;
 export const multinomial = op({multinomial_});
 export const oneHot = op({oneHot_});
 export const pad = op({pad_});

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {deprecationWarn, ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
 import {convertToTensor, convertToTensorArray} from '../tensor_util_env';
 import {DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike4D} from '../types';
@@ -320,6 +320,11 @@ function oneHot_(
 function fromPixels_(
     pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
     numChannels = 3): Tensor3D {
+  deprecationWarn(
+      `tf.fromPixels() is renamed to tf.browser.fromPixels(), please switch ` +
+      `to the new method as the old method will be removed in TensorFlow.js ` +
+      `1.0.`);
+
   return browserFromPixels(pixels, numChannels);
 }
 
@@ -337,6 +342,10 @@ function fromPixels_(
 async function toPixels(
     img: Tensor2D|Tensor3D|TensorLike,
     canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
+  deprecationWarn(
+      `tf.toPixels() is renamed to tf.browser.toPixels(), please switch to ` +
+      `the new method as the old method will be removed in TensorFlow.js 1.0.`);
+
   return browserToPixels(img, canvas);
 }
 
@@ -939,7 +948,7 @@ function expandDims_<R2 extends Rank>(
  * ```js
  * const x = tf.tensor4d([1, 2, 3, 4], [1, 1, 1, 4]);
  * const blockSize = 2;
- * const dataFormat = "NHWC";
+ * const dataFormat = 'NHWC';
  *
  * tf.depthToSpace(x, blockSize, dataFormat).print();
  * ```

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -1249,7 +1249,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   it('accepts a canvas-like element', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any);
+    const t = tf.browser.fromPixels(c as any);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 3]);
     tf.test_util.expectArraysEqual(
@@ -1259,7 +1259,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   it('accepts a canvas-like element, numChannels=4', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any, 4);
+    const t = tf.browser.fromPixels(c as any, 4);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 4]);
     tf.test_util.expectArraysEqual(
@@ -1268,7 +1268,7 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
 
   it('errors when passed a non-canvas object', () => {
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels(5 as any)).toThrowError();
+    expect(() => tf.browser.fromPixels(5 as any)).toThrowError();
   });
 });
 
@@ -1280,7 +1280,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = tf.fromPixels(pixels, 3);
+    const array = tf.browser.fromPixels(pixels, 3);
 
     expectArraysEqual(array, [0, 80, 160]);
   });
@@ -1292,7 +1292,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = tf.fromPixels(pixels, 4);
+    const array = tf.browser.fromPixels(pixels, 4);
 
     expectArraysEqual(array, [0, 80, 160, 240]);
   });
@@ -1307,7 +1307,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       pixels.data[i] = i * 2;
     }
 
-    const array = tf.fromPixels(pixels, 3);
+    const array = tf.browser.fromPixels(pixels, 3);
 
     expectArraysEqual(array, [0, 2, 4, 8, 10, 12, 16, 18, 20, 24, 26, 28]);
   });
@@ -1321,7 +1321,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
       pixels.data[i] = i * 2;
     }
 
-    const array = tf.fromPixels(pixels, 4);
+    const array = tf.browser.fromPixels(pixels, 4);
 
     expectArraysClose(
         array,
@@ -1339,7 +1339,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[5] = 6;
     pixels.data[6] = 7;
     pixels.data[7] = 255;  // Not used.
-    const res = tf.fromPixels(pixels, 3);
+    const res = tf.browser.fromPixels(pixels, 3);
     expect(res.shape).toEqual([2, 1, 3]);
     expect(res.dtype).toBe('int32');
     expectArraysClose(res, [2, 3, 4, 5, 6, 7]);
@@ -1351,7 +1351,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixels.data[1] = 3;
     pixels.data[2] = 4;
     pixels.data[3] = 255;  // Not used.
-    const a = tf.fromPixels(pixels, 3).reshape([1, 1, 1, 3]);
+    const a = tf.browser.fromPixels(pixels, 3).reshape([1, 1, 1, 3]);
     const res = a.add(tf.scalar(2, 'int32'));
     expect(res.shape).toEqual([1, 1, 1, 3]);
     expect(res.dtype).toBe('int32');
@@ -1369,8 +1369,8 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     pixelsB.data[1] = 6;
     pixelsB.data[2] = 7;
     pixelsB.data[3] = 255;  // Not used.
-    const a = tf.fromPixels(pixelsA, 3).toFloat();
-    const b = tf.fromPixels(pixelsB, 3).toFloat();
+    const a = tf.browser.fromPixels(pixelsA, 3).toFloat();
+    const b = tf.browser.fromPixels(pixelsB, 3).toFloat();
     const res = a.add(b);
     expect(res.shape).toEqual([1, 1, 3]);
     expect(res.dtype).toBe('float32');
@@ -1378,15 +1378,17 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
   });
 
   it('throws when passed a primitive number', () => {
+    const msg = /pixels passed to tf.browser.fromPixels\(\) must be either/;
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels(3 as any))
-        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+    expect(() => tf.browser.fromPixels(3 as any))
+        .toThrowError(msg);
   });
 
   it('throws when passed a string', () => {
+    const msg = /pixels passed to tf.browser.fromPixels\(\) must be either/;
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels('test' as any))
-        .toThrowError(/pixels passed to tf.fromPixels\(\) must be either/);
+    expect(() => tf.browser.fromPixels('test' as any))
+        .toThrowError(msg);
   });
 });
 
@@ -1394,7 +1396,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-2 float32 tensor', async () => {
     const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
       Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
@@ -1404,7 +1406,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
 
   it('draws a rank-2 int32 tensor', async () => {
     const x = tf.tensor2d([10, 20], [2, 1], 'int32');
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
   });
@@ -1412,7 +1414,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 float32 tensor, 1 channel', async () => {
     const x = tf.tensor3d([.15, .2], [2, 1, 1], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
       Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
@@ -1423,7 +1425,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 1 channel', async () => {
     const x = tf.tensor3d([10, 20], [2, 1, 1], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
   });
@@ -1435,7 +1437,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
     const x =
         tf.tensor3d([.05, .1001, .15, .2, .25, .3001], [2, 1, 3], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
       255, Math.round(.2 * 255), Math.round(.25 * 255), Math.round(.3001 * 255),
@@ -1447,7 +1449,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 3 channel', async () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60], [2, 1, 3], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 20, 30, 255, 40, 50, 60, 255]);
     expect(data).toEqual(expected);
   });
@@ -1456,7 +1458,7 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
     const x = tf.tensor3d(
         [.05, .1001, .15, .2, .25, .3001, .35, .4], [2, 1, 4], 'float32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([
       Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
       Math.round(.20 * 255), Math.round(.25 * 255), Math.round(.3001 * 255),
@@ -1468,52 +1470,56 @@ describeWithFlags('toPixels no canvas', ALL_ENVS, () => {
   it('draws a rank-3 int32 tensor, 4 channel', async () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60, 70, 80], [2, 1, 4], 'int32');
 
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
     const expected = new Uint8ClampedArray([10, 20, 30, 40, 50, 60, 70, 80]);
     expect(data).toEqual(expected);
   });
 
   it('throws for scalars', done => {
     // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels(tf.scalar(1) as any), done);
+    expectPromiseToFail(() => tf.browser.toPixels(tf.scalar(1) as any), done);
   });
 
   it('throws for rank-1 tensors', done => {
-    // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels(tf.tensor1d([1]) as any), done);
+    expectPromiseToFail(
+        // tslint:disable-next-line:no-any
+        () => tf.browser.toPixels(tf.tensor1d([1]) as any), done);
   });
   it('throws for rank-4 tensors', done => {
     expectPromiseToFail(
         // tslint:disable-next-line:no-any
-        () => tf.toPixels(tf.tensor4d([1], [1, 1, 1, 1]) as any), done);
+        () => tf.browser.toPixels(tf.tensor4d([1], [1, 1, 1, 1]) as any), done);
   });
   it('throws for bool dtype', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor2d([1], [1, 1], 'bool')), done);
+        () => tf.browser.toPixels(tf.tensor2d([1], [1, 1], 'bool')), done);
   });
   it('throws for rank-3 depth = 2', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor3d([1, 2], [1, 1, 2])), done);
+        () => tf.browser.toPixels(tf.tensor3d([1, 2], [1, 1, 2])), done);
   });
   it('throws for rank-3 depth = 5', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor3d([1, 2, 3, 4, 5], [1, 1, 5])), done);
+        () => tf.browser.toPixels(tf.tensor3d([1, 2, 3, 4, 5], [1, 1, 5])),
+        done);
   });
   it('throws for float32 tensor with values not in [0 - 1]', done => {
-    expectPromiseToFail(() => tf.toPixels(tf.tensor2d([-1, .5], [1, 2])), done);
+    expectPromiseToFail(
+        () => tf.browser.toPixels(tf.tensor2d([-1, .5], [1, 2])), done);
   });
   it('throws for int32 tensor with values not in [0 - 255]', done => {
     expectPromiseToFail(
-        () => tf.toPixels(tf.tensor2d([-1, 100], [1, 2], 'int32')), done);
+        () => tf.browser.toPixels(tf.tensor2d([-1, 100], [1, 2], 'int32')),
+        done);
   });
   it('throws when passed a non-tensor', done => {
     // tslint:disable-next-line:no-any
-    expectPromiseToFail(() => tf.toPixels({} as any), done);
+    expectPromiseToFail(() => tf.browser.toPixels({} as any), done);
   });
 
   it('accepts a tensor-like object', async () => {
     const x = [[10], [20]];  // 2x1;
-    const data = await tf.toPixels(x);
+    const data = await tf.browser.toPixels(x);
 
     const expected = new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
     expect(data).toEqual(expected);
@@ -1525,7 +1531,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255),
@@ -1545,7 +1551,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor2d([10, 20], [2, 1], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
       expect(data).toEqual(expected);
@@ -1562,7 +1568,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([.15, .2], [2, 1, 1], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255),
@@ -1582,7 +1588,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([10, 20], [2, 1, 1], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 10, 10, 255, 20, 20, 20, 255]);
       expect(data).toEqual(expected);
@@ -1600,7 +1606,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         tf.tensor3d([.05, .1001, .15, .20, .25, .3001], [2, 1, 3], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
         255, Math.round(.2 * 255), Math.round(.25 * 255),
@@ -1620,7 +1626,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = tf.tensor3d([10, 20, 30, 40, 50, 60], [2, 1, 3], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 20, 30, 255, 40, 50, 60, 255]);
       expect(data).toEqual(expected);
@@ -1640,7 +1646,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         [.05, .1001, .15, 1, .20, .25, .3001, 1], [2, 1, 4], 'float32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected = new Uint8ClampedArray([
         Math.round(.05 * 255), Math.round(.1001 * 255), Math.round(.15 * 255),
         255, Math.round(.20 * 255), Math.round(.25 * 255),
@@ -1664,7 +1670,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
         tf.tensor3d([10, 20, 30, 255, 50, 60, 70, 255], [2, 1, 4], 'int32');
     const canvas = document.createElement('canvas');
 
-    tf.toPixels(x, canvas).then(data => {
+    tf.browser.toPixels(x, canvas).then(data => {
       const expected =
           new Uint8ClampedArray([10, 20, 30, 255, 50, 60, 70, 255]);
       expect(data).toEqual(expected);
@@ -1681,7 +1687,7 @@ describeWithFlags('toPixels', WEBGL_ENVS, () => {
     const x = [[127], [100]];  // 2x1;
     const canvas = document.createElement('canvas');
 
-    const data = await tf.toPixels(x, canvas);
+    const data = await tf.browser.toPixels(x, canvas);
     const expected =
         new Uint8ClampedArray([127, 127, 127, 255, 100, 100, 100, 255]);
     expect(data).toEqual(expected);

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -20,6 +20,7 @@ import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, BROWSER_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, expectPromiseToFail, expectValuesInRange, NODE_ENVS, WEBGL_ENVS} from '../test_util';
 import * as util from '../util';
 import {expectArrayInMeanStdRange, jarqueBeraNormalityTest} from './rand_util';
+import { ENV } from '../environment';
 
 describeWithFlags('zeros', ALL_ENVS, () => {
   it('1D default dtype', () => {
@@ -1269,6 +1270,52 @@ describeWithFlags('fromPixels, mock canvas', NODE_ENVS, () => {
   it('errors when passed a non-canvas object', () => {
     // tslint:disable-next-line:no-any
     expect(() => tf.browser.fromPixels(5 as any)).toThrowError();
+  });
+});
+
+describeWithFlags('Deprecation warnings', BROWSER_ENVS, () => {
+  beforeEach(() => {
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
+  });
+
+  it('tf.fromPixels', () => {
+    const pixels = new ImageData(1, 1);
+    pixels.data[0] = 0;
+    pixels.data[1] = 80;
+    pixels.data[2] = 160;
+    pixels.data[3] = 240;
+
+    const array = tf.fromPixels(pixels, 3);
+
+    expectArraysEqual(array, [0, 80, 160]);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `tf.fromPixels() is renamed to tf.browser.fromPixels(), please ` +
+            `switch to the new method as the old method will be removed in ` +
+            `TensorFlow.js 1.0. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+
+  it('tf.toPixels', async () => {
+    const x = tf.tensor2d([.15, .2], [2, 1], 'float32');
+
+    const data = await tf.toPixels(x);
+    const expected = new Uint8ClampedArray([
+      Math.round(.15 * 255), Math.round(.15 * 255), Math.round(.15 * 255), 255,
+      Math.round(.2 * 255), Math.round(.2 * 255), Math.round(.2 * 255), 255
+    ]);
+    expect(data).toEqual(expected);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `tf.toPixels() is renamed to tf.browser.toPixels(), please ` +
+            `switch to the new method as the old method will be removed in ` +
+            `TensorFlow.js 1.0. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
   });
 });
 

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {deprecationWarn, ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {Rank, TensorLike} from '../types';
@@ -29,169 +29,179 @@ import {rsqrt} from './unary_ops';
 
 /**
  * Batch normalization, strictly for 2D. For the more relaxed version, see
- * `tf.batchNormalization`.
+ * `tf.batchNorm`.
  *
  * @param x The input Tensor.
  * @param mean A mean Tensor.
  * @param variance A variance Tensor.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale Tensor.
  * @param offset An offset Tensor.
+ * @param scale A scale Tensor.
+ * @param varianceEpsilon A small float number to avoid dividing by 0.
  */
-function batchNormalization2d_(
+function batchNorm2d_(
     x: Tensor2D|TensorLike, mean: Tensor2D|Tensor1D|TensorLike,
-    variance: Tensor2D|Tensor1D|TensorLike, varianceEpsilon = .001,
-    scale?: Tensor2D|Tensor1D|TensorLike,
-    offset?: Tensor2D|Tensor1D|TensorLike): Tensor2D {
-  const $x = convertToTensor(x, 'x', 'batchNormalization');
-  const $mean = convertToTensor(mean, 'mean', 'batchNormalization');
-  const $variance = convertToTensor(variance, 'variance', 'batchNormalization');
+    variance: Tensor2D|Tensor1D|TensorLike,
+    offset?: Tensor2D|Tensor1D|TensorLike, scale?: Tensor2D|Tensor1D|TensorLike,
+    varianceEpsilon = .001): Tensor2D {
+  const $x = convertToTensor(x, 'x', 'batchNorm');
+  const $mean = convertToTensor(mean, 'mean', 'batchNorm');
+  const $variance = convertToTensor(variance, 'variance', 'batchNorm');
   let $scale: Tensor2D|Tensor1D;
   if (scale != null) {
-    $scale = convertToTensor(scale, 'scale', 'batchNormalization');
+    $scale = convertToTensor(scale, 'scale', 'batchNorm');
   }
   let $offset: Tensor2D|Tensor1D;
   if (offset != null) {
-    $offset = convertToTensor(offset, 'offset', 'batchNormalization');
+    $offset = convertToTensor(offset, 'offset', 'batchNorm');
   }
   util.assert(
       $x.rank === 2,
-      `Error in batchNormalization3D: x must be rank 3 but got rank ` +
+      `Error in batchNorm3D: x must be rank 3 but got rank ` +
           `${$x.rank}.`);
   util.assert(
       $mean.rank === 2 || $mean.rank === 1,
-      `Error in batchNormalization2D: mean must be rank 2 or rank 1 but ` +
+      `Error in batchNorm2D: mean must be rank 2 or rank 1 but ` +
           `got rank ${$mean.rank}.`);
   util.assert(
       $variance.rank === 2 || $variance.rank === 1,
-      `Error in batchNormalization2D: variance must be rank 2 or rank 1 ` +
+      `Error in batchNorm2D: variance must be rank 2 or rank 1 ` +
           `but got rank ${$variance.rank}.`);
   if ($scale != null) {
     util.assert(
         $scale.rank === 2 || $scale.rank === 1,
-        `Error in batchNormalization2D: scale must be rank 2 or rank 1 ` +
+        `Error in batchNorm2D: scale must be rank 2 or rank 1 ` +
             `but got rank ${$scale.rank}.`);
   }
   if ($offset != null) {
     util.assert(
         $offset.rank === 2 || $offset.rank === 1,
-        `Error in batchNormalization2D: offset must be rank 2 or rank 1 ` +
+        `Error in batchNorm2D: offset must be rank 2 or rank 1 ` +
             `but got rank ${$offset.rank}.`);
   }
 
-  return batchNormalization(
-      $x, $mean, $variance, varianceEpsilon, $scale, $offset);
+  return batchNorm_($x, $mean, $variance, $offset, $scale, varianceEpsilon);
 }
 
 /**
  * Batch normalization, strictly for 3D. For the more relaxed version, see
- * `tf.batchNormalization`.
+ * `tf.batchNorm`.
  *
  * @param x The input Tensor.
  * @param mean A mean Tensor.
  * @param variance A variance Tensor.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale Tensor.
  * @param offset An offset Tensor.
+ * @param scale A scale Tensor.
+ * @param varianceEpsilon A small float number to avoid dividing by 0.
  */
-function batchNormalization3d_(
+function batchNorm3d_(
     x: Tensor3D|TensorLike, mean: Tensor3D|Tensor1D|TensorLike,
-    variance: Tensor3D|Tensor1D|TensorLike, varianceEpsilon = .001,
-    scale?: Tensor3D|Tensor1D|TensorLike,
-    offset?: Tensor3D|Tensor1D|TensorLike): Tensor3D {
-  const $x = convertToTensor(x, 'x', 'batchNormalization');
-  const $mean = convertToTensor(mean, 'mean', 'batchNormalization');
-  const $variance = convertToTensor(variance, 'variance', 'batchNormalization');
+    variance: Tensor3D|Tensor1D|TensorLike,
+    offset?: Tensor3D|Tensor1D|TensorLike, scale?: Tensor3D|Tensor1D|TensorLike,
+    varianceEpsilon = .001): Tensor3D {
+  const $x = convertToTensor(x, 'x', 'batchNorm');
+  const $mean = convertToTensor(mean, 'mean', 'batchNorm');
+  const $variance = convertToTensor(variance, 'variance', 'batchNorm');
   let $scale: Tensor3D|Tensor1D;
   if (scale != null) {
-    $scale = convertToTensor(scale, 'scale', 'batchNormalization');
+    $scale = convertToTensor(scale, 'scale', 'batchNorm');
   }
   let $offset: Tensor3D|Tensor1D;
   if (offset != null) {
-    $offset = convertToTensor(offset, 'offset', 'batchNormalization');
+    $offset = convertToTensor(offset, 'offset', 'batchNorm');
   }
   util.assert(
       $x.rank === 3,
-      `Error in batchNormalization3D: x must be rank 3 but got rank ` +
+      `Error in batchNorm3D: x must be rank 3 but got rank ` +
           `${$x.rank}.`);
   util.assert(
       $mean.rank === 3 || $mean.rank === 1,
-      `Error in batchNormalization3D: mean must be rank 3 or rank 1 but ` +
+      `Error in batchNorm3D: mean must be rank 3 or rank 1 but ` +
           `got rank ${$mean.rank}.`);
   util.assert(
       $variance.rank === 3 || $variance.rank === 1,
-      `Error in batchNormalization3D: variance must be rank 3 or rank 1 ` +
+      `Error in batchNorm3D: variance must be rank 3 or rank 1 ` +
           `but got rank ${$variance.rank}.`);
   if ($scale != null) {
     util.assert(
         $scale.rank === 3 || $scale.rank === 1,
-        `Error in batchNormalization3D: scale must be rank 3 or rank 1 ` +
+        `Error in batchNorm3D: scale must be rank 3 or rank 1 ` +
             `but got rank ${$scale.rank}.`);
   }
   if ($offset != null) {
     util.assert(
         $offset.rank === 3 || $offset.rank === 1,
-        `Error in batchNormalization3D: offset must be rank 3 or rank 1 ` +
+        `Error in batchNorm3D: offset must be rank 3 or rank 1 ` +
             `but got rank ${$offset.rank}.`);
   }
 
-  return batchNormalization(
-      $x, $mean, $variance, varianceEpsilon, $scale, $offset);
+  return batchNorm_($x, $mean, $variance, $offset, $scale, varianceEpsilon);
 }
 
 /**
  * Batch normalization, strictly for 4D. For the more relaxed version, see
- * `tf.batchNormalization`.
+ * `tf.batchNorm`.
  *
  * @param x The input Tensor.
  * @param mean A mean Tensor.
  * @param variance A variance Tensor.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale Tensor.
  * @param offset An offset Tensor.
+ * @param scale A scale Tensor.
+ * @param varianceEpsilon A small float number to avoid dividing by 0.
  */
-function batchNormalization4d_(
+function batchNorm4d_(
     x: Tensor4D|TensorLike, mean: Tensor4D|Tensor1D|TensorLike,
-    variance: Tensor4D|Tensor1D|TensorLike, varianceEpsilon = .001,
-    scale?: Tensor4D|Tensor1D|TensorLike,
-    offset?: Tensor4D|Tensor1D|TensorLike): Tensor4D {
-  const $x = convertToTensor(x, 'x', 'batchNormalization');
-  const $mean = convertToTensor(mean, 'mean', 'batchNormalization');
-  const $variance = convertToTensor(variance, 'variance', 'batchNormalization');
+    variance: Tensor4D|Tensor1D|TensorLike,
+    offset?: Tensor4D|Tensor1D|TensorLike, scale?: Tensor4D|Tensor1D|TensorLike,
+    varianceEpsilon = .001): Tensor4D {
+  const $x = convertToTensor(x, 'x', 'batchNorm');
+  const $mean = convertToTensor(mean, 'mean', 'batchNorm');
+  const $variance = convertToTensor(variance, 'variance', 'batchNorm');
   let $scale: Tensor4D|Tensor1D;
   if (scale != null) {
-    $scale = convertToTensor(scale, 'scale', 'batchNormalization');
+    $scale = convertToTensor(scale, 'scale', 'batchNorm');
   }
   let $offset: Tensor4D|Tensor1D;
   if (offset != null) {
-    $offset = convertToTensor(offset, 'offset', 'batchNormalization');
+    $offset = convertToTensor(offset, 'offset', 'batchNorm');
   }
   util.assert(
       $x.rank === 4,
-      `Error in batchNormalization4D: x must be rank 4 but got rank ` +
+      `Error in batchNorm4D: x must be rank 4 but got rank ` +
           `${$x.rank}.`);
   util.assert(
       $mean.rank === 4 || $mean.rank === 1,
-      `Error in batchNormalization4D: mean must be rank 4 or rank 1 but ` +
+      `Error in batchNorm4D: mean must be rank 4 or rank 1 but ` +
           `got rank ${$mean.rank}.`);
   util.assert(
       $variance.rank === 4 || $variance.rank === 1,
-      `Error in batchNormalization4D: variance must be rank 4 or rank 1 ` +
+      `Error in batchNorm4D: variance must be rank 4 or rank 1 ` +
           `but got rank ${$variance.rank}.`);
   if ($scale != null) {
     util.assert(
         $scale.rank === 4 || $scale.rank === 1,
-        `Error in batchNormalization4D: scale must be rank 4 or rank 1 ` +
+        `Error in batchNorm4D: scale must be rank 4 or rank 1 ` +
             `but got rank ${$scale.rank}.`);
   }
   if ($offset != null) {
     util.assert(
         $offset.rank === 4 || $offset.rank === 1,
-        `Error in batchNormalization4D: offset must be rank 4 or rank 1 ` +
+        `Error in batchNorm4D: offset must be rank 4 or rank 1 ` +
             `but got rank ${$offset.rank}.`);
   }
-  return batchNormalization(
-      $x, $mean, $variance, varianceEpsilon, $scale, $offset);
+  return batchNorm_($x, $mean, $variance, $offset, $scale, varianceEpsilon);
+}
+
+/**
+ * @deprecated Please use `tf.batchNorm` instead and note the positional
+ *     argument change of scale, offset, and varianceEpsilon.
+ */
+function batchNormalization_<R extends Rank>(
+    x: Tensor<R>|Tensor1D|TensorLike, mean: Tensor<R>|Tensor1D|TensorLike,
+    variance: Tensor<R>|Tensor1D|TensorLike, varianceEpsilon = .001,
+    scale?: Tensor<R>|Tensor1D|TensorLike,
+    offset?: Tensor<R>|Tensor1D|TensorLike): Tensor<R> {
+  warnDeprecation();
+  return batchNorm_(x, mean, variance, offset, scale, varianceEpsilon);
 }
 
 /**
@@ -207,33 +217,33 @@ function batchNormalization4d_(
  *
  * Also available are stricter rank-specific methods with the same signature
  * as this method that assert that parameters passed are of given rank
- *   - `tf.batchNormalization2d`
- *   - `tf.batchNormalization3d`
- *   - `tf.batchNormalization4d`
+ *   - `tf.batchNorm2d`
+ *   - `tf.batchNorm3d`
+ *   - `tf.batchNorm4d`
  *
  * @param x The input Tensor.
  * @param mean A mean Tensor.
  * @param variance A variance Tensor.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale Tensor.
  * @param offset An offset Tensor.
+ * @param scale A scale Tensor.
+ * @param varianceEpsilon A small float number to avoid dividing by 0.
  */
 /** @doc {heading: 'Operations', subheading: 'Normalization'} */
-function batchNormalization_<R extends Rank>(
+function batchNorm_<R extends Rank>(
     x: Tensor<R>|Tensor1D|TensorLike, mean: Tensor<R>|Tensor1D|TensorLike,
-    variance: Tensor<R>|Tensor1D|TensorLike, varianceEpsilon = .001,
-    scale?: Tensor<R>|Tensor1D|TensorLike,
-    offset?: Tensor<R>|Tensor1D|TensorLike): Tensor<R> {
-  const $x = convertToTensor(x, 'x', 'batchNormalization');
-  const $mean = convertToTensor(mean, 'mean', 'batchNormalization');
-  const $variance = convertToTensor(variance, 'variance', 'batchNormalization');
+    variance: Tensor<R>|Tensor1D|TensorLike,
+    offset?: Tensor<R>|Tensor1D|TensorLike,
+    scale?: Tensor<R>|Tensor1D|TensorLike, varianceEpsilon = .001): Tensor<R> {
+  const $x = convertToTensor(x, 'x', 'batchNorm');
+  const $mean = convertToTensor(mean, 'mean', 'batchNorm');
+  const $variance = convertToTensor(variance, 'variance', 'batchNorm');
   let $scale: Tensor<R>|Tensor1D;
   if (scale != null) {
-    $scale = convertToTensor(scale, 'scale', 'batchNormalization');
+    $scale = convertToTensor(scale, 'scale', 'batchNorm');
   }
   let $offset: Tensor<R>|Tensor1D;
   if (offset != null) {
-    $offset = convertToTensor(offset, 'offset', 'batchNormalization');
+    $offset = convertToTensor(offset, 'offset', 'batchNorm');
   }
 
   util.assert(
@@ -351,7 +361,58 @@ function batchnormReshape4D(x: Tensor): Tensor4D|Tensor1D {
   return x as Tensor4D;
 }
 
+/**
+ * @deprecated Please use `tf.batchNorm2d` instead and note the positional
+ *     argument change of scale, offset, and varianceEpsilon.
+ */
+function batchNormalization2d_(
+    x: Tensor2D|TensorLike, mean: Tensor2D|Tensor1D|TensorLike,
+    variance: Tensor2D|Tensor1D|TensorLike, varianceEpsilon = .001,
+    scale?: Tensor2D|Tensor1D|TensorLike,
+    offset?: Tensor2D|Tensor1D|TensorLike): Tensor2D {
+  warnDeprecation();
+  return batchNorm2d_(x, mean, variance, offset, scale, varianceEpsilon);
+}
+
+/**
+ * @deprecated Please use `tf.batchNorm3d` instead and note the positional
+ *     argument change of scale, offset, and varianceEpsilon.
+ */
+function batchNormalization3d_(
+    x: Tensor3D|TensorLike, mean: Tensor3D|Tensor1D|TensorLike,
+    variance: Tensor3D|Tensor1D|TensorLike, varianceEpsilon = .001,
+    scale?: Tensor3D|Tensor1D|TensorLike,
+    offset?: Tensor3D|Tensor1D|TensorLike): Tensor3D {
+  warnDeprecation();
+  return batchNorm3d_(x, mean, variance, offset, scale, varianceEpsilon);
+}
+
+/**
+ * @deprecated Please use `tf.batchNorm4d` instead and note the positional
+ *     argument change of scale, offset, and varianceEpsilon.
+ */
+function batchNormalization4d_(
+    x: Tensor4D|TensorLike, mean: Tensor4D|Tensor1D|TensorLike,
+    variance: Tensor4D|Tensor1D|TensorLike, varianceEpsilon = .001,
+    scale?: Tensor4D|Tensor1D|TensorLike,
+    offset?: Tensor4D|Tensor1D|TensorLike): Tensor4D {
+  warnDeprecation();
+  return batchNorm4d_(x, mean, variance, offset, scale, varianceEpsilon);
+}
+
+function warnDeprecation() {
+  deprecationWarn(
+      'tf.batchNormalization() is going away. ' +
+      'Use tf.batchNorm() instead, and note the positional argument change ' +
+      'of scale, offset, and varianceEpsilon');
+}
+
 export const batchNormalization2d = op({batchNormalization2d_});
 export const batchNormalization3d = op({batchNormalization3d_});
 export const batchNormalization4d = op({batchNormalization4d_});
 export const batchNormalization = op({batchNormalization_});
+
+export const batchNorm = op({batchNorm_});
+export const batchNorm2d = op({batchNorm2d_});
+export const batchNorm3d = op({batchNorm3d_});
+export const batchNorm4d = op({batchNorm4d_});

--- a/src/ops/batchnorm_test.ts
+++ b/src/ops/batchnorm_test.ts
@@ -28,8 +28,7 @@ describeWithFlags('batchnorm packed', PACKED_ENVS, () => {
 
     const startNumBytes = tf.memory().numBytes;
     const startNumTensors = tf.memory().numTensors;
-    tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+    tf.batchNorm4d(x, mean, variance, undefined, undefined, varianceEpsilon);
     const endNumBytes = tf.memory().numBytes;
     const endNumTensors = tf.memory().numTensors;
 
@@ -38,13 +37,13 @@ describeWithFlags('batchnorm packed', PACKED_ENVS, () => {
   });
 });
 
-describeWithFlags('batchNormalization', WEBGL_ENVS, () => {
+describeWithFlags('batchNorm', WEBGL_ENVS, () => {
   it('should work for broadcasted inputs', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const mean = tf.tensor4d([1], [1, 1, 1, 1]);
     const variance = tf.tensor4d([1], [1, 1, 1, 1]);
 
-    const result = tf.batchNormalization4d(x, mean, variance);
+    const result = tf.batchNorm4d(x, mean, variance);
     expectArraysClose(result, [0.9995003, 2.9985011, 7.9960027, 21.9890079]);
   });
 
@@ -66,8 +65,8 @@ describeWithFlags('batchNormalization', WEBGL_ENVS, () => {
     const scale = tf.tensor1d([-0.5607271, 0.9878457, 0.25181573]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, scale, varianceEpsilon);
 
     tf.ENV.set('WEBGL_MAX_TEXTURE_SIZE', maxTextureSize);
 
@@ -79,15 +78,15 @@ describeWithFlags('batchNormalization', WEBGL_ENVS, () => {
   });
 });
 
-describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
-  it('simple batchnorm4D, no offset or scale, 2x1x1x2', () => {
+describeWithFlags('batchNorm4D', ALL_ENVS, () => {
+  it('simple batchnorm4D, no offset or scale, 2x1x1x2', async () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+    const result = tf.batchNorm4d(
+        x, mean, variance, undefined, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0, 0, 0) - mean.get(0)) * 1 /
@@ -108,8 +107,8 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
     const scale = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+    const result =
+        tf.batchNorm4d(x, mean, variance, undefined, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0, 0, 0) - mean.get(0)) * scale.get(0) /
@@ -131,8 +130,8 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+    const result =
+        tf.batchNorm4d(x, mean, variance, offset, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -159,8 +158,8 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm4d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -187,8 +186,8 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization4d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm4d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset[0] +
@@ -217,25 +216,25 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const dy = tf.tensor4d([-1, -1, -1, -1], [2, 1, 1, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(
         gradX, tf.tensor4d([-1.414, -2.887, -1.414, -2.887], [2, 1, 1, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor1D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor1D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(gradMean, tf.tensor1d([2.828, 5.773]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor1D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor1D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(gradVariance, tf.tensor1d([3.180, 11.060]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor1D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor1D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, dy.sum([0, 1, 2]));
     const gradScale = tf.grad(
-        (scale: tf.Tensor1D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor1D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(gradScale, tf.tensor1d([-6.362, -13.277]));
   });
 
@@ -250,41 +249,41 @@ describeWithFlags('batchNormalization4D', ALL_ENVS, () => {
 
     const dy = tf.tensor4d([-1, -1, -1, -1], [2, 1, 1, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(
         gradX, tf.tensor4d([-1.414, -2.500, -0.816, -1.768], [2, 1, 1, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(
         gradMean, tf.tensor4d([1.414, 2.500, 0.816, 1.768], [2, 1, 1, 2]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(
         gradVariance, tf.tensor4d([3.533, 4.686, 1.360, 2.762], [2, 1, 1, 2]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, dy);
     const gradScale = tf.grad(
-        (scale: tf.Tensor4D) => tf.batchNormalization4d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor4D) => tf.batchNorm4d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(
         gradScale, tf.tensor4d([-7.069, -7.499, -8.164, -8.838], [2, 1, 1, 2]));
   });
 });
 
-describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
-  it('simple batchnorm3D, no offset or scale, 2x1x2', () => {
+describeWithFlags('batchNorm3D', ALL_ENVS, () => {
+  it('simple batchnorm3D, no offset or scale, 2x1x2', async () => {
     const x = tf.tensor3d([2, 4, 9, 23], [2, 1, 2]);
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+    const result = tf.batchNorm3d(
+        x, mean, variance, undefined, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0, 0) - mean.get(0)) * 1 /
@@ -305,8 +304,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     const scale = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+    const result =
+        tf.batchNorm3d(x, mean, variance, undefined, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0, 0) - mean.get(0)) * scale.get(0) /
@@ -328,8 +327,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -356,8 +355,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -384,8 +383,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset[0] +
@@ -413,8 +412,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0, 0, 0) +
@@ -443,25 +442,25 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const dy = tf.tensor3d([1, 1, 1, 1], [2, 1, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(
         gradX, tf.tensor3d([1.414, 2.887, 1.414, 2.887], [2, 1, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor1D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor1D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(gradMean, tf.tensor1d([-2.828, -5.773]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor1D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor1D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(gradVariance, tf.tensor1d([-3.180, -11.060]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor1D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor1D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, tf.onesLike(offset).mul(tf.scalar(2)));
     const gradScale = tf.grad(
-        (scale: tf.Tensor1D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor1D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(gradScale, tf.tensor1d([6.362, 13.277]));
   });
 
@@ -476,27 +475,27 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
 
     const dy = tf.tensor3d([1, 1, 1, 1], [2, 1, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(
         gradX, tf.tensor3d([1.414, 2.500, 0.816, 1.768], [2, 1, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(
         gradMean, tf.tensor3d([-1.414, -2.500, -0.816, -1.768], [2, 1, 2]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(
         gradVariance, tf.tensor3d([-3.533, -4.686, -1.360, -2.762], [2, 1, 2]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, tf.onesLike(offset));
     const gradScale = tf.grad(
-        (scale: tf.Tensor3D) => tf.batchNormalization3d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor3D) => tf.batchNorm3d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(
         gradScale, tf.tensor3d([7.069, 7.499, 8.164, 8.838], [2, 1, 2]));
   });
@@ -516,8 +515,8 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
     const scale = tf.tensor1d([-0.5607271, 0.9878457, 0.25181573]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization3d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm3d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       0.59352049, -0.66135202, 0.5610874, -0.92077015, -1.45341019, 1.52106473,
@@ -527,15 +526,15 @@ describeWithFlags('batchNormalization3D', ALL_ENVS, () => {
   });
 });
 
-describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
-  it('simple batchnorm2D, no offset or scale, 2x2', () => {
+describeWithFlags('batchNorm2D', ALL_ENVS, () => {
+  it('simple batchnorm2D, no offset or scale, 2x2', async () => {
     const x = tf.tensor2d([2, 4, 9, 23], [2, 2]);
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, undefined, undefined);
+    const result = tf.batchNorm2d(
+        x, mean, variance, undefined, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0) - mean.get(0)) * 1 /
@@ -555,8 +554,8 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
     const scale = tf.tensor1d([4, 5]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, undefined);
+    const result =
+        tf.batchNorm2d(x, mean, variance, undefined, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       (x.get(0, 0) - mean.get(0)) * scale.get(0) /
@@ -578,8 +577,8 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, undefined, offset);
+    const result =
+        tf.batchNorm2d(x, mean, variance, offset, undefined, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -606,8 +605,8 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm2d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset.get(0) +
@@ -636,24 +635,24 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const dy = tf.tensor2d([1, 1, 1, 1], [2, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(gradX, tf.tensor2d([1.414, 2.887, 1.414, 2.887], [2, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor1D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor1D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(gradMean, tf.tensor1d([-2.828, -5.773]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor1D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor1D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(gradVariance, tf.tensor1d([-3.180, -11.060]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor1D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor1D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, tf.onesLike(offset).mul(tf.scalar(2)));
     const gradScale = tf.grad(
-        (scale: tf.Tensor1D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor1D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(gradScale, tf.tensor1d([6.362, 13.277]));
   });
 
@@ -668,26 +667,26 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const dy = tf.tensor2d([1, 1, 1, 1], [2, 2]);
     const gradX = tf.grad(
-        (x: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(x, dy);
+        (x: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(x, dy);
     expectArraysClose(gradX, tf.tensor2d([1.414, 2.500, 0.816, 1.768], [2, 2]));
     const gradMean = tf.grad(
-        (mean: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(mean, dy);
+        (mean: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(mean, dy);
     expectArraysClose(
         gradMean, tf.tensor2d([-1.414, -2.500, -0.816, -1.768], [2, 2]));
     const gradVariance = tf.grad(
-        (variance: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(variance, dy);
+        (variance: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(variance, dy);
     expectArraysClose(
         gradVariance, tf.tensor2d([-3.533, -4.686, -1.360, -2.762], [2, 2]));
     const gradOffset = tf.grad(
-        (offset: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(offset, dy);
+        (offset: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(offset, dy);
     expectArraysClose(gradOffset, tf.onesLike(offset));
     const gradScale = tf.grad(
-        (scale: tf.Tensor2D) => tf.batchNormalization2d(
-            x, mean, variance, varianceEpsilon, scale, offset))(scale, dy);
+        (scale: tf.Tensor2D) => tf.batchNorm2d(
+            x, mean, variance, offset, scale, varianceEpsilon))(scale, dy);
     expectArraysClose(
         gradScale, tf.tensor2d([7.069, 7.499, 8.164, 8.838], [2, 2]));
   });
@@ -705,8 +704,8 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
     const scale = tf.tensor1d([0.62186907, 0.85673736, 0.19201061]);
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm2d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       0.58433646, 0.96846228, 0.51936529, 0.24315402, 0.69732157, 0.61608542,
@@ -718,26 +717,22 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
     const mean = tf.tensor1d([1, 2]);
     const variance = tf.tensor1d([2, 3]);
 
-    expect(() => tf.batchNormalization({} as tf.Tensor, mean, variance))
-        .toThrowError(
-            /Argument 'x' passed to 'batchNormalization' must be a Tensor/);
+    expect(() => tf.batchNorm({} as tf.Tensor, mean, variance))
+        .toThrowError(/Argument 'x' passed to 'batchNorm' must be a Tensor/);
   });
   it('throws when passed mean as a non-tensor', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const variance = tf.tensor1d([2, 3]);
 
-    expect(() => tf.batchNormalization(x, {} as tf.Tensor, variance))
-        .toThrowError(
-            /Argument 'mean' passed to 'batchNormalization' must be a Tensor/);
+    expect(() => tf.batchNorm(x, {} as tf.Tensor, variance))
+        .toThrowError(/Argument 'mean' passed to 'batchNorm' must be a Tensor/);
   });
   it('throws when passed variance as a non-tensor', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
     const mean = tf.tensor1d([1, 2]);
 
-    const e =
-        /Argument 'variance' passed to 'batchNormalization' must be a Tensor/;
-    expect(() => tf.batchNormalization(x, mean, {} as tf.Tensor))
-        .toThrowError(e);
+    const e = /Argument 'variance' passed to 'batchNorm' must be a Tensor/;
+    expect(() => tf.batchNorm(x, mean, {} as tf.Tensor)).toThrowError(e);
   });
   it('throws when passed scale as a non-tensor', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
@@ -745,11 +740,9 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
     const variance = tf.tensor1d([2, 3]);
     const epsilon = .001;
 
-    expect(
-        () =>
-            tf.batchNormalization(x, mean, variance, epsilon, {} as tf.Tensor))
+    expect(() => tf.batchNorm(x, mean, variance, epsilon, {} as tf.Tensor))
         .toThrowError(
-            /Argument 'scale' passed to 'batchNormalization' must be a Tensor/);
+            /Argument 'scale' passed to 'batchNorm' must be a Tensor/);
   });
   it('throws when passed offset as a non-tensor', () => {
     const x = tf.tensor4d([2, 4, 9, 23], [2, 1, 1, 2]);
@@ -758,11 +751,9 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
     const epsilon = .001;
     const scale = tf.tensor1d([0.62186907, 0.85673736, 0.19201061]);
 
-    const e =
-        /Argument 'offset' passed to 'batchNormalization' must be a Tensor/;
+    const e = /Argument 'offset' passed to 'batchNorm' must be a Tensor/;
     expect(
-        () => tf.batchNormalization(
-            x, mean, variance, epsilon, scale, {} as tf.Tensor))
+        () => tf.batchNorm(x, mean, variance, {} as tf.Tensor, scale, epsilon))
         .toThrowError(e);
   });
 
@@ -775,8 +766,8 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const result = tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, offset);
+    const result =
+        tf.batchNorm2d(x, mean, variance, offset, scale, varianceEpsilon);
 
     expectArraysClose(result, [
       offset[0] +
@@ -802,11 +793,11 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const f = () => tf.batchNormalization2d(
-        [['a', 'b'], ['c', 'd']], mean, variance, varianceEpsilon, scale,
-        offset);
+    const f = () => tf.batchNorm2d(
+        [['a', 'b'], ['c', 'd']], mean, variance, offset, scale,
+        varianceEpsilon);
     expect(f).toThrowError(
-        /Argument 'x' passed to 'batchNormalization' must be numeric/);
+        /Argument 'x' passed to 'batchNorm' must be numeric/);
   });
 
   it('throws error when mean is a string tensor', () => {
@@ -817,10 +808,10 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const f = () => tf.batchNormalization2d(
-        x, ['a', 'b'], variance, varianceEpsilon, scale, offset);
+    const f = () =>
+        tf.batchNorm2d(x, ['a', 'b'], variance, offset, scale, varianceEpsilon);
     expect(f).toThrowError(
-        /Argument 'mean' passed to 'batchNormalization' must be numeric/);
+        /Argument 'mean' passed to 'batchNorm' must be numeric/);
   });
 
   it('throws error when variance is a string tensor', () => {
@@ -831,10 +822,9 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const f = () => tf.batchNormalization2d(
-        x, mean, ['a', 'b'], varianceEpsilon, scale, offset);
-    expect(f).toThrowError(
-        /'variance' passed to 'batchNormalization' must be numeric/);
+    const f = () =>
+        tf.batchNorm2d(x, mean, ['a', 'b'], offset, scale, varianceEpsilon);
+    expect(f).toThrowError(/'variance' passed to 'batchNorm' must be numeric/);
   });
 
   it('throws error when scale is a string tensor', () => {
@@ -845,10 +835,9 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const f = () => tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, ['a', 'b'], offset);
-    expect(f).toThrowError(
-        /'scale' passed to 'batchNormalization' must be numeric/);
+    const f = () =>
+        tf.batchNorm2d(x, mean, variance, offset, ['a', 'b'], varianceEpsilon);
+    expect(f).toThrowError(/'scale' passed to 'batchNorm' must be numeric/);
   });
 
   it('throws error when offset is a string tensor', () => {
@@ -859,9 +848,48 @@ describeWithFlags('batchNormalization2D', ALL_ENVS, () => {
 
     const varianceEpsilon = .001;
 
-    const f = () => tf.batchNormalization2d(
-        x, mean, variance, varianceEpsilon, scale, ['a', 'b']);
-    expect(f).toThrowError(
-        /'offset' passed to 'batchNormalization' must be numeric/);
+    const f = () =>
+        tf.batchNorm2d(x, mean, variance, ['a', 'b'], scale, varianceEpsilon);
+    expect(f).toThrowError(/'offset' passed to 'batchNorm' must be numeric/);
+  });
+});
+
+describeWithFlags('deprecated batchNormalization', ALL_ENVS, () => {
+  it('simple batchnorm2D, 2x2', () => {
+    const xT = tf.tensor2d([2, 4, 9, 23], [2, 2]);
+    const meanT = tf.tensor1d([1, 2]);
+    const varianceT = tf.tensor1d([2, 3]);
+    const offsetT = tf.tensor1d([3, 4]);
+    const scaleT = tf.tensor1d([4, 5]);
+
+    const varianceEpsilon = .001;
+
+    const result = tf.batchNormalization(
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
+
+    const offset = offsetT.arraySync() as number[];
+    const mean = meanT.arraySync() as number[];
+    const variance = varianceT.arraySync() as number[];
+    const scale = scaleT.arraySync() as number[];
+    const x = xT.arraySync() as number[][];
+
+    expectArraysClose(result, [
+      offset[0] +
+          (x[0][0] - mean[0]) * scale[0] /
+              Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[0][1] - mean[1]) * scale[1] /
+              Math.sqrt(variance[1] + varianceEpsilon),
+      offset[0] +
+          (x[1][0] - mean[0]) * scale[0] /
+              Math.sqrt(variance[0] + varianceEpsilon),
+      offset[1] +
+          (x[1][1] - mean[1]) * scale[1] /
+              Math.sqrt(variance[1] + varianceEpsilon)
+    ]);
+
+    const result2 = tf.batchNormalization2d(
+        xT, meanT, varianceT, varianceEpsilon, scaleT, offsetT);
+    expectArraysClose(result, result2);
   });
 });

--- a/src/ops/browser.ts
+++ b/src/ops/browser.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../environment';
+import {Tensor, Tensor2D, Tensor3D} from '../tensor';
+import {convertToTensor} from '../tensor_util_env';
+import {TensorLike} from '../types';
+
+import {op} from './operation';
+
+/**
+ * Creates a `tf.Tensor` from an image.
+ *
+ * ```js
+ * const image = new ImageData(1, 1);
+ * image.data[0] = 100;
+ * image.data[1] = 150;
+ * image.data[2] = 200;
+ * image.data[3] = 255;
+ *
+ * tf.browser.fromPixels(image).print();
+ * ```
+ *
+ * @param pixels The input image to construct the tensor from. The
+ * supported image types are all 4-channel.
+ * @param numChannels The number of channels of the output tensor. A
+ * numChannels value less than 4 allows you to ignore channels. Defaults to
+ * 3 (ignores alpha channel of input image).
+ */
+/** @doc {heading: 'Browser', namespace: 'browser'} */
+function fromPixels_(
+    pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
+    numChannels = 3): Tensor3D {
+  if (numChannels > 4) {
+    throw new Error(
+        'Cannot construct Tensor with more than 4 channels from pixels.');
+  }
+  return ENV.engine.fromPixels(pixels, numChannels);
+}
+
+/**
+ * Draws a `tf.Tensor` of pixel values to a byte array or optionally a
+ * canvas.
+ *
+ * When the dtype of the input is 'float32', we assume values in the range
+ * [0-1]. Otherwise, when input is 'int32', we assume values in the range
+ * [0-255].
+ *
+ * Returns a promise that resolves when the canvas has been drawn to.
+ *
+ * @param img A rank-2 or rank-3 tensor. If rank-2, draws grayscale. If
+ *     rank-3, must have depth of 1, 3 or 4. When depth of 1, draws
+ * grayscale. When depth of 3, we draw with the first three components of
+ * the depth dimension corresponding to r, g, b and alpha = 1. When depth of
+ * 4, all four components of the depth dimension correspond to r, g, b, a.
+ * @param canvas The canvas to draw to.
+ */
+/** @doc {heading: 'Browser', namespace: 'browser'} */
+export async function toPixels(
+    img: Tensor2D|Tensor3D|TensorLike,
+    canvas?: HTMLCanvasElement): Promise<Uint8ClampedArray> {
+  let $img = convertToTensor(img, 'img', 'toPixels');
+  if (!(img instanceof Tensor)) {
+    // Assume int32 if user passed a native array.
+    $img = $img.toInt();
+  }
+  if ($img.rank !== 2 && $img.rank !== 3) {
+    throw new Error(
+        `toPixels only supports rank 2 or 3 tensors, got rank ${$img.rank}.`);
+  }
+  const [height, width] = $img.shape.slice(0, 2);
+  const depth = $img.rank === 2 ? 1 : $img.shape[2];
+
+  if (depth > 4 || depth === 2) {
+    throw new Error(
+        `toPixels only supports depth of size ` +
+        `1, 3 or 4 but got ${depth}`);
+  }
+
+  const minTensor = $img.min();
+  const maxTensor = $img.max();
+  const min = (await minTensor.data())[0];
+  const max = (await maxTensor.data())[0];
+  minTensor.dispose();
+  maxTensor.dispose();
+  if ($img.dtype === 'float32') {
+    if (min < 0 || max > 1) {
+      throw new Error(
+          `Tensor values for a float32 Tensor must be in the ` +
+          `range [0 - 1] but got range [${min} - ${max}].`);
+    }
+  } else if ($img.dtype === 'int32') {
+    if (min < 0 || max > 255) {
+      throw new Error(
+          `Tensor values for a int32 Tensor must be in the ` +
+          `range [0 - 255] but got range [${min} - ${max}].`);
+    }
+  } else {
+    throw new Error(
+        `Unsupported type for toPixels: ${$img.dtype}.` +
+        ` Please use float32 or int32 tensors.`);
+  }
+
+  const data = await $img.data();
+  const multiplier = $img.dtype === 'float32' ? 255 : 1;
+  const bytes = new Uint8ClampedArray(width * height * 4);
+
+  for (let i = 0; i < height * width; ++i) {
+    let r, g, b, a;
+    if (depth === 1) {
+      r = data[i] * multiplier;
+      g = data[i] * multiplier;
+      b = data[i] * multiplier;
+      a = 255;
+    } else if (depth === 3) {
+      r = data[i * 3] * multiplier;
+      g = data[i * 3 + 1] * multiplier;
+      b = data[i * 3 + 2] * multiplier;
+      a = 255;
+    } else if (depth === 4) {
+      r = data[i * 4] * multiplier;
+      g = data[i * 4 + 1] * multiplier;
+      b = data[i * 4 + 2] * multiplier;
+      a = data[i * 4 + 3] * multiplier;
+    }
+
+    const j = i * 4;
+    bytes[j + 0] = Math.round(r);
+    bytes[j + 1] = Math.round(g);
+    bytes[j + 2] = Math.round(b);
+    bytes[j + 3] = Math.round(a);
+  }
+
+  if (canvas != null) {
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    const imageData = new ImageData(bytes, width, height);
+    ctx.putImageData(imageData, 0, 0);
+  }
+  if ($img !== img) {
+    $img.dispose();
+  }
+  return bytes;
+}
+
+export const fromPixels = op({fromPixels_});

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -185,11 +185,12 @@ export interface OpHandler {
   unstack<T extends Tensor>(value: T, axis: number): Tensor[];
   pad<T extends Tensor>(
       x: T, paddings: Array<[number, number]>, constantValue: number): T;
-  batchNormalization<R extends Rank>(
+  batchNorm<R extends Rank>(
       x: Tensor<R>, mean: Tensor<R>|Tensor1D|TensorLike,
-      variance: Tensor<R>|Tensor1D|TensorLike, varianceEpsilon: number,
+      variance: Tensor<R>|Tensor1D|TensorLike,
+      offset?: Tensor<R>|Tensor1D|TensorLike,
       scale?: Tensor<R>|Tensor1D|TensorLike,
-      offset?: Tensor<R>|Tensor1D|TensorLike): Tensor<R>;
+      varianceEpsilon?: number): Tensor<R>;
   all<T extends Tensor>(x: Tensor, axis: number|number[], keepDims: boolean): T;
   any<T extends Tensor>(x: Tensor, axis: number|number[], keepDims: boolean): T;
   logSumExp<T extends Tensor>(
@@ -824,16 +825,33 @@ export class Tensor<R extends Rank = Rank> {
       this: T, paddings: Array<[number, number]>, constantValue = 0): T {
     return opHandler.pad(this, paddings, constantValue);
   }
+  /**
+   * @deprecated Use `tf.batchNorm` instead, and note the positional argument
+   *     change of scale, offset, and varianceEpsilon.
+   */
   batchNormalization(
       mean: Tensor<R>|Tensor1D|TensorLike,
       variance: Tensor<R>|Tensor1D|TensorLike, varianceEpsilon = .001,
       scale?: Tensor<R>|Tensor1D|TensorLike,
       offset?: Tensor<R>|Tensor1D|TensorLike): Tensor<R> {
-    this.throwIfDisposed();
-    return opHandler.batchNormalization(
-        this, mean, variance, varianceEpsilon, scale, offset);
+    deprecationWarningFn(
+        'tf.batchNormalization() is going away. ' +
+        'Use tf.batchNorm() instead, and note the positional argument change ' +
+        'of scale, offset, and varianceEpsilon');
+    return this.batchNorm(mean, variance, offset, scale, varianceEpsilon);
   }
 
+  batchNorm(
+      mean: Tensor<R>|Tensor1D|TensorLike,
+      variance: Tensor<R>|Tensor1D|TensorLike,
+      offset?: Tensor<R>|Tensor1D|TensorLike,
+      scale?: Tensor<R>|Tensor1D|TensorLike,
+      varianceEpsilon = .001,
+      ): Tensor<R> {
+    this.throwIfDisposed();
+    return opHandler.batchNorm(
+        this, mean, variance, offset, scale, varianceEpsilon);
+  }
   // Reduction ops.
   all<T extends Tensor>(axis: number|number[] = null, keepDims = false): T {
     this.throwIfDisposed();

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -351,6 +351,12 @@ export interface OpHandler {
 let trackerFn: () => TensorTracker = null;
 // Used by chaining methods to call into ops.
 let opHandler: OpHandler = null;
+// Used to warn about deprecated methods.
+let deprecationWarningFn: (msg: string) => void = null;
+// This here so that we can use this method on dev branches and keep the
+// functionality at master.
+// tslint:disable-next-line:no-unused-expression
+[deprecationWarningFn];
 
 /**
  * An external consumer can register itself as the tensor tracker. This way
@@ -367,6 +373,14 @@ export function setTensorTracker(fn: () => TensorTracker) {
  */
 export function setOpHandler(handler: OpHandler) {
   opHandler = handler;
+}
+
+/**
+ * Sets the deprecation warning function to be used by this file. This way the
+ * Tensor class can be a leaf but still use the environment.
+ */
+export function setDeprecationWarningFn(fn: (msg: string) => void) {
+  deprecationWarningFn = fn;
 }
 
 /**

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from './environment';
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
 import {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from './tensor';
@@ -2100,5 +2101,37 @@ describeWithFlags('tensor with 0 in shape', ALL_ENVS, () => {
     expect(a.rank).toBe(2);
     expect(a.shape).toEqual([0, 5]);
     expectArraysEqual(a, []);
+  });
+});
+
+describeWithFlags('Deprecation warnings', ALL_ENVS, () => {
+  beforeEach(() => {
+    spyOn(console, 'warn').and.callFake((msg: string): void => null);
+    ENV.set('DEPRECATION_WARNINGS_ENABLED', true);
+  });
+
+  it('Tensor.get', () => {
+    const t = tf.tensor1d([5, 3, 2]);
+    expectNumbersClose(t.get(1), 3);
+
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `Tensor.get() is deprecated. Use Tensor.array() and native array ` +
+            `indexing instead. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
+  });
+
+  it('Tensor.buffer', () => {
+    const t = tf.tensor1d([5, 3, 2]);
+    const buffer = t.buffer<'float32'>();
+    expectNumbersClose(buffer.get(1), 3);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn)
+        .toHaveBeenCalledWith(
+            `Tensor.buffer() is renamed to Tensor.bufferSync() in ` +
+            `TensorFlow.js 1.0 and Tensor.buffer() will become an async ` +
+            `function. You can disable deprecation warnings with ` +
+            `tf.disableDeprecationWarnings().`);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,17 @@ export interface ShapeMap {
   R6: [number, number, number, number, number, number];
 }
 
+/** @docalias number[] */
+export interface ArrayMap {
+  R0: number;
+  R1: number[];
+  R2: number[][];
+  R3: number[][][];
+  R4: number[][][][];
+  R5: number[][][][][];
+  R6: number[][][][][][];
+}
+
 export interface DataTypeMap {
   float32: Float32Array;
   int32: Int32Array;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.15.0';
+const version = '0.15.1';
 export {version};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.14.5';
+const version = '0.15.0';
 export {version};


### PR DESCRIPTION
Currently we check that the shape matches values in the tensor() factory method, but Tensor.make can be called by a buffer with a non-integer shape and we end up throwing an error deep in a shader. This throws an error earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1561)
<!-- Reviewable:end -->
