### PR TITLE
Fix upload of half-float textures in "WebGL 1"

### DIFF
--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -145,8 +145,13 @@ export class TextureManager {
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
   if (logicalTexType === TextureUsage.UPLOAD) {
-    return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
-                      PhysicalTextureType.UNPACKED_FLOAT32;
+    if (ENV.get('WEBGL_RENDER_FLOAT32_ENABLED')) {
+      return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
+                        PhysicalTextureType.UNPACKED_FLOAT32;
+    } else {
+      return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
+                        PhysicalTextureType.UNPACKED_FLOAT32;
+    }
   } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
     if (isPacked) {
       return ENV.get('WEBGL_RENDER_FLOAT32_ENABLED') ?

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -142,6 +142,7 @@ export class TextureManager {
   }
 }
 
+// TODO - export this function?
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
   if (logicalTexType === TextureUsage.UPLOAD) {

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -149,8 +149,8 @@ function getPhysicalFromLogicalTextureType(
       return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
                         PhysicalTextureType.UNPACKED_FLOAT32;
     } else {
-      return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT32 :
-                        PhysicalTextureType.UNPACKED_FLOAT32;
+      return isPacked ? PhysicalTextureType.PACKED_2X2_FLOAT16 :
+                        PhysicalTextureType.UNPACKED_FLOAT16;
     }
   } else if (logicalTexType === TextureUsage.RENDER || logicalTexType == null) {
     if (isPacked) {

--- a/src/kernels/webgl/texture_manager.ts
+++ b/src/kernels/webgl/texture_manager.ts
@@ -142,7 +142,6 @@ export class TextureManager {
   }
 }
 
-// TODO - export this function?
 function getPhysicalFromLogicalTextureType(
     logicalTexType: TextureUsage, isPacked: boolean): PhysicalTextureType {
   if (logicalTexType === TextureUsage.UPLOAD) {

--- a/src/kernels/webgl/texture_manager_test.ts
+++ b/src/kernels/webgl/texture_manager_test.ts
@@ -1,3 +1,39 @@
-//
-// TODO(kreeger): write me.
-//
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {describeWithFlags} from '../../jasmine_util';
+
+import {GPGPUContext} from './gpgpu_context';
+import {TextureManager} from './texture_manager';
+
+const DOWNLOAD_FLOAT_ENVS = {
+  'WEBGL_DOWNLOAD_FLOAT_ENABLED': true
+};
+
+describeWithFlags(
+    'getPhysicalFromLogicalTextureType', DOWNLOAD_FLOAT_ENVS, () => {
+      let textureManager: TextureManager;
+
+      beforeEach(() => {
+        //
+        // TODO(kreeger): Left off right here.
+        //
+
+        // Either export the helper function or mock out GPGPUContext..
+        textureManager = new TextureManager(new GPGPUContext());
+      });
+    });

--- a/src/kernels/webgl/texture_manager_test.ts
+++ b/src/kernels/webgl/texture_manager_test.ts
@@ -1,0 +1,3 @@
+//
+// TODO(kreeger): write me.
+//


### PR DESCRIPTION
Looks like this was regressed a few months ago here: https://github.com/tensorflow/tfjs-core/pull/1375

I'm curious how this worked on iOS devices? From what I was told - Safari only supported `OES_texture_half_float` which enables creating `gl.OES_HALF_FLOAT` textures but allows them to write f32 data in `gl.texSubImage2D()`.

Happy to discuss offline. But this essentially makes devices that only support f16 not work with the regression in texture manager.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1594)
<!-- Reviewable:end -->
