### PR TITLE
Packed concat op

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -57,6 +57,7 @@ import {ClipProgram} from './webgl/clip_gpu';
 import {ClipPackedProgram} from './webgl/clip_packed_gpu';
 import {ComplexAbsProgram} from './webgl/complex_abs_gpu';
 import {ConcatProgram} from './webgl/concat_gpu';
+import {ConcatPackedProgram} from './webgl/concat_packed_gpu';
 import {Conv2DDerFilterProgram, Conv2DDerInputProgram, Conv3DDerFilterProgram, Conv3DDerInputProgram} from './webgl/conv_backprop_gpu';
 import {DepthwiseConv2DDerFilterProgram, DepthwiseConv2DDerInputProgram} from './webgl/conv_backprop_gpu_depthwise';
 import {Conv2DProgram, Conv3DProgram} from './webgl/conv_gpu';
@@ -722,6 +723,10 @@ export class MathBackendWebGL implements KernelBackend {
       const leftSide = this.concat(tensors.slice(0, midIndex), axis);
       const rightSide = this.concat(tensors.slice(midIndex), axis);
       return this.concat([leftSide, rightSide], axis);
+    }
+    if (ENV.get('WEBGL_PACK_ARRAY_OPERATIONS') && tensors[0].rank > 1) {
+      const program = new ConcatPackedProgram(tensors.map(t => t.shape), axis);
+      return this.compileAndRun(program, tensors);
     }
     // Any concat of n-dimensional tensors across any axis can be reduced to
     // a concatenation of two-dimensional tensors across the axis 1 by first

--- a/src/kernels/webgl/concat_packed_gpu.ts
+++ b/src/kernels/webgl/concat_packed_gpu.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -27,7 +27,7 @@ export class ConcatPackedProgram implements GPGPUProgram {
   outputShape: number[] = [];
   userCode: string;
 
-  constructor(shapes: Array<number[]>, axis: number) {
+  constructor(shapes: number[][], axis: number) {
     this.outputShape = concat_util.computeOutShape(shapes, axis);
     const shape = this.outputShape;
     const rank = shape.length;
@@ -54,7 +54,7 @@ export class ConcatPackedProgram implements GPGPUProgram {
         else if (${channel} < ${offsets[i]}) {
           ${channel} -= ${shift};
           return getChannel(getT${i}(${allChannels}), ${lastChannels});
-        }`
+        }`;
     }
     const lastIndex = offsets.length;
     const shift = offsets[offsets.length - 1];

--- a/src/kernels/webgl/concat_packed_gpu.ts
+++ b/src/kernels/webgl/concat_packed_gpu.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as concat_util from '../../ops/concat_util';
+import {getChannels} from '../packing_util';
+
+import {GPGPUProgram} from './gpgpu_math';
+import {getCoordsDataType} from './shader_compiler';
+
+export class ConcatPackedProgram implements GPGPUProgram {
+  variableNames: string[];
+  usesPackedTextures = true;
+  outputShape: number[] = [];
+  userCode: string;
+
+  constructor(shapes: Array<number[]>, axis: number) {
+    this.outputShape = concat_util.computeOutShape(shapes, axis);
+    const shape = this.outputShape;
+    const rank = shape.length;
+    const dtype = getCoordsDataType(rank);
+    const coords = getChannels('coords', rank);
+    const channels = ['x', 'y', 'z', 'w', 'u', 'v'].slice(0, rank);
+    this.variableNames = shapes.map((_, i) => `T${i}`);
+
+    const offsets: number[] = new Array(shapes.length - 1);
+    offsets[0] = shapes[0][axis];
+    for (let i = 1; i < offsets.length; i++) {
+      offsets[i] = offsets[i - 1] + shapes[i][axis];
+    }
+
+    const channel = channels[axis];
+    const lastChannels = 'vec2(' + channels.slice(-2).join() + ')';
+    const allChannels = channels.join();
+
+    let getValueSnippet = `if (${channel} < ${offsets[0]})
+          return getChannel(getT0(${allChannels}), ${lastChannels});`;
+    for (let i = 1; i < offsets.length; i++) {
+      const shift = offsets[i - 1];
+      getValueSnippet += `
+        else if (${channel} < ${offsets[i]}) {
+          ${channel} -= ${shift};
+          return getChannel(getT${i}(${allChannels}), ${lastChannels});
+        }`
+    }
+    const lastIndex = offsets.length;
+    const shift = offsets[offsets.length - 1];
+    getValueSnippet += `
+        else {
+          ${channel} -= ${shift};
+          return getChannel(getT${lastIndex}(${allChannels}), ${lastChannels});
+        }`;
+
+    this.userCode = `
+      float getValue(${channels.map(x => 'int ' + x)}) {
+        ${getValueSnippet}
+      }
+
+      void main() {
+        ${dtype} coords = getOutputCoords();
+        vec4 result = vec4(getValue(${coords}), 0., 0., 0.);
+        if (++${coords[rank - 1]} < ${shape[rank - 1]}) {
+          result.g = getValue(${coords});
+        }
+        if (++${coords[rank - 2]} < ${shape[rank - 2]}) {
+          result.a = getValue(${coords});
+        }
+        if (${coords[rank - 2]} < ${shape[rank - 2]} &&
+            --${coords[rank - 1]} < ${shape[rank - 1]}) {
+          result.b = getValue(${coords});
+        }
+        setOutput(result);
+      }
+    `;
+  }
+}


### PR DESCRIPTION
* Packed concat op doesn't do input and output reshape to and from 2D, respectively, but uses original tensors.
* Implemented only for input shapes with rank greater than 1 to have the code simpler.

* This brings performance improvement as measured [by benchmark](https://gist.github.com/astojilj/e2388f8a376b1f436597337c2efda389#file-resizebilinearbenchmark-patch-L104) on integrated GPU Intel® Iris™ Pro 5200 on MacBook Pro (Retina, 15-inch, Mid 2014). The benchmark [concatenates two](https://gist.github.com/astojilj/e2388f8a376b1f436597337c2efda389#file-resizebilinearbenchmark-patch-L104) 4-D tensors of the same shape (given in the table below), on axis 3.

```
         | [1,33,33,256] | [1,65,65,256]
----------------------------------------
master:  |     26.1ms    |   98.3ms 
patch:   |     15.4ms    |   33.8ms

```
concat two tensor of shape [1,65,65,256] to result of shape [1,513,513,256] is part of DeepLabV3+ MobileNetV2 model.
 
#### Generated userCode for:
```
    const tensor1 = tf.tensor3d([1, 11, 111, 3, 33, 333], [2, 1, 3]);
    const tensor2 = tf.tensor3d(
        [5, 55, 555, 6, 66, 666, 7, 77, 777, 8, 88, 888], [2, 2, 3]);
    const values = tf.concat3d([tensor1, tensor2], 1);
```
by ConcatPackedProgram, is:
```
      float getValue(int x,int y,int z) {
        if (y < 1)
          return getChannel(getT0(x,y,z), vec2(y,z));
        else {
          y -= 1;
          return getChannel(getT1(x,y,z), vec2(y,z));
        }
      }

      void main() {
        ivec3 coords = getOutputCoords();
        vec4 result = vec4(getValue(coords.x,coords.y,coords.z), 0., 0., 0.);
        if (++coords.z < 3) {
          result.g = getValue(coords.x,coords.y,coords.z);
        }
        if (++coords.y < 3) {
          result.a = getValue(coords.x,coords.y,coords.z);
        }
        if (coords.y < 3 &&
            --coords.z < 3) {
          result.b = getValue(coords.x,coords.y,coords.z);
        }
        setOutput(result);
      }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1576)
<!-- Reviewable:end -->
