### PR TITLE
Ensure uniform cache is updated when only maxLoc is null

### DIFF
--- a/src/kernels/webgl/clip_gpu.ts
+++ b/src/kernels/webgl/clip_gpu.ts
@@ -47,7 +47,7 @@ export class ClipProgram implements GPGPUProgram {
 
   getCustomSetupFunc(min: number, max: number) {
     return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.minLoc == null) {
+      if (this.minLoc == null || this.maxLoc == null) {
         this.minLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'min');
         this.maxLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'max');
       }

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -49,7 +49,7 @@ export class ClipPackedProgram implements GPGPUProgram {
 
   getCustomSetupFunc(min: number, max: number) {
     return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
-      if (this.minLoc == null) {
+      if (this.minLoc == null || this.maxLoc == null) {
         this.minLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'min');
         this.maxLoc = gpgpu.getUniformLocationNoThrow(webGLProgram, 'max');
       }


### PR DESCRIPTION
MISC

Even if only `maxLoc` is null, the uniform cache should be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1583)
<!-- Reviewable:end -->
