### PR TITLE
Cut off negative values for padAlongDim in computing convInfo.padInfo

### DIFF
--- a/src/ops/conv2d_test.ts
+++ b/src/ops/conv2d_test.ts
@@ -58,6 +58,26 @@ describeWithFlags('im2col', PACKED_ENVS, () => {
 });
 
 describeWithFlags('conv2d', ALL_ENVS, () => {
+  it('x=[1,4,4,1] f=[1,1,1,3] s=2 d=1 p=same', () => {
+    const inputDepth = 1;
+    const inputShape: [number, number, number] = [4, 4, inputDepth];
+    const outputDepth = 3;
+    const fSize = 1;
+    const pad = 'same';
+    const stride: [number, number] = [2, 2];
+
+    const x = tf.tensor3d(
+        [
+          10, 30, 50, 70, 20, 40, 60, 80, -10, -30, -50, -70, -20, -40, -60, -80
+        ],
+        inputShape);
+    const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
+
+    const result = tf.conv2d(x, w, stride, pad);
+
+    expectArraysClose(
+        result, [10, 5, 10, 50, 25, 50, -10, -5, -10, -50, -25, -50]);
+  });
   it('x=[2,2,1] f=[1,1,1,2] s=1 d=1 p=0', () => {
     const inputDepth = 1;
     const inputShape: [number, number, number] = [2, 2, inputDepth];

--- a/src/ops/conv_util.ts
+++ b/src/ops/conv_util.ts
@@ -338,8 +338,9 @@ function getPadAndOutInfo(
     outHeight = Math.ceil(inHeight / strideHeight);
     outWidth = Math.ceil(inWidth / strideWidth);
     const padAlongHeight =
-        (outHeight - 1) * strideHeight + filterHeight - inHeight;
-    const padAlongWidth = (outWidth - 1) * strideWidth + filterWidth - inWidth;
+        Math.max(0, (outHeight - 1) * strideHeight + filterHeight - inHeight);
+    const padAlongWidth =
+        Math.max(0, (outWidth - 1) * strideWidth + filterWidth - inWidth);
     const top = Math.floor(padAlongHeight / 2);
     const bottom = padAlongHeight - top;
     const left = Math.floor(padAlongWidth / 2);


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/1270

Reference: https://www.tensorflow.org/api_guides/python/nn#Convolution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1581)
<!-- Reviewable:end -->
