### PR TITLE
Call rollup instead of yarn rollup as part of publish-local script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build": "tsc",
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
-    "publish-local": "rimraf dist/ && yarn build && yarn rollup -c && yalc push",
+    "publish-local": "rimraf dist/ && yarn build && rollup -c && yalc push",
     "lint": "tslint -p . -t verbose",
     "coverage": "KARMA_COVERAGE=1 karma start --browsers='Chrome' --singleRun",
     "test": "karma start",


### PR DESCRIPTION
Otherwise when tfjs union tries to call publish-local from within tfjs-core it complains that there is no rollup script.

This will fix tests in https://github.com/tensorflow/tfjs/pull/1319

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1618)
<!-- Reviewable:end -->
