### PR TITLE
Improve the TensorContainer type

### DIFF
--- a/src/tensor_types.ts
+++ b/src/tensor_types.ts
@@ -28,7 +28,7 @@ export type NamedVariableMap = {
 };
 
 /**
- * @docalias void|number|string|Tensor|Tensor[]|{[key:
+ * @docalias void|number|string|TypedArray|Tensor|Tensor[]|{[key:
  * string]:Tensor|number|string}
  */
 export type TensorContainer =

--- a/src/tensor_types.ts
+++ b/src/tensor_types.ts
@@ -31,8 +31,9 @@ export type NamedVariableMap = {
  * @docalias void|number|string|Tensor|Tensor[]|{[key:
  * string]:Tensor|number|string}
  */
-export type TensorContainer = void|Tensor|string|number|boolean|
-    TensorContainerObject|TensorContainerArray;
+export type TensorContainer =
+    void|Tensor|string|number|boolean|TensorContainerObject|
+    TensorContainerArray|Float32Array|Int32Array|Uint8Array;
 export interface TensorContainerObject {
   [x: string]: TensorContainer;
 }


### PR DESCRIPTION
Add `Float32Array|Int32Array|Uint8Array` to the `TensorContainer` type.

This fixes the compiler error in the following code:
```js
const ds = tf.data.array([new Float32Array([1, 2]), new Float32Array([3, 4])]);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1587)
<!-- Reviewable:end -->
