### PR TITLE
Speedup the WebGL tests by 2.5x

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -136,7 +136,7 @@ export interface WebGLTimingInfo extends TimingInfo {
   downloadWaitMs: number;
 }
 
-const binaryCaches: {[webGlVersion: string]: {[key: string]: GPGPUBinary}} = {};
+const binaryCaches: {[webGLVersion: string]: {[key: string]: GPGPUBinary}} = {};
 
 function getBinaryCache(webGLVersion: number) {
   if (webGLVersion in binaryCaches) {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -136,6 +136,16 @@ export interface WebGLTimingInfo extends TimingInfo {
   downloadWaitMs: number;
 }
 
+const binaryCaches: {[webGlVersion: string]: {[key: string]: GPGPUBinary}} = {};
+
+function getBinaryCache(webGLVersion: number) {
+  if (webGLVersion in binaryCaches) {
+    return binaryCaches[webGLVersion];
+  }
+  binaryCaches[webGLVersion] = {};
+  return binaryCaches[webGLVersion];
+}
+
 function mapActivationToShaderProgram(
     activation: Activation, packed = false): string {
   if (activation === 'linear') {
@@ -568,7 +578,7 @@ export class MathBackendWebGL implements KernelBackend {
   }
 
   private textureManager: TextureManager;
-  private binaryCache: {[key: string]: GPGPUBinary} = {};
+  private binaryCache: {[key: string]: GPGPUBinary};
   private gpgpuCreatedLocally: boolean;
 
   constructor(private gpgpu?: GPGPUContext) {
@@ -578,10 +588,12 @@ export class MathBackendWebGL implements KernelBackend {
 
     if (gpgpu == null) {
       const gl = getWebGLContext(ENV.get('WEBGL_VERSION'));
+      this.binaryCache = getBinaryCache(ENV.get('WEBGL_VERSION'));
       this.gpgpu = new GPGPUContext(gl);
       this.canvas = gl.canvas;
       this.gpgpuCreatedLocally = true;
     } else {
+      this.binaryCache = {};
       this.gpgpuCreatedLocally = false;
       this.canvas = gpgpu.gl.canvas;
     }
@@ -2316,7 +2328,8 @@ export class MathBackendWebGL implements KernelBackend {
       query = this.startTimer();
     }
 
-    gpgpu_math.runProgram(binary, inputsData, outputData, customSetup);
+    gpgpu_math.runProgram(
+        this.gpgpu, binary, inputsData, outputData, customSetup);
 
     const numBytesBeforePaging = ENV.get('WEBGL_NUM_MB_BEFORE_PAGING') * 1024;
     if (pageToCpu && this.numBytesInGPU > numBytesBeforePaging) {
@@ -2360,15 +2373,13 @@ export class MathBackendWebGL implements KernelBackend {
     if (this.disposed) {
       return;
     }
-    for (const key in this.binaryCache) {
-      this.gpgpu.deleteProgram(this.binaryCache[key].webGLProgram);
-    }
     this.textureManager.dispose();
     this.canvas.remove();
     if (this.fromPixels2DContext != null) {
       this.fromPixels2DContext.canvas.remove();
     }
     if (this.gpgpuCreatedLocally) {
+      this.gpgpu.program = null;
       this.gpgpu.dispose();
     }
     this.disposed = true;

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -43,7 +43,7 @@ export class GPGPUContext {
   outputTexture: WebGLTexture|null = null;
   program: WebGLProgram|null = null;
   private disposed = false;
-  private autoDebugValidate = false;
+  private debug = false;
   private disjoint: boolean;
   private textureConfig: TextureConfig;
 
@@ -57,25 +57,25 @@ export class GPGPUContext {
     }
     // WebGL 2.0 enables texture floats without an extension.
     if (ENV.get('WEBGL_VERSION') === 1) {
-      this.textureFloatExtension =
-          webgl_util.getExtensionOrThrow(this.gl, 'OES_texture_float');
+      this.textureFloatExtension = webgl_util.getExtensionOrThrow(
+          this.gl, this.debug, 'OES_texture_float');
       this.colorBufferFloatExtension =
           this.gl.getExtension('WEBGL_color_buffer_float');
 
       if (!ENV.get('WEBGL_RENDER_FLOAT32_ENABLED')) {
-        this.textureHalfFloatExtension =
-            webgl_util.getExtensionOrThrow(this.gl, 'OES_texture_half_float');
+        this.textureHalfFloatExtension = webgl_util.getExtensionOrThrow(
+            this.gl, this.debug, 'OES_texture_half_float');
         this.colorBufferHalfFloatExtension =
             this.gl.getExtension('EXT_color_buffer_half_float');
       }
     } else {
-      this.colorBufferFloatExtension =
-          webgl_util.getExtensionOrThrow(this.gl, 'EXT_color_buffer_float');
+      this.colorBufferFloatExtension = webgl_util.getExtensionOrThrow(
+          this.gl, this.debug, 'EXT_color_buffer_float');
     }
 
-    this.vertexBuffer = gpgpu_util.createVertexBuffer(this.gl);
-    this.indexBuffer = gpgpu_util.createIndexBuffer(this.gl);
-    this.framebuffer = webgl_util.createFramebuffer(this.gl);
+    this.vertexBuffer = gpgpu_util.createVertexBuffer(this.gl, this.debug);
+    this.indexBuffer = gpgpu_util.createIndexBuffer(this.gl, this.debug);
+    this.framebuffer = webgl_util.createFramebuffer(this.gl, this.debug);
 
     this.textureConfig =
         gpgpu_util.getTextureConfig(this.gl, this.textureHalfFloatExtension);
@@ -99,70 +99,75 @@ export class GPGPUContext {
           'disposing.');
     }
     const gl = this.gl;
-    webgl_util.callAndCheck(gl, () => gl.finish());
-    webgl_util.callAndCheck(gl, () => gl.bindFramebuffer(gl.FRAMEBUFFER, null));
-    webgl_util.callAndCheck(gl, () => gl.deleteFramebuffer(this.framebuffer));
-    webgl_util.callAndCheck(gl, () => gl.bindBuffer(gl.ARRAY_BUFFER, null));
+    webgl_util.callAndCheck(gl, this.debug, () => gl.finish());
     webgl_util.callAndCheck(
-        gl, () => gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null));
-    webgl_util.callAndCheck(gl, () => gl.deleteBuffer(this.indexBuffer));
+        gl, this.debug, () => gl.bindFramebuffer(gl.FRAMEBUFFER, null));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.deleteFramebuffer(this.framebuffer));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.bindBuffer(gl.ARRAY_BUFFER, null));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.deleteBuffer(this.indexBuffer));
     this.disposed = true;
   }
 
   public enableAutomaticDebugValidation(enabled: boolean) {
-    this.autoDebugValidate = enabled;
-    webgl_util.enableDebugWebGLErrorChecking(enabled);
+    this.debug = enabled;
   }
 
   public createFloat32MatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat32MatrixTexture(
-        this.gl, rows, columns, this.textureConfig);
+        this.gl, this.debug, rows, columns, this.textureConfig);
   }
 
   public createFloat16MatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat16MatrixTexture(
-        this.gl, rows, columns, this.textureConfig);
+        this.gl, this.debug, rows, columns, this.textureConfig);
   }
 
   public createUnsignedBytesMatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();
     return gpgpu_util.createUnsignedBytesMatrixTexture(
-        this.gl, rows, columns, this.textureConfig);
+        this.gl, this.debug, rows, columns, this.textureConfig);
   }
 
   public uploadPixelDataToTexture(
       texture: WebGLTexture,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement) {
     this.throwIfDisposed();
-    gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
+    gpgpu_util.uploadPixelDataToTexture(this.gl, this.debug, texture, pixels);
   }
 
   public createFloat16PackedMatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();
     return gpgpu_util.createFloat16PackedMatrixTexture(
-        this.gl, rows, columns, this.textureConfig);
+        this.gl, this.debug, rows, columns, this.textureConfig);
   }
 
   public createPackedMatrixTexture(rows: number, columns: number):
       WebGLTexture {
     this.throwIfDisposed();
     return gpgpu_util.createPackedMatrixTexture(
-        this.gl, rows, columns, this.textureConfig);
+        this.gl, this.debug, rows, columns, this.textureConfig);
   }
 
   public deleteMatrixTexture(texture: WebGLTexture) {
     this.throwIfDisposed();
     if (this.outputTexture === texture) {
-      webgl_util.unbindColorTextureFromFramebuffer(this.gl, this.framebuffer);
+      webgl_util.unbindColorTextureFromFramebuffer(
+          this.gl, this.debug, this.framebuffer);
       this.outputTexture = null;
     }
-    webgl_util.callAndCheck(this.gl, () => this.gl.deleteTexture(texture));
+    webgl_util.callAndCheck(
+        this.gl, this.debug, () => this.gl.deleteTexture(texture));
   }
 
   public uploadMatrixToTexture(
@@ -171,7 +176,7 @@ export class GPGPUContext {
     this.throwIfDisposed();
     const numChannels = webgl_util.getNumChannels();
     return gpgpu_util.uploadMatrixToTexture(
-        this.gl, texture, rows, columns, matrix, numChannels,
+        this.gl, this.debug, texture, rows, columns, matrix, numChannels,
         this.textureConfig);
   }
 
@@ -180,8 +185,8 @@ export class GPGPUContext {
       physicalRows: number, physicalCols: number, matrix: Float32Array) {
     this.throwIfDisposed();
     return gpgpu_util.uploadMatrixToPackedTexture(
-        this.gl, texture, batch, rows, columns, physicalRows, physicalCols,
-        matrix, this.textureConfig);
+        this.gl, this.debug, texture, batch, rows, columns, physicalRows,
+        physicalCols, matrix, this.textureConfig);
   }
 
   public downloadFloat32MatrixFromOutputTexture(
@@ -189,7 +194,7 @@ export class GPGPUContext {
     return this.downloadMatrixDriver(
         texture,
         () => gpgpu_util.downloadFloat32MatrixFromOutputTexture(
-            this.gl, rows, columns, this.textureConfig));
+            this.gl, this.debug, rows, columns, this.textureConfig));
   }
 
   public downloadByteEncodedFloatMatrixFromOutputTexture(
@@ -197,7 +202,7 @@ export class GPGPUContext {
     return this.downloadMatrixDriver(
         texture,
         () => gpgpu_util.downloadByteEncodedFloatMatrixFromOutputTexture(
-            this.gl, rows, columns, this.textureConfig));
+            this.gl, this.debug, rows, columns, this.textureConfig));
   }
 
   public downloadPackedMatrixFromBuffer(
@@ -219,7 +224,7 @@ export class GPGPUContext {
       |WebGLTexture {
     this.bindTextureToFrameBuffer(texture);
     const result = gpgpu_util.maybeCreateBufferFromOutputTexture(
-        this.gl, texture, rows, columns, this.textureConfig);
+        this.gl, this.debug, texture, rows, columns, this.textureConfig);
     this.unbindTextureToFrameBuffer();
     return result;
   }
@@ -268,8 +273,8 @@ export class GPGPUContext {
     return this.downloadMatrixDriver(
         texture,
         () => gpgpu_util.downloadMatrixFromPackedOutputTexture(
-            this.gl, batch, rows, columns, physicalRows, physicalCols,
-            this.textureConfig));
+            this.gl, this.debug, batch, rows, columns, physicalRows,
+            physicalCols, this.textureConfig));
   }
 
   private vertexAttrsAreBound = false;
@@ -278,19 +283,25 @@ export class GPGPUContext {
     this.throwIfDisposed();
     const gl = this.gl;
     const fragmentShader: WebGLShader =
-        webgl_util.createFragmentShader(gl, fragmentShaderSource);
-    const vertexShader: WebGLShader = gpgpu_util.createVertexShader(gl);
-    const program: WebGLProgram = webgl_util.createProgram(gl);
-    webgl_util.callAndCheck(gl, () => gl.attachShader(program, vertexShader));
-    webgl_util.callAndCheck(gl, () => gl.attachShader(program, fragmentShader));
-    webgl_util.linkProgram(gl, program);
-    if (this.autoDebugValidate) {
-      webgl_util.validateProgram(gl, program);
+        webgl_util.createFragmentShader(gl, this.debug, fragmentShaderSource);
+    const vertexShader: WebGLShader =
+        gpgpu_util.createVertexShader(gl, this.debug);
+    const program: WebGLProgram = webgl_util.createProgram(
+        gl,
+        this.debug,
+    );
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.attachShader(program, vertexShader));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.attachShader(program, fragmentShader));
+    webgl_util.linkProgram(gl, this.debug, program);
+    if (this.debug) {
+      webgl_util.validateProgram(gl, this.debug, program);
     }
     if (!this.vertexAttrsAreBound) {
       this.setProgram(program);
       this.vertexAttrsAreBound = gpgpu_util.bindVertexProgramAttributeStreams(
-          gl, this.program, this.vertexBuffer);
+          gl, this.debug, this.program, this.vertexBuffer);
     }
     return program;
   }
@@ -301,17 +312,19 @@ export class GPGPUContext {
       this.program = null;
     }
     if (program != null) {
-      webgl_util.callAndCheck(this.gl, () => this.gl.deleteProgram(program));
+      webgl_util.callAndCheck(
+          this.gl, this.debug, () => this.gl.deleteProgram(program));
     }
   }
 
   public setProgram(program: WebGLProgram|null) {
     this.throwIfDisposed();
     this.program = program;
-    if ((this.program != null) && this.autoDebugValidate) {
-      webgl_util.validateProgram(this.gl, this.program);
+    if ((this.program != null) && this.debug) {
+      webgl_util.validateProgram(this.gl, this.debug, this.program);
     }
-    webgl_util.callAndCheck(this.gl, () => this.gl.useProgram(program));
+    webgl_util.callAndCheck(
+        this.gl, this.debug, () => this.gl.useProgram(program));
   }
 
   public getUniformLocation(
@@ -320,7 +333,7 @@ export class GPGPUContext {
     this.throwIfDisposed();
     if (shouldThrow) {
       return webgl_util.getProgramUniformLocationOrThrow(
-          this.gl, program, uniformName);
+          this.gl, this.debug, program, uniformName);
     } else {
       return webgl_util.getProgramUniformLocation(
           this.gl, program, uniformName);
@@ -331,7 +344,8 @@ export class GPGPUContext {
       number {
     this.throwIfDisposed();
     return webgl_util.callAndCheck(
-        this.gl, () => this.gl.getAttribLocation(program, attribute));
+        this.gl, this.debug,
+        () => this.gl.getAttribLocation(program, attribute));
   }
 
   public getUniformLocationNoThrow(program: WebGLProgram, uniformName: string):
@@ -346,7 +360,7 @@ export class GPGPUContext {
     this.throwIfDisposed();
     this.throwIfNoProgram();
     webgl_util.bindTextureToProgramUniformSampler(
-        this.gl, this.program, inputMatrixTexture, uniformLocation,
+        this.gl, this.debug, this.program, inputMatrixTexture, uniformLocation,
         textureUnit);
   }
 
@@ -378,7 +392,7 @@ export class GPGPUContext {
 
   public debugValidate() {
     if (this.program != null) {
-      webgl_util.validateProgram(this.gl, this.program);
+      webgl_util.validateProgram(this.gl, this.debug, this.program);
     }
     webgl_util.validateFramebuffer(this.gl);
   }
@@ -387,16 +401,17 @@ export class GPGPUContext {
     this.throwIfDisposed();
     this.throwIfNoProgram();
     const gl = this.gl;
-    if (this.autoDebugValidate) {
+    if (this.debug) {
       this.debugValidate();
     }
     webgl_util.callAndCheck(
-        gl, () => gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0));
+        gl, this.debug,
+        () => gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0));
   }
 
   public blockUntilAllProgramsCompleted() {
     this.throwIfDisposed();
-    webgl_util.callAndCheck(this.gl, () => this.gl.finish());
+    webgl_util.callAndCheck(this.gl, this.debug, () => this.gl.finish());
   }
 
   private getQueryTimerExtension(): WebGL1DisjointQueryTimerExtension
@@ -404,7 +419,7 @@ export class GPGPUContext {
     if (this.disjointQueryTimerExtension == null) {
       this.disjointQueryTimerExtension =
           webgl_util.getExtensionOrThrow(
-              this.gl,
+              this.gl, this.debug,
               ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2 ?
                   'EXT_disjoint_timer_query_webgl2' :
                   'EXT_disjoint_timer_query') as
@@ -546,8 +561,8 @@ export class GPGPUContext {
   private bindTextureToFrameBuffer(texture: WebGLTexture) {
     this.throwIfDisposed();
     webgl_util.bindColorTextureToFramebuffer(
-        this.gl, texture, this.framebuffer);
-    if (this.autoDebugValidate) {
+        this.gl, this.debug, texture, this.framebuffer);
+    if (this.debug) {
       webgl_util.validateFramebuffer(this.gl);
     }
   }
@@ -555,12 +570,13 @@ export class GPGPUContext {
   private unbindTextureToFrameBuffer() {
     if (this.outputTexture != null) {
       webgl_util.bindColorTextureToFramebuffer(
-          this.gl, this.outputTexture, this.framebuffer);
-      if (this.autoDebugValidate) {
+          this.gl, this.debug, this.outputTexture, this.framebuffer);
+      if (this.debug) {
         webgl_util.validateFramebuffer(this.gl);
       }
     } else {
-      webgl_util.unbindColorTextureFromFramebuffer(this.gl, this.framebuffer);
+      webgl_util.unbindColorTextureFromFramebuffer(
+          this.gl, this.debug, this.framebuffer);
     }
   }
 
@@ -580,20 +596,22 @@ export class GPGPUContext {
     this.throwIfDisposed();
     const gl = this.gl;
     webgl_util.bindColorTextureToFramebuffer(
-        gl, outputMatrixTextureMaybePacked, this.framebuffer);
-    if (this.autoDebugValidate) {
+        gl, this.debug, outputMatrixTextureMaybePacked, this.framebuffer);
+    if (this.debug) {
       webgl_util.validateFramebuffer(gl);
     }
     this.outputTexture = outputMatrixTextureMaybePacked;
-    webgl_util.callAndCheck(gl, () => gl.viewport(0, 0, width, height));
-    webgl_util.callAndCheck(gl, () => gl.scissor(0, 0, width, height));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.viewport(0, 0, width, height));
+    webgl_util.callAndCheck(
+        gl, this.debug, () => gl.scissor(0, 0, width, height));
   }
 
   private setOutputMatrixWriteRegionDriver(
       x: number, y: number, width: number, height: number) {
     this.throwIfDisposed();
     webgl_util.callAndCheck(
-        this.gl, () => this.gl.scissor(x, y, width, height));
+        this.gl, this.debug, () => this.gl.scissor(x, y, width, height));
   }
 
   private throwIfDisposed() {

--- a/src/kernels/webgl/gpgpu_context.ts
+++ b/src/kernels/webgl/gpgpu_context.ts
@@ -43,7 +43,6 @@ export class GPGPUContext {
   outputTexture: WebGLTexture|null = null;
   program: WebGLProgram|null = null;
   private disposed = false;
-  private debug = false;
   private disjoint: boolean;
   private textureConfig: TextureConfig;
 
@@ -81,6 +80,10 @@ export class GPGPUContext {
         gpgpu_util.getTextureConfig(this.gl, this.textureHalfFloatExtension);
   }
 
+  private get debug(): boolean {
+    return ENV.get('DEBUG');
+  }
+
   public dispose() {
     if (this.disposed) {
       return;
@@ -111,10 +114,6 @@ export class GPGPUContext {
     webgl_util.callAndCheck(
         gl, this.debug, () => gl.deleteBuffer(this.indexBuffer));
     this.disposed = true;
-  }
-
-  public enableAutomaticDebugValidation(enabled: boolean) {
-    this.debug = enabled;
   }
 
   public createFloat32MatrixTexture(rows: number, columns: number):

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -126,8 +126,6 @@ describeWithFlags(
         const tBeforeClear =
             gpgpu.downloadFloat32MatrixFromOutputTexture(texture, 1, 1);
         expectNumbersClose(tBeforeClear[0], 10);
-        gpgpu.gl.clearColor(1, 0, 0, 0);
-        gpgpu.gl.clear(gpgpu.gl.COLOR_BUFFER_BIT);
         const tAfterClear =
             gpgpu.downloadFloat32MatrixFromOutputTexture(texture, 1, 1);
         expectNumbersClose(tAfterClear[0], 10);

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -126,6 +126,7 @@ describeWithFlags(
         const tBeforeClear =
             gpgpu.downloadFloat32MatrixFromOutputTexture(texture, 1, 1);
         expectNumbersClose(tBeforeClear[0], 10);
+        gpgpu.gl.clearColor(1, 0, 0, 0);
         const tAfterClear =
             gpgpu.downloadFloat32MatrixFromOutputTexture(texture, 1, 1);
         expectNumbersClose(tAfterClear[0], 10);

--- a/src/kernels/webgl/gpgpu_context_test.ts
+++ b/src/kernels/webgl/gpgpu_context_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from '../../environment';
 import {describeWithFlags} from '../../jasmine_util';
 import {expectArraysClose, expectNumbersClose} from '../../test_util';
 import {getGlslDifferences} from './glsl_version';
@@ -32,7 +33,7 @@ describeWithFlags(
 
       beforeEach(() => {
         gpgpu = new GPGPUContext();
-        gpgpu.enableAutomaticDebugValidation(true);
+        ENV.set('DEBUG', true);
         texture = gpgpu.createFloat32MatrixTexture(1, 1);
       });
 
@@ -86,7 +87,7 @@ describeWithFlags(
 
       it('basic', () => {
         gpgpu = new GPGPUContext();
-        gpgpu.enableAutomaticDebugValidation(true);
+        ENV.set('DEBUG', true);
         texture = gpgpu.createFloat32MatrixTexture(1, 1);
 
         gpgpu.setOutputMatrixTexture(texture, 1, 1);
@@ -105,7 +106,7 @@ describeWithFlags(
 
       beforeEach(() => {
         gpgpu = new GPGPUContext();
-        gpgpu.enableAutomaticDebugValidation(true);
+        ENV.set('DEBUG', true);
         texture = gpgpu.createFloat32MatrixTexture(1, 1);
       });
 
@@ -168,7 +169,7 @@ describeWithFlags(
 
       beforeEach(() => {
         gpgpu = new GPGPUContext();
-        gpgpu.enableAutomaticDebugValidation(true);
+        ENV.set('DEBUG', true);
       });
 
       afterEach(() => {
@@ -204,7 +205,7 @@ describeWithFlags(
 
       beforeEach(() => {
         gpgpu = new GPGPUContext();
-        gpgpu.enableAutomaticDebugValidation(true);
+        ENV.set('DEBUG', true);
         const glsl = getGlslDifferences();
         const src = `${glsl.version}
           precision highp float;
@@ -286,7 +287,7 @@ describeWithFlags('GPGPUContext', DOWNLOAD_FLOAT_ENVS, () => {
 
   beforeEach(() => {
     gpgpu = new GPGPUContext();
-    gpgpu.enableAutomaticDebugValidation(true);
+    ENV.set('DEBUG', true);
   });
 
   afterEach(() => {

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -38,7 +38,6 @@ export interface GPGPUBinary {
   webGLProgram: WebGLProgram;
   program: GPGPUProgram;
   uniformLocations: {[name: string]: WebGLUniformLocation};
-  gpgpu: GPGPUContext;
   source: string;
   inShapeInfos: ShapeInfo[];
   outShapeInfo: ShapeInfo;
@@ -98,7 +97,6 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
     source,
     webGLProgram,
     uniformLocations,
-    gpgpu,
     inShapeInfos,
     outShapeInfo
   };
@@ -138,7 +136,8 @@ function validateBinaryAndProgram(
 }
 
 export function runProgram<T extends Tensor, K extends Tensor>(
-    binary: GPGPUBinary, inputs: TensorData[], output: TensorData,
+    gpgpu: GPGPUContext, binary: GPGPUBinary, inputs: TensorData[],
+    output: TensorData,
     customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) =>
         void): void {
   validateBinaryAndProgram(binary.inShapeInfos, inputs);
@@ -146,7 +145,6 @@ export function runProgram<T extends Tensor, K extends Tensor>(
 
   const outTex = output.texData.texture;
   const outTexShape = output.texData.texShape;
-  const gpgpu = binary.gpgpu;
   if (output.texData.isPacked) {
     gpgpu.setOutputPackedMatrixTexture(outTex, outTexShape[0], outTexShape[1]);
   } else {

--- a/src/kernels/webgl/gpgpu_util_test.ts
+++ b/src/kernels/webgl/gpgpu_util_test.ts
@@ -66,8 +66,8 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
-    const tex =
-        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+    const tex = gpgpu_util.createFloat32MatrixTexture(
+        gpgpu.gl, false, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
@@ -83,8 +83,8 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_[MIN|MAG]_FILTER parameters to NEAREST', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
-    const tex =
-        gpgpu_util.createFloat32MatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+    const tex = gpgpu_util.createFloat32MatrixTexture(
+        gpgpu.gl, false, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))
@@ -102,8 +102,8 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
-    const tex =
-        gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+    const tex = gpgpu_util.createPackedMatrixTexture(
+        gpgpu.gl, false, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
@@ -119,8 +119,8 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_[MIN|MAG]_FILTER parameters to NEAREST', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
-    const tex =
-        gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 32, 32, textureConfig);
+    const tex = gpgpu_util.createPackedMatrixTexture(
+        gpgpu.gl, false, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))
@@ -141,8 +141,8 @@ describeWithFlags(
         const gpgpu = new GPGPUContext();
         const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
 
-        const tex =
-            gpgpu_util.createPackedMatrixTexture(gpgpu.gl, 4, 6, textureConfig);
+        const tex = gpgpu_util.createPackedMatrixTexture(
+            gpgpu.gl, false, 4, 6, textureConfig);
 
         const mat =
             tf.tensor2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [1, 12]);
@@ -186,7 +186,7 @@ describeWithFlags(
            const physicalRows = 10;
            const physicalCols = 16;
            const tex = gpgpu_util.createPackedMatrixTexture(
-               gpgpu.gl, physicalRows, physicalCols, textureConfig);
+               gpgpu.gl, false, physicalRows, physicalCols, textureConfig);
 
            const mat = tf.tensor3d(
                [

--- a/src/kernels/webgl/gpgpu_util_test.ts
+++ b/src/kernels/webgl/gpgpu_util_test.ts
@@ -66,8 +66,9 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
+    const debug = false;
     const tex = gpgpu_util.createFloat32MatrixTexture(
-        gpgpu.gl, false, 32, 32, textureConfig);
+        gpgpu.gl, debug, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
@@ -83,8 +84,9 @@ describeWithFlags('gpgpu_util createFloat32MatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_[MIN|MAG]_FILTER parameters to NEAREST', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
+    const debug = false;
     const tex = gpgpu_util.createFloat32MatrixTexture(
-        gpgpu.gl, false, 32, 32, textureConfig);
+        gpgpu.gl, debug, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))
@@ -102,8 +104,9 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_WRAP S+T parameters to CLAMP_TO_EDGE', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
+    const debug = false;
     const tex = gpgpu_util.createPackedMatrixTexture(
-        gpgpu.gl, false, 32, 32, textureConfig);
+        gpgpu.gl, debug, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(
         gpgpu.gl.getTexParameter(gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_WRAP_S))
@@ -119,8 +122,9 @@ describeWithFlags('gpgpu_util createPackedMatrixTexture', WEBGL_ENVS, () => {
   it('sets the TEXTURE_[MIN|MAG]_FILTER parameters to NEAREST', () => {
     const gpgpu = new GPGPUContext();
     const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
+    const debug = false;
     const tex = gpgpu_util.createPackedMatrixTexture(
-        gpgpu.gl, false, 32, 32, textureConfig);
+        gpgpu.gl, debug, 32, 32, textureConfig);
     gpgpu.gl.bindTexture(gpgpu.gl.TEXTURE_2D, tex);
     expect(gpgpu.gl.getTexParameter(
                gpgpu.gl.TEXTURE_2D, gpgpu.gl.TEXTURE_MIN_FILTER))
@@ -140,9 +144,9 @@ describeWithFlags(
       it('should work when texture shape != logical shape', () => {
         const gpgpu = new GPGPUContext();
         const textureConfig = gpgpu_util.getTextureConfig(gpgpu.gl);
-
+        const debug = false;
         const tex = gpgpu_util.createPackedMatrixTexture(
-            gpgpu.gl, false, 4, 6, textureConfig);
+            gpgpu.gl, debug, 4, 6, textureConfig);
 
         const mat =
             tf.tensor2d([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [1, 12]);
@@ -185,8 +189,9 @@ describeWithFlags(
            // these dimensions will be halved to create the packed texture
            const physicalRows = 10;
            const physicalCols = 16;
+           const debug = false;
            const tex = gpgpu_util.createPackedMatrixTexture(
-               gpgpu.gl, false, physicalRows, physicalCols, textureConfig);
+               gpgpu.gl, debug, physicalRows, physicalCols, textureConfig);
 
            const mat = tf.tensor3d(
                [


### PR DESCRIPTION
Speedup the WebGL tests by 2.5x.

On my MacBook Pro 15inch, the WebGL 2.0 tests used to take 55 sec. Now they make 22sec. Same for WebGL 1.0.

This PR's travis run is 5 mins 53 sec [link](https://travis-ci.org/tensorflow/tfjs-core/builds/506987446). Before it was 8mins and 33 secs [link](https://travis-ci.org/tensorflow/tfjs-core/builds/506838185)

**Details**
- Cache the WebGL binaries globally instead of re-compiling after every describe.
- Fix a bug with the webgl debug mode being global, which caused most of the unit tests to run with gl.checkError() after every GL call.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1625)
<!-- Reviewable:end -->
