### PR TITLE
Add ENV.findBackendFactory() to be used by test utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tslint": "~5.11.0",
     "tslint-no-circular-imports": "~0.5.0",
     "typescript": "3.3.3333",
+    "watchify": "~3.11.1",
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -34,6 +34,7 @@ export class Environment {
   private globalEngine: Engine;
   private registry:
       {[id: string]: {backend: KernelBackend, priority: number}} = {};
+  private registryFactory: {[id: string]: () => KernelBackend} = {};
   backendName: string;
 
   constructor(features?: Features) {
@@ -403,11 +404,27 @@ export class Environment {
     return this.engine.backend;
   }
 
+  /**
+   * Finds the backend registered under the provided name. Returns null if the
+   * name is not in the registry.
+   */
   findBackend(name: string): KernelBackend {
     if (!(name in this.registry)) {
       return null;
     }
     return this.registry[name].backend;
+  }
+
+  /**
+   * Finds the backend factory registered under the provided name. Returns a
+   * function that produces a new backend when called. Returns null if the name
+   * is not in the registry.
+   */
+  findBackendFactory(name: string): () => KernelBackend {
+    if (!(name in this.registryFactory)) {
+      return null;
+    }
+    return this.registryFactory[name];
   }
 
   /**
@@ -429,6 +446,7 @@ export class Environment {
           `${name} backend was already registered. Reusing existing backend`);
       return false;
     }
+    this.registryFactory[name] = factory;
     try {
       const backend = factory();
       backend.setDataMover(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -446,12 +446,12 @@ export class Environment {
           `${name} backend was already registered. Reusing existing backend`);
       return false;
     }
-    this.registryFactory[name] = factory;
     try {
       const backend = factory();
       backend.setDataMover(
           {moveData: (dataId: DataId) => this.engine.moveData(dataId)});
       this.registry[name] = {backend, priority};
+      this.registryFactory[name] = factory;
       return true;
     } catch (err) {
       console.warn(`Registration of backend ${name} failed`);

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -110,8 +110,11 @@ describe('Backend', () => {
   it('custom cpu registration', () => {
     let backend: KernelBackend;
     ENV.registerBackend('custom-cpu', () => {
-      backend = new MathBackendCPU();
-      return backend;
+      const newBackend = new MathBackendCPU();
+      if (backend == null) {
+        backend = newBackend;
+      }
+      return newBackend;
     });
 
     expect(ENV.findBackend('custom-cpu')).toBe(backend);

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -115,6 +115,9 @@ describe('Backend', () => {
     });
 
     expect(ENV.findBackend('custom-cpu')).toBe(backend);
+    const factory = ENV.findBackendFactory('custom-cpu');
+    expect(factory).not.toBeNull();
+    expect(factory() instanceof MathBackendCPU).toBe(true);
     Environment.setBackend('custom-cpu');
     expect(ENV.backend).toBe(backend);
 
@@ -132,6 +135,7 @@ describe('Backend', () => {
         ENV.registerBackend('custom-webgl', () => new MathBackendWebGL(), 104);
     expect(success).toBe(false);
     expect(ENV.findBackend('custom-webgl') == null).toBe(true);
+    expect(ENV.findBackendFactory('custom-webgl') == null).toBe(true);
     expect(Environment.getBackend()).toBe('custom-cpu');
     expect(ENV.backend).toBe(cpuBackend);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@
  */
 
 // backend_cpu.ts and backend_webgl.ts are standalone files and should be
-// explicitly included here. Below, there is an export from backend_webgl, but
-// that doesn't count since it's exporting a Typescript interface.
+// explicitly included here.
 import './kernels/backend_webgl';
 import './kernels/backend_cpu';
 

--- a/src/test_node.ts
+++ b/src/test_node.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
+import {ENV} from './environment';
 import {setTestEnvs} from './jasmine_util';
-import {MathBackendCPU} from './kernels/backend_cpu';
 // tslint:disable-next-line:no-require-imports
 const jasmine = require('jasmine');
 
@@ -25,7 +25,7 @@ process.on('unhandledRejection', e => {
 });
 
 setTestEnvs(
-    [{name: 'node', factory: () => new MathBackendCPU(), features: {}}]);
+    [{name: 'node', factory: ENV.findBackendFactory('cpu'), features: {}}]);
 
 const runner = new jasmine();
 runner.loadConfig({spec_files: ['dist/**/**_test.js'], random: false});

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,11 @@ async-each@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
+async-each@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.2.tgz#8b8a7ca2a658f927e9f307d6d1a42f4199f0f735"
+  integrity sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==
+
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
@@ -426,7 +431,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0, braces@^2.3.1:
+braces@^2.3.0, braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -525,7 +530,7 @@ browserify-zlib@^0.2.0, browserify-zlib@~0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserify@~16.2.3:
+browserify@^16.1.0, browserify@~16.2.3:
   version "16.2.3"
   resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.2.3.tgz#7ee6e654ba4f92bce6ab3599c3485b1cc7a0ad0b"
   integrity sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==
@@ -749,6 +754,25 @@ chokidar@^2.0.3:
     upath "^1.0.5"
   optionalDependencies:
     fsevents "^1.2.2"
+
+chokidar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.0"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 chownr@^1.1.1:
   version "1.1.1"
@@ -1635,6 +1659,14 @@ fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
+
+fsevents@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
+  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
@@ -2940,6 +2972,11 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -3110,6 +3147,13 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+outpipe@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/outpipe/-/outpipe-1.1.1.tgz#50cf8616365e87e031e29a5ec9339a3da4725fa2"
+  integrity sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=
+  dependencies:
+    shell-quote "^1.4.2"
 
 pad@^2.2.2:
   version "2.2.2"
@@ -3488,7 +3532,7 @@ readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readdirp@^2.0.0:
+readdirp@^2.0.0, readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
   integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
@@ -3769,7 +3813,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shell-quote@^1.6.1:
+shell-quote@^1.4.2, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
@@ -4408,6 +4452,11 @@ upath@^1.0.5:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
+upath@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
+  integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -4494,6 +4543,19 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+
+watchify@~3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/watchify/-/watchify-3.11.1.tgz#8e4665871fff1ef64c0430d1a2c9d084d9721881"
+  integrity sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==
+  dependencies:
+    anymatch "^2.0.0"
+    browserify "^16.1.0"
+    chokidar "^2.1.1"
+    defined "^1.0.0"
+    outpipe "^1.1.0"
+    through2 "^2.0.0"
+    xtend "^4.0.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Add `ENV.findBackendFactory()` analogous to `ENV.findBackend()` to be used by test utils in node: see changes in `test_node.ts`.

This avoids having to export the `MathBackendCPU` in the public namespace and allow us to preserve the ability to modularize the library later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1635)
<!-- Reviewable:end -->
