### PR TITLE
Expose useful tf.util.* methods to our docs

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -17,7 +17,17 @@
 
 import {DataType, DataTypeMap, FlatVector, NumericDataType, RecursiveArray, TensorLike, TypedArray} from './types';
 
-/** Shuffles the array using Fisher-Yates algorithm. */
+/**
+ * Shuffles the array in-place using Fisher-Yates algorithm.
+ *
+ * ```js
+ * const a = [1, 2, 3, 4, 5];
+ * tf.util.shuffle(a);
+ * console.log(a);
+ * ```
+ *
+ * @param array The array to shuffle in-place.
+ */
 /** @doc {heading: 'Util'} */
 // tslint:disable-next-line:no-any
 export function shuffle(array: any[]|Uint32Array|Int32Array|
@@ -81,6 +91,10 @@ export function distSquared(a: FlatVector, b: FlatVector): number {
  * Asserts that the expression is true. Otherwise throws an error with the
  * provided message.
  *
+ * ```js
+ * tf.util.assert(2 === 3, 'Two is not three');
+ * ```
+ *
  * @param expr The expression to assert (as a boolean).
  * @param msg The message to report when throwing an error. Can be either a
  *     string, or a function that returns a string (for performance reasons).
@@ -111,6 +125,12 @@ export function assertNonNull(a: TensorLike): void {
 /**
  *  Flattens an arbitrarily nested array.
  *
+ * ```js
+ * const a = [[1, 2], [3, 4], [5, [6, [7]]]];
+ * const flat = tf.util.flatten(a);
+ * console.log(flat);
+ * ```
+ *
  *  @param arr The nested array to flatten.
  *  @param result Optional. The destination array which holds the elements.
  */
@@ -131,7 +151,15 @@ flatten<T extends number|boolean|string|Promise<number>|TypedArray>(
   return result;
 }
 
-/** Returns the size (number of elements) of the tensor given its shape. */
+/**
+ * Returns the size (number of elements) of the tensor given its shape.
+ *
+ * ```js
+ * const shape = [3, 4, 2];
+ * const size = tf.util.sizeFromShape(shape);
+ * console.log(size);
+ * ```
+ */
 /** @doc {heading: 'Util'} */
 export function sizeFromShape(shape: number[]): number {
   if (shape.length === 0) {
@@ -606,6 +634,10 @@ export function makeZerosTypedArray<D extends DataType>(
 /**
  * Returns the current high-resolution time in milliseconds. It is
  * relative to an arbitrary time in the past.
+ *
+ * ```js
+ * console.log(tf.util.now());
+ * ```
  */
 /** @doc {heading: 'Util'} */
 export function now(): number {

--- a/src/util.ts
+++ b/src/util.ts
@@ -132,7 +132,7 @@ export function assertNonNull(a: TensorLike): void {
  * ```
  *
  *  @param arr The nested array to flatten.
- *  @param result Optional. The destination array which holds the elements.
+ *  @param result The destination array which holds the elements.
  */
 /** @doc {heading: 'Util'} */
 export function
@@ -632,8 +632,9 @@ export function makeZerosTypedArray<D extends DataType>(
 }
 
 /**
- * Returns the current high-resolution time in milliseconds. It is
- * relative to an arbitrary time in the past.
+ * Returns the current high-resolution time in milliseconds relative to an
+ * arbitrary time in the past. It works across different platforms (node.js,
+ * browsers).
  *
  * ```js
  * console.log(tf.util.now());

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,7 @@
 import {DataType, DataTypeMap, FlatVector, NumericDataType, RecursiveArray, TensorLike, TypedArray} from './types';
 
 /** Shuffles the array using Fisher-Yates algorithm. */
+/** @doc {heading: 'Util'} */
 // tslint:disable-next-line:no-any
 export function shuffle(array: any[]|Uint32Array|Int32Array|
                         Float32Array): void {
@@ -76,6 +77,15 @@ export function distSquared(a: FlatVector, b: FlatVector): number {
   return result;
 }
 
+/**
+ * Asserts that the expression is true. Otherwise throws an error with the
+ * provided message.
+ *
+ * @param expr The expression to assert (as a boolean).
+ * @param msg The message to report when throwing an error. Can be either a
+ *     string, or a function that returns a string (for performance reasons).
+ */
+/** @doc {heading: 'Util'} */
 export function assert(expr: boolean, msg: string|(() => string)) {
   if (!expr) {
     throw new Error(typeof msg === 'string' ? msg : msg());
@@ -98,19 +108,31 @@ export function assertNonNull(a: TensorLike): void {
 // NOTE: We explicitly type out what T extends instead of any so that
 // util.flatten on a nested array of number doesn't try to infer T as a
 // number[][], causing us to explicitly type util.flatten<number>().
+/**
+ *  Flattens an arbitrarily nested array.
+ *
+ *  @param arr The nested array to flatten.
+ *  @param result Optional. The destination array which holds the elements.
+ */
+/** @doc {heading: 'Util'} */
 export function
 flatten<T extends number|boolean|string|Promise<number>|TypedArray>(
-    arr: T|RecursiveArray<T>, ret: T[] = []): T[] {
+    arr: T|RecursiveArray<T>, result: T[] = []): T[] {
+  if (result == null) {
+    result = [];
+  }
   if (Array.isArray(arr) || isTypedArray(arr)) {
     for (let i = 0; i < arr.length; ++i) {
-      flatten(arr[i], ret);
+      flatten(arr[i], result);
     }
   } else {
-    ret.push(arr as T);
+    result.push(arr as T);
   }
-  return ret;
+  return result;
 }
 
+/** Returns the size (number of elements) of the tensor given its shape. */
+/** @doc {heading: 'Util'} */
 export function sizeFromShape(shape: number[]): number {
   if (shape.length === 0) {
     // Scalar.
@@ -582,9 +604,10 @@ export function makeZerosTypedArray<D extends DataType>(
 }
 
 /**
- * Returns the current high-resolution real time in milliseconds. It is
+ * Returns the current high-resolution time in milliseconds. It is
  * relative to an arbitrary time in the past.
  */
+/** @doc {heading: 'Util'} */
 export function now(): number {
   if (typeof performance !== 'undefined') {
     return performance.now();


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/1206

Expose and document:
- `tf.util.shuffle`
- `tf.util.assert`
- `tf.util.flatten`
- `tf.util.sizeFromShape`
- `tf.util.now`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1580)
<!-- Reviewable:end -->
