### PR TITLE
If matMul is going to be unpacked, then don't try to avoid expensive reshape in pointwise conv.

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1709,9 +1709,19 @@ export class MathBackendWebGL implements KernelBackend {
     // result from 2D to 4D.
     const xShape = x.shape;
     const xTexData = this.texData.get(x.dataId);
-    if (!ENV.get('WEBGL_LAZILY_UNPACK') ||
-        !ENV.get('WEBGL_PACK_BINARY_OPERATIONS') || xShape[2] % 2 === 0 ||
-        !xTexData.isPacked) {
+    const sharedMatMulDim = convInfo.inChannels;
+    const outerShapeX = xShape[0] * xShape[1] * xShape[2];
+    const outerShapeFilter = convInfo.outChannels;
+
+    // TODO: Once reduction ops are packed, batchMatMul will always be packed
+    // and we can remove this condition.
+    const batchMatMulWillBeUnpacked =
+        (outerShapeX === 1 || outerShapeFilter === 1) &&
+        sharedMatMulDim > MATMUL_SHARED_DIM_THRESHOLD;
+    const reshapeWillBeExpensive = xShape[2] % 2 !== 0 && xTexData.isPacked;
+
+    if (batchMatMulWillBeUnpacked || !ENV.get('WEBGL_LAZILY_UNPACK') ||
+        !ENV.get('WEBGL_PACK_BINARY_OPERATIONS') || !reshapeWillBeExpensive) {
       const xReshaped =
           this.reshape(
               x, [1, xShape[0] * xShape[1] * xShape[2], convInfo.inChannels]) as

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -1718,7 +1718,7 @@ export class MathBackendWebGL implements KernelBackend {
     const batchMatMulWillBeUnpacked =
         (outerShapeX === 1 || outerShapeFilter === 1) &&
         sharedMatMulDim > MATMUL_SHARED_DIM_THRESHOLD;
-    const reshapeWillBeExpensive = xShape[2] % 2 !== 0 && xTexData.isPacked;
+    const reshapeWillBeExpensive = xShape[2] % 2 !== 0 && !!xTexData.isPacked;
 
     if (batchMatMulWillBeUnpacked || !ENV.get('WEBGL_LAZILY_UNPACK') ||
         !ENV.get('WEBGL_PACK_BINARY_OPERATIONS') || !reshapeWillBeExpensive) {


### PR DESCRIPTION
This PR fixes https://github.com/tensorflow/tfjs/issues/1335

Related: https://github.com/tensorflow/tfjs/issues/1336

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1610)
<!-- Reviewable:end -->
