### PR TITLE
Save tensor x in forward mode when zerosLike(x) is used in backward mode

### DIFF
--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -424,11 +424,15 @@ function argMin_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     $x = $x.transpose(permutedAxes);
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
-  const grad = (dy: T) => {
+  const grad = (dy: T, saved: NamedTensorMap) => {
+    const {$x} = saved;
     return {$x: () => zerosLike($x)};
   };
-  return ENV.engine.runKernel(
-             backend => backend.argMin($x, axes[0]), {$x}, grad) as T;
+  return ENV.engine.runKernel((backend, save) => {
+    const res = backend.argMin($x, axes[0]);
+    save({$x});
+    return res;
+  }, {$x}, grad) as T;
 }
 
 /**
@@ -466,11 +470,15 @@ function argMax_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     $x = $x.transpose(permutedAxes);
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
-  const grad = (dy: T) => {
+  const grad = (dy: T, saved: NamedTensorMap) => {
+    const {$x} = saved;
     return {$x: () => zerosLike($x)};
   };
-  return ENV.engine.runKernel(
-             backend => backend.argMax($x, axes[0]), {$x}, grad) as T;
+  return ENV.engine.runKernel((backend, save) => {
+    const res = backend.argMax($x, axes[0]);
+    save({$x});
+    return res;
+  }, {$x}, grad) as T;
 }
 
 /**


### PR DESCRIPTION
In our webgl and cpu backend, `zerosLike(x)` and `onesLike(x)` don't care if `x` is disposed, because they only need its shape.

In the tfjs-node backend however, calls to TF C++ kernel `zerosLike(x)` requires that `x` is not disposed.

Because of this discrepancy, we need to call `save(x)` during forward pass for all ops that use `zerosLike(x)` and `onesLike(x)` in the backwards pass.

This fixes the failing integration test in tfjs-node here: https://travis-ci.org/tensorflow/tfjs-core/jobs/508508231#L893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1636)
<!-- Reviewable:end -->
