### PR TITLE
Fix a bug in shader compiler with zero-sized tensors

### DIFF
--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -165,7 +165,7 @@ export function runProgram<T extends Tensor, K extends Tensor>(
 
     if (input.isUniform) {
       // Upload the values of the tensor as uniform.
-      if (util.sizeFromShape(input.shape) === 1) {
+      if (util.sizeFromShape(input.shape) < 2) {
         gpgpu.gl.uniform1f(varLoc, input.uniformValues[0]);
       } else {
         let vals = input.uniformValues;

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -1244,7 +1244,7 @@ function getUniformSampler(inputInfo: InputInfo): string {
   const texName = inputInfo.name;
   const inSize = util.sizeFromShape(inputInfo.shapeInfo.logicalShape);
 
-  if (inSize === 1) {
+  if (inSize < 2) {
     return `return ${texName};`;
   }
   return `


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/1235

When tensors are zero-sized, we should upload as `uniform float` instead of `uniform float[]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1632)
<!-- Reviewable:end -->
