### PR TITLE
Remove redundant 'break'

### DIFF
--- a/src/ops/segment_util.ts
+++ b/src/ops/segment_util.ts
@@ -42,7 +42,6 @@ export function segOpComputeOptimalWindowSize(
   while (!done) {
     if (res > numSegments || res === inSize) {
       done = true;
-      break;
     } else {
       res = nearestDivisor(inSize, res + 1);
     }


### PR DESCRIPTION
The while iteration will stop when the flag `done` is set to _true_. The requirement of a break statement here doesn't seem necessary. 

An alternative fix would be to remove the assignment of `done` to _true_ instead. 😄

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1642)
<!-- Reviewable:end -->
