### PR TITLE
Check explicitly for equals 0 in packed division kernel.

### DIFF
--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -28,14 +28,33 @@ const CHECK_NAN_SNIPPET = `
 
 // We do the same as in ./binaryop_gpu, with vec4 and ivec4.
 // On Linux, the vectorized implementation produces NaNs when a and b are 0.
+// We must also check for a / b channels equal to 0 in case they are empty.
+// Equality check fails, so checking epsilon.
+// TODO: Find a vectorized implementation of epsilon check that works on Linux.
 export const DIV = `
   // vec4 one = vec4(equal(a, b));
   // return one + (vec4(1.0) - one) * a / b;
+  float epsilon = 0.00000001;
   vec4 result = a / b;
+
   result.x = a.x == b.x ? 1. : result.x;
   result.y = a.y == b.y ? 1. : result.y;
   result.z = a.z == b.z ? 1. : result.z;
   result.w = a.w == b.w ? 1. : result.w;
+
+  if(abs(a.x) < epsilon && abs(b.x) < epsilon) {
+    result.x = 0.;
+  }
+  if(abs(a.y) < epsilon && abs(b.y) < epsilon) {
+    result.y = 0.;
+  }
+  if(abs(a.z) < epsilon && abs(b.z) < epsilon) {
+    result.z = 0.;
+  }
+  if(abs(a.w) < epsilon && abs(b.w) < epsilon) {
+    result.w = 0.;
+  }
+
   return result;
 `;
 

--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -18,7 +18,6 @@
 import * as broadcast_util from '../../ops/broadcast_util';
 import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
-import {ENV} from '../../environment';
 
 const CHECK_NAN_SNIPPET = `
   result.r = isNaN.r > 0. ? NAN : result.r;
@@ -35,7 +34,8 @@ const CHECK_NAN_SNIPPET = `
 export const DIV = `
   // vec4 one = vec4(equal(a, b));
   // return one + (vec4(1.0) - one) * a / b;
-  float epsilon = ${ENV.get('EPSILON')};
+  // cannot use environment epsilon because it is lazily evaluated
+  float epsilon = 0.0000001;
   vec4 result = a / b;
 
   result.x = a.x == b.x ? 1. : result.x;

--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -30,7 +30,7 @@ const CHECK_NAN_SNIPPET = `
 // On Linux, the vectorized implementation produces NaNs when a and b are 0.
 // We must also check for a / b channels equal to 0 in case they are empty.
 // Equality check fails, so checking epsilon.
-// TODO: Find a vectorized implementation of epsilon check that works on Linux.
+// TODO (https://github.com/tensorflow/tfjs/issues/1324): Find a vectorized implementation of epsilon check that works on Linux.
 export const DIV = `
   // vec4 one = vec4(equal(a, b));
   // return one + (vec4(1.0) - one) * a / b;

--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -18,6 +18,7 @@
 import * as broadcast_util from '../../ops/broadcast_util';
 import {GPGPUContext} from './gpgpu_context';
 import {GPGPUProgram} from './gpgpu_math';
+import {ENV} from '../../environment';
 
 const CHECK_NAN_SNIPPET = `
   result.r = isNaN.r > 0. ? NAN : result.r;
@@ -34,7 +35,7 @@ const CHECK_NAN_SNIPPET = `
 export const DIV = `
   // vec4 one = vec4(equal(a, b));
   // return one + (vec4(1.0) - one) * a / b;
-  float epsilon = 0.00000001;
+  float epsilon = ${ENV.get('EPSILON')};
   vec4 result = a / b;
 
   result.x = a.x == b.x ? 1. : result.x;

--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -30,7 +30,8 @@ const CHECK_NAN_SNIPPET = `
 // On Linux, the vectorized implementation produces NaNs when a and b are 0.
 // We must also check for a / b channels equal to 0 in case they are empty.
 // Equality check fails, so checking epsilon.
-// TODO (https://github.com/tensorflow/tfjs/issues/1324): Find a vectorized implementation of epsilon check that works on Linux.
+// TODO (https://github.com/tensorflow/tfjs/issues/1324):
+// Find a vectorized implementation of epsilon check that works on Linux.
 export const DIV = `
   // vec4 one = vec4(equal(a, b));
   // return one + (vec4(1.0) - one) * a / b;

--- a/src/kernels/webgl/binaryop_packed_gpu.ts
+++ b/src/kernels/webgl/binaryop_packed_gpu.ts
@@ -44,16 +44,16 @@ export const DIV = `
   result.w = a.w == b.w ? 1. : result.w;
 
   if(abs(a.x) < epsilon && abs(b.x) < epsilon) {
-    result.x = 0.;
+    result.x = 1.;
   }
   if(abs(a.y) < epsilon && abs(b.y) < epsilon) {
-    result.y = 0.;
+    result.y = 1.;
   }
   if(abs(a.z) < epsilon && abs(b.z) < epsilon) {
-    result.z = 0.;
+    result.z = 1.;
   }
   if(abs(a.w) < epsilon && abs(b.w) < epsilon) {
-    result.w = 0.;
+    result.w = 1.;
   }
 
   return result;

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -31,17 +31,6 @@ describeWithFlags('div', PACKED_ENVS, () => {
     const c = a.div(b).matMul(b);
     expectArraysClose(c, [3]);
   });
-
-  it('unused channels should be left as 0', () => {
-    const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
-    const a = tf.tensor2d([3], [1, 1]);
-    const b = tf.tensor2d([3], [1, 1]);
-
-    a.div(b);
-    const packedRGBA = new Float32Array(4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, packedRGBA);
-    expectArraysClose(packedRGBA, new Float32Array([1, 0, 0, 0]));
-  });
 });
 
 describeWithFlags('prelu', ALL_ENVS, () => {

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -15,8 +15,6 @@
  * =============================================================================
  */
 
-import {getWebGLContext} from '../canvas_util';
-import {ENV} from '../environment';
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose, expectArraysEqual, PACKED_ENVS, WEBGL_ENVS} from '../test_util';

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {getWebGLContext} from '../canvas_util';
+import {ENV} from '../environment';
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose, expectArraysEqual, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
@@ -28,6 +30,17 @@ describeWithFlags('div', PACKED_ENVS, () => {
 
     const c = a.div(b).matMul(b);
     expectArraysClose(c, [3]);
+  });
+
+  it('unused channels should be left as 0', () => {
+    const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
+    const a = tf.tensor2d([3], [1, 1]);
+    const b = tf.tensor2d([3], [1, 1]);
+
+    a.div(b);
+    const packedRGBA = new Float32Array(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, packedRGBA)
+    expectArraysClose(packedRGBA, new Float32Array([1, 0, 0, 0]));
   });
 });
 

--- a/src/ops/binary_ops_test.ts
+++ b/src/ops/binary_ops_test.ts
@@ -39,7 +39,7 @@ describeWithFlags('div', PACKED_ENVS, () => {
 
     a.div(b);
     const packedRGBA = new Float32Array(4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, packedRGBA)
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, packedRGBA);
     expectArraysClose(packedRGBA, new Float32Array([1, 0, 0, 0]));
   });
 });

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -27,7 +27,8 @@ export const WEBGL_ENVS: Features = {
   'HAS_WEBGL': true
 };
 export const PACKED_ENVS: Features = {
-  'WEBGL_PACK': true
+  'WEBGL_PACK': true,
+  'HAS_WEBGL': true
 };
 export const NODE_ENVS: Features = {
   'IS_NODE': true


### PR DESCRIPTION
This PR fixes https://github.com/tensorflow/tfjs/issues/1321

I benchmarked repeated division calls given this change and there is no performance impact compared to the previous kernel. 

I don't know how to reproduce this issue outside of the LSTM text generation example. I also don't understand why straightforward equality check fails. I thought that maybe the problem was mixing in unused channels that experienced division by 0, so I tried a fix where we check whether a channel is out of bounds and explicitly set it to zero, but that didn't seem to fix Shanqing's bug. 

Hopefully this is enough of a band-aid for now. I created an issue (https://github.com/tensorflow/tfjs/issues/1324) for better understanding the root cause of this. 

This change integrates with the tfjs-layers test suite on my MBP. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1603)
<!-- Reviewable:end -->
