### PR TITLE
Export MathBackendCPU used in tfjs-data node test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export {
 
 // Backend specific.
 export {KernelBackend, BackendTimingInfo, DataMover, DataStorage} from './kernels/backend';
+export {MathBackendCPU} from './kernels/backend_cpu';
 
 import * as ops from './ops/ops';
 setOpHandler(ops);


### PR DESCRIPTION
Export MathBackendCPU from kernels/backend_cpu. This is used to set test environment in node test.

https://github.com/tensorflow/tfjs/issues/1391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1634)
<!-- Reviewable:end -->
