### PR TITLE
Optimize tf.tidy() and tf.keep().

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -97,9 +97,9 @@ export class Engine implements TensorManager, TensorTracker, DataMover {
   private customGradientDepth = 0;
 
   // Keep Tensors that parallel the tapes.
-  private nextScopeId = 0;
   private activeScope: ScopeState;
   private scopeStack: ScopeState[] = [];
+  private nextScopeId = 0;
   private profiler: Profiler;
 
   private tensorInfo = new WeakMap<DataId, {
@@ -397,14 +397,7 @@ export class Engine implements TensorManager, TensorTracker, DataMover {
           'Safe mode is ON. Enclose all tensor operations inside tf.tidy(): ' +
           'tf.tidy(() => {...}) to avoid memory leaks.');
     }
-    // Add kept bit on the tensor.
     result.kept = true;
-    // Remove it from this scope's tracking mechanism.
-    // const scopeTrackIdx = this.activeScope.track.indexOf(result);
-    // if (scopeTrackIdx !== -1) {
-    //   this.activeScope.track.splice(scopeTrackIdx);
-    // }
-
     return result;
   }
 

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -64,8 +64,7 @@ export class TensorBuffer<R extends Rank, D extends DataType = 'float32'> {
           `a TensorBuffer for the real and imaginary parts separately and ` +
           `call tf.complex(real, imag).`);
     }
-    this.values =
-        values || util.getArrayFromDType(dtype, this.size);
+    this.values = values || util.getArrayFromDType(dtype, this.size);
     this.strides = computeStrides(shape);
   }
 
@@ -426,6 +425,9 @@ export class Tensor<R extends Rank = Rank> {
   readonly dtype: DataType;
   /** The rank type for the array (see `Rank` enum). */
   readonly rankType: R;
+
+  /** Whether this tensor has been globally kept. */
+  kept = false;
 
   /**
    * Number of elements to skip in each dimension when indexing. See

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -428,6 +428,8 @@ export class Tensor<R extends Rank = Rank> {
 
   /** Whether this tensor has been globally kept. */
   kept = false;
+  /** The id of the scope this tensor is being tracked in. */
+  scopeId: number;
 
   /**
    * Number of elements to skip in each dimension when indexing. See


### PR DESCRIPTION
We do this by:

- Removing global `tf.keep()` tracking. Instead, we add a "kept" bit to tensors and we implicitly remove kept tensors from tracking mechanisms. When we are going to track in a parent scope, we avoid doing that if the kept bit is set on the tensor.
- Add an integer ID to every scope. `track` sets the tensor's scope ID and then when we're checking whether the tensor belongs to the current scope when tracking in a parent, we simply check that id matching the current scope ID.

No unit tests added since we have pretty serious coverage over memory and this is an internal optimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1621)
<!-- Reviewable:end -->
