### PR TITLE
Export types used in tfjs-data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import * as math from './math';
 import * as browser from './ops/browser';
 import * as serialization from './serialization';
 import {setOpHandler} from './tensor';
+import * as tensor_util from './tensor_util';
 import * as test_util from './test_util';
 import * as util from './util';
 import {version} from './version';
@@ -47,7 +48,6 @@ export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer, variable, Variable} from './tensor';
 export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
-export {getTensorsInContainer, isTensorInList} from './tensor_util';
 export {DataType, DataTypeMap, DataValues, Rank, ShapeMap, TensorLike} from './types';
 
 export * from './ops/ops';
@@ -77,7 +77,17 @@ export {
 };
 
 // Second level exports.
-export {browser, environment, io, math, serialization, test_util, util, webgl};
+export {
+  browser,
+  environment,
+  io,
+  math,
+  serialization,
+  test_util,
+  util,
+  webgl,
+  tensor_util
+};
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,9 @@ export {Optimizer} from './optimizers/optimizer';
 export {RMSPropOptimizer} from './optimizers/rmsprop_optimizer';
 export {SGDOptimizer} from './optimizers/sgd_optimizer';
 export {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer, variable, Variable} from './tensor';
-export {GradSaveFunc, NamedTensorMap} from './tensor_types';
-export {DataType, DataTypeMap, DataValues, Rank, ShapeMap} from './types';
+export {GradSaveFunc, NamedTensorMap, TensorContainer, TensorContainerArray, TensorContainerObject} from './tensor_types';
+export {getTensorsInContainer, isTensorInList} from './tensor_util';
+export {DataType, DataTypeMap, DataValues, Rank, ShapeMap, TensorLike} from './types';
 
 export * from './ops/ops';
 export {LSTMCellFunc} from './ops/lstm';

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -16,7 +16,7 @@
  */
 
 import {Tensor} from './tensor';
-import {NamedTensorMap, TensorContainer, TensorContainerArray} from './tensor_types';
+import {TensorContainer, TensorContainerArray} from './tensor_types';
 import {upcastType} from './types';
 import {assert} from './util';
 
@@ -42,33 +42,6 @@ export function isTensorInList(tensor: Tensor, tensorList: Tensor[]): boolean {
     }
   }
   return false;
-}
-
-export function flattenNameArrayMap(
-    nameArrayMap: Tensor|NamedTensorMap, keys?: string[]): Tensor[] {
-  const xs: Tensor[] = [];
-  if (nameArrayMap instanceof Tensor) {
-    xs.push(nameArrayMap);
-  } else {
-    const xMap = nameArrayMap as {[xName: string]: Tensor};
-    for (let i = 0; i < keys.length; i++) {
-      xs.push(xMap[keys[i]]);
-    }
-  }
-  return xs;
-}
-
-export function unflattenToNameArrayMap(
-    keys: string[], flatArrays: Tensor[]): NamedTensorMap {
-  if (keys.length !== flatArrays.length) {
-    throw new Error(
-        `Cannot unflatten Tensor[], keys and arrays are not of same length.`);
-  }
-  const result: NamedTensorMap = {};
-  for (let i = 0; i < keys.length; i++) {
-    result[keys[i]] = flatArrays[i];
-  }
-  return result;
 }
 
 /**

--- a/src/tensor_util_test.ts
+++ b/src/tensor_util_test.ts
@@ -18,8 +18,7 @@
 import * as tf from './index';
 import {describeWithFlags} from './jasmine_util';
 import {Tensor} from './tensor';
-import {NamedTensorMap} from './tensor_types';
-import {flattenNameArrayMap, getTensorsInContainer, isTensorInList, unflattenToNameArrayMap} from './tensor_util';
+import {getTensorsInContainer, isTensorInList} from './tensor_util';
 import {convertToTensor} from './tensor_util_env';
 import {ALL_ENVS, expectArraysClose, expectArraysEqual} from './test_util';
 
@@ -36,29 +35,6 @@ describe('tensor_util.isTensorInList', () => {
     const list: Tensor[] = [tf.scalar(2), tf.tensor1d([1, 2, 3]), a];
 
     expect(isTensorInList(a, list)).toBe(true);
-  });
-});
-
-describe('tensor_util.flattenNameArrayMap', () => {
-  it('basic', () => {
-    const a = tf.scalar(1);
-    const b = tf.scalar(3);
-    const c = tf.tensor1d([1, 2, 3]);
-
-    const map: NamedTensorMap = {a, b, c};
-    expect(flattenNameArrayMap(map, Object.keys(map))).toEqual([a, b, c]);
-  });
-});
-
-describe('tensor_util.unflattenToNameArrayMap', () => {
-  it('basic', () => {
-    const a = tf.scalar(1);
-    const b = tf.scalar(3);
-    const c = tf.tensor1d([1, 2, 3]);
-
-    expect(unflattenToNameArrayMap(['a', 'b', 'c'], [
-      a, b, c
-    ])).toEqual({a, b, c});
   });
 });
 


### PR DESCRIPTION
Some un-exported types are used in tfjs-data through `import {xxx} from '@tensorflow/tfjs-core/dist/xxx'`. Export these types in tfjs-core and import them through index file.

resolves https://github.com/tensorflow/tfjs/issues/1391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1626)
<!-- Reviewable:end -->
