### PR TITLE
Fix shallow slice bugs: dtype and mem leak

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -661,6 +661,7 @@ export class MathBackendWebGL implements KernelBackend {
     // Copy texture data from the original tensor.
     Object.assign(newTexData, xTexData);
     newTexData.shape = size;
+    newTexData.dtype = x.dtype;
     let flatOffset = computeFlatOffset(begin, x.strides);
     if (xTexData.slice) {
       // We are slicing an already sliced tensor, so we have to accumulate

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -300,7 +300,9 @@ export class MathBackendWebGL implements KernelBackend {
     if (slice != null) {
       const program = new UnaryOpProgram(shape, unary_op.CLONE);
       const res = this.compileAndRun(program, [{dataId, shape, dtype}]);
-      return this.readSync(res.dataId);
+      const data = this.readSync(res.dataId);
+      (res as Tensor).dispose();
+      return data;
     }
     if (values != null) {
       return this.convertAndCacheOnCPU(dataId);
@@ -340,7 +342,9 @@ export class MathBackendWebGL implements KernelBackend {
     if (slice != null) {
       const program = new UnaryOpProgram(shape, unary_op.CLONE);
       const res = this.compileAndRun(program, [{dataId, shape, dtype}]);
-      return this.read(res.dataId);
+      const data = this.read(res.dataId);
+      (res as Tensor).dispose();
+      return data;
     }
 
     if (values != null) {

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -3066,12 +3066,31 @@ describeWithFlags('stack', ALL_ENVS, () => {
     expect(res.shape).toEqual([2, 2, 1]);
     expectArraysClose(res, [1, 2, 3, 4]);
   });
+
+  it('chain api', () => {
+    const a = tf.tensor([1, 2]);
+    const res = a.stack(tf.tensor([3, 4]));
+    expect(res.shape).toEqual([2, 2]);
+    expectArraysClose(res, [1, 2, 3, 4]);
+  });
 });
 
 describeWithFlags('unstack', ALL_ENVS, () => {
   it('unstack by default', () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
     const res = tf.unstack(x);
+    expect(res.length).toEqual(2);
+    expect(res[0].rank).toEqual(1);
+    expect(res[0].shape).toEqual([4]);
+    expectArraysClose(res[0], [1, 2, 3, 4]);
+    expect(res[1].rank).toEqual(1);
+    expect(res[1].shape).toEqual([4]);
+    expectArraysClose(res[1], [5, 6, 7, 8]);
+  });
+
+  it('chain api', () => {
+    const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
+    const res = x.unstack();
     expect(res.length).toEqual(2);
     expect(res[0].rank).toEqual(1);
     expect(res[0].shape).toEqual([4]);

--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -505,3 +505,18 @@ describeWithFlags('slice ergonomics', ALL_ENVS, () => {
     expect(tf.slice(b, 0).dtype).toEqual('float32');
   });
 });
+
+describeWithFlags('shallow slice an input that was cast', ALL_ENVS, () => {
+  beforeAll(() => {
+    tf.ENV.set('WEBGL_CPU_FORWARD', false);
+  });
+
+  it('shallow slice an input that was cast', () => {
+    const a = tf.tensor([[1, 2], [3, 4]], [2, 2], 'int32');
+    const b = a.toFloat();
+    const c = b.slice(1, 1);
+    expect(c.dtype).toBe('float32');
+    expect(c.shape).toEqual([1, 2]);
+    expectArraysClose(c, [3, 4]);
+  });
+});

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -797,7 +797,7 @@ export class Tensor<R extends Rank = Rank> {
   stack(x: Tensor, axis = 0): Tensor {
     return opHandler.stack([this, x], axis);
   }
-  unstack(x: Tensor, axis = 0): Tensor[] {
+  unstack(axis = 0): Tensor[] {
     return opHandler.unstack(this, axis);
   }
   pad<T extends Tensor>(


### PR DESCRIPTION
When doing shallow slicing:
- the `dtype` associated with the tex data can get out of sync with the `dtype` of the sliced tensor.
- there is a mem leak related to the intermediate tensor when doing data reads of sliced tensor.

Also fix the chain API for unstack.

Fixes https://github.com/tensorflow/tfjs/issues/1257
Also partially https://github.com/tensorflow/tfjs/issues/569 (fixes Coco-SSD when using tfjs-core 0.15.x once this is cherry-picked)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1577)
<!-- Reviewable:end -->
