### PR TITLE
show better error message for not converted TFHub module

### DIFF
--- a/src/io/browser_http.ts
+++ b/src/io/browser_http.ts
@@ -88,7 +88,7 @@ export class BrowserHTTPRequest implements IOHandler {
             'URL path for browserHTTPRequest must not be null, undefined or ' +
             'empty.');
 
-    if (loadOptions.fromTFHub === true && !path.endsWith(TFHUB_SEARCH_PARAM)) {
+    if (loadOptions.fromTFHub && !path.endsWith(TFHUB_SEARCH_PARAM)) {
       if (!path.endsWith('/')) {
         path = path + '/';
       }
@@ -168,7 +168,7 @@ export class BrowserHTTPRequest implements IOHandler {
         await this.getFetchFunc()(this.path, this.requestInit);
 
     if (!modelConfigRequest.ok) {
-      if (this.fromTFHub === true && modelConfigRequest.status === 404) {
+      if (this.fromTFHub && modelConfigRequest.status === 404) {
         throw new Error(
             `TFHub module at ${this.originalPath} has not been` +
             ' converted to TensorFlow.js yet.');


### PR DESCRIPTION
moved TFHub url update logic to browser http handler and show module not converted message when 404 is returned.
fix issue tensorflow/tfjs#1408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1639)
<!-- Reviewable:end -->
