### PR TITLE
Point to the non-deprecated TSLint extension for VSCode.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ to keep the `yarn.lock` file up to date.
 #### Code editor
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) for
 development. Make sure to install
-[TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+[TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin)
 and the npm [clang-format](https://github.com/angular/clang-format) `1.2.2` or later
 with the
 [Clang-Format VSCode extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)


### PR DESCRIPTION
Setting up a new machine - looks like the old TSLint extension is deprecated in favor of a MS-built one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1569)
<!-- Reviewable:end -->
