### PR TITLE
adds error checking for tf.Buffer.get(outOfRangeLocation)

### DIFF
--- a/src/buffer_test.ts
+++ b/src/buffer_test.ts
@@ -34,6 +34,16 @@ describeWithFlags('tf.buffer', ALL_ENVS, () => {
     expectArraysClose(buff.values, new Float32Array([1.3, 0, 0, 2.9, 0, 0]));
   });
 
+  it('get() out of range throws', () => {
+    const t = tf.tensor([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2]);
+
+    const buff = t.bufferSync();
+    expect(buff.get(0, 0, 0)).toBeCloseTo(1);
+    expect(buff.get(0, 0, 1)).toBeCloseTo(2);
+    expect(() => buff.get(0, 0, 2))
+        .toThrowError(/Requested out of range element/);
+  });
+
   it('int32', () => {
     const buff = tf.buffer([2, 3], 'int32');
     buff.set(1.3, 0, 0);

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -98,12 +98,14 @@ export class TensorBuffer<R extends Rank, D extends DataType = 'float32'> {
     if (locs.length === 0) {
       locs = [0];
     }
-    for (const i in locs) {
-      if (locs[i] < 0 || locs[i] >= this.shape[i]) {
+    let i = 0;
+    for (const loc of locs) {
+      if (loc < 0 || loc >= this.shape[i]) {
         const msg = `Requested out of range element at ${locs}. ` +
             `  Buffer shape=${this.shape}`;
         throw new Error(msg);
       }
+      i++;
     }
     let index = locs[locs.length - 1];
     for (let i = 0; i < locs.length - 1; ++i) {

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -98,6 +98,13 @@ export class TensorBuffer<R extends Rank, D extends DataType = 'float32'> {
     if (locs.length === 0) {
       locs = [0];
     }
+    for (const i in locs) {
+      if (locs[i] < 0 || locs[i] >= this.shape[i]) {
+        const msg = `Requested out of range element at ${locs}. ` +
+            `  Buffer shape=${this.shape}`;
+        throw new Error(msg);
+      }
+    }
     let index = locs[locs.length - 1];
     for (let i = 0; i < locs.length - 1; ++i) {
       index += this.strides[i] * locs[i];


### PR DESCRIPTION
Previously, given a buffer of size [2, 2], accessing [0, 2] and [1, 0] did the same thing, which can be surprising.  This PR adds error checking. 

Fixes https://github.com/tensorflow/tfjs/issues/1304

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1630)
<!-- Reviewable:end -->
