### PR TITLE
Make the save function in a gradient be a Tensor[] instead of a NamedTensorMap

### DIFF
--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -20,7 +20,6 @@ import {describeWithFlags} from './jasmine_util';
 import {MathBackendCPU} from './kernels/backend_cpu';
 import {MathBackendWebGL} from './kernels/backend_webgl';
 import {Tensor} from './tensor';
-import {NamedTensorMap} from './tensor_types';
 import {ALL_ENVS, CPU_ENVS, expectArraysClose, expectArraysEqual, WEBGL_ENVS} from './test_util';
 
 describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
@@ -350,9 +349,9 @@ describeWithFlags('customGradient', ALL_ENVS, () => {
 
     const customPow = tf.customGrad((a: tf.Tensor, save: tf.GradSaveFunc) => {
       const value = tf.pow(a, b);
-      save({a});
-      const gradFunc = (dy: tf.Tensor, saved: NamedTensorMap) => {
-        const {a} = saved;
+      save([a]);
+      const gradFunc = (dy: tf.Tensor, saved: Tensor[]) => {
+        const [a] = saved;
         return dy.mul(a);
       };
       return {value, gradFunc};
@@ -368,11 +367,11 @@ describeWithFlags('customGradient', ALL_ENVS, () => {
   it('calling gradient of custom op twice works', () => {
     const customOp = tf.customGrad((x: tf.Tensor, save: tf.GradSaveFunc) => {
       // Override gradient of our custom x ^ 2 op to be dy * abs(x);
-      save({x});
+      save([x]);
       return {
         value: x.square(),
-        gradFunc: (dy, saved: NamedTensorMap) => {
-          const {x} = saved;
+        gradFunc: (dy, saved: Tensor[]) => {
+          const [x] = saved;
           return dy.mul(x.abs());
         }
       };

--- a/src/io/local_storage.ts
+++ b/src/io/local_storage.ts
@@ -152,9 +152,9 @@ export class BrowserLocalStorage implements IOHandler {
         this.LS.setItem(this.keys['topology'], topology);
         this.LS.setItem(this.keys['weightSpecs'], weightSpecs);
         this.LS.setItem(
-            this.keys.weightData,
+            this.keys['weightData'],
             arrayBufferToBase64String(modelArtifacts.weightData));
-        this.LS.setItem(this.keys.modelMetadata, JSON.stringify({
+        this.LS.setItem(this.keys['modelMetadata'], JSON.stringify({
           format: modelArtifacts.format,
           generatedBy: modelArtifacts.generatedBy,
           convertedBy: modelArtifacts.convertedBy
@@ -187,7 +187,7 @@ export class BrowserLocalStorage implements IOHandler {
    */
   async load(): Promise<ModelArtifacts> {
     const info =
-        JSON.parse(this.LS.getItem(this.keys.info)) as ModelArtifactsInfo;
+        JSON.parse(this.LS.getItem(this.keys['info'])) as ModelArtifactsInfo;
     if (info == null) {
       throw new Error(
           `In local storage, there is no model with name '${this.modelPath}'`);
@@ -202,7 +202,7 @@ export class BrowserLocalStorage implements IOHandler {
     const out: ModelArtifacts = {};
 
     // Load topology.
-    const topology = JSON.parse(this.LS.getItem(this.keys.topology));
+    const topology = JSON.parse(this.LS.getItem(this.keys['topology']));
     if (topology == null) {
       throw new Error(
           `In local storage, the topology of model '${this.modelPath}' ` +
@@ -211,7 +211,7 @@ export class BrowserLocalStorage implements IOHandler {
     out.modelTopology = topology;
 
     // Load weight specs.
-    const weightSpecs = JSON.parse(this.LS.getItem(this.keys.weightSpecs));
+    const weightSpecs = JSON.parse(this.LS.getItem(this.keys['weightSpecs']));
     if (weightSpecs == null) {
       throw new Error(
           `In local storage, the weight specs of model '${this.modelPath}' ` +
@@ -230,7 +230,7 @@ export class BrowserLocalStorage implements IOHandler {
     }
 
     // Load weight data.
-    const weightDataBase64 = this.LS.getItem(this.keys.weightData);
+    const weightDataBase64 = this.LS.getItem(this.keys['weightData']);
     if (weightDataBase64 == null) {
       throw new Error(
           `In local storage, the binary weight values of model ` +

--- a/src/io/local_storage.ts
+++ b/src/io/local_storage.ts
@@ -148,9 +148,9 @@ export class BrowserLocalStorage implements IOHandler {
           getModelArtifactsInfoForJSON(modelArtifacts);
 
       try {
-        this.LS.setItem(this.keys.info, JSON.stringify(modelArtifactsInfo));
-        this.LS.setItem(this.keys.topology, topology);
-        this.LS.setItem(this.keys.weightSpecs, weightSpecs);
+        this.LS.setItem(this.keys['info'], JSON.stringify(modelArtifactsInfo));
+        this.LS.setItem(this.keys['topology'], topology);
+        this.LS.setItem(this.keys['weightSpecs'], weightSpecs);
         this.LS.setItem(
             this.keys.weightData,
             arrayBufferToBase64String(modelArtifacts.weightData));

--- a/src/kernels/webgl/webgl_custom_op_test.ts
+++ b/src/kernels/webgl/webgl_custom_op_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '../../index';
 import {describeWithFlags} from '../../jasmine_util';
-import {NamedTensorMap} from '../../tensor_types';
+import {Tensor} from '../../tensor';
 import {expectArraysClose, WEBGL_ENVS} from '../../test_util';
 
 describeWithFlags('custom-op webgl', WEBGL_ENVS, () => {
@@ -57,15 +57,15 @@ describeWithFlags('custom-op webgl', WEBGL_ENVS, () => {
 
   function squareAndAdd<T extends tf.Tensor>(x: T): T {
     const fn = tf.customGrad((x: tf.Tensor, save: tf.GradSaveFunc) => {
-      save({x});
+      save([x]);
       const webglBackend = tf.ENV.backend as tf.webgl.MathBackendWebGL;
       const program = new SquareAndAddKernel(x.shape);
       const backpropProgram = new SquareAndAddBackpropKernel(x.shape);
 
       const value = webglBackend.compileAndRun(program, [x]) as tf.Tensor;
 
-      const gradFunc = (dy: T, saved: NamedTensorMap) => {
-        const {x} = saved;
+      const gradFunc = (dy: T, saved: Tensor[]) => {
+        const [x] = saved;
         return (webglBackend.compileAndRun(backpropProgram, [x]) as T).mul(dy);
       };
       return {value, gradFunc};

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor, convertToTensorArray} from '../tensor_util_env';
 import {DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike4D} from '../types';
 import * as util from '../util';
@@ -417,8 +416,8 @@ function tile_<T extends Tensor>(x: T|TensorLike, reps: number[]): T {
       $x.rank === reps.length,
       () => `Error in transpose: rank of input ${$x.rank} ` +
           `must match length of reps ${reps}.`);
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     const derX = () => {
       let xGrad = zerosLike($x);
       // TODO(cais): Maybe reduce memory footprint by avoiding repeated
@@ -471,7 +470,7 @@ function tile_<T extends Tensor>(x: T|TensorLike, reps: number[]): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.tile($x, reps);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -17,7 +17,6 @@
 
 import {deprecationWarn, ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {Rank, TensorLike} from '../types';
 import * as util from '../util';
@@ -274,8 +273,8 @@ function batchNorm_<R extends Rank>(
     x4D = $x as Tensor4D;
   }
 
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$x, $mean, $variance, $scale} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$x, $mean, $variance, $scale] = saved;
     const scaleValue = $scale == null ? scalar(1) : $scale;
     const reductionAxes = getReductionAxes($mean.shape, x4D.shape);
     const tileShape: number[] = [];
@@ -347,7 +346,7 @@ function batchNorm_<R extends Rank>(
         x4D, batchnormReshape4D($mean), batchnormReshape4D($variance),
         varianceEpsilon, batchnormReshape4D($scale),
         batchnormReshape4D($offset));
-    save({$x, $mean, $variance, $scale});
+    save([$x, $mean, $variance, $scale]);
     return res;
   }, {$x, $mean, $variance, $scale, $offset}, der);
   return res.reshape($x.shape);

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -252,8 +252,8 @@ function pow_<T extends Tensor>(base: T|TensorLike, exp: Tensor|TensorLike): T {
       broadcast_util.assertAndGetBroadcastShape($base.shape, $exp.shape);
   base = $base.cast(upcastType($base.dtype, $exp.dtype));
   exp = $exp.cast(upcastType($base.dtype, $exp.dtype));
-  const grad = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$base, $exp, y} = saved;
+  const grad = (dy: Tensor, saved: Tensor[]) => {
+    const [$base, $exp, y] = saved;
     const derBase = () => {
       const expFloat = $exp.toFloat();
       let res = dy.mul(expFloat.mul($base.pow(expFloat.sub(scalar(1)))));
@@ -277,7 +277,7 @@ function pow_<T extends Tensor>(base: T|TensorLike, exp: Tensor|TensorLike): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const y = backend.pow($base, $exp);
-    save({$base, $exp, y});
+    save([$base, $exp, y]);
     return y;
   }, {$base, $exp}, grad) as T;
 }
@@ -328,8 +328,8 @@ function mul_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   const outShape =
       broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
 
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => {
       const res = dy.mul($b.toFloat());
       const reduceAxes = broadcast_util.getReductionAxes($a.shape, outShape);
@@ -350,7 +350,7 @@ function mul_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.multiply($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -408,8 +408,8 @@ function div_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
 
   const outShape =
       broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => {
       const res = dy.div($b.toFloat());
       const reduceAxes = broadcast_util.getReductionAxes($a.shape, outShape);
@@ -431,7 +431,7 @@ function div_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.realDivide($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -469,8 +469,8 @@ function floorDiv_<T extends Tensor>(
 
   const outShape =
       broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => {
       const res = dy.div($b.toFloat());
       const reduceAxes = broadcast_util.getReductionAxes($a.shape, outShape);
@@ -492,7 +492,7 @@ function floorDiv_<T extends Tensor>(
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.floorDiv($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -545,8 +545,8 @@ function mod_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
 
   const outShape =
       broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => {
       const reduceAxes = broadcast_util.getReductionAxes($a.shape, outShape);
       if (reduceAxes.length > 0) {
@@ -566,7 +566,7 @@ function mod_<T extends Tensor>(a: Tensor|TensorLike, b: Tensor|TensorLike): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.mod($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -623,15 +623,15 @@ function minimum_<T extends Tensor>(
   }
 
   broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => dy.mul($a.lessEqual($b).toFloat());
     const derB = () => dy.mul($a.greater($b).toFloat());
     return {$a: derA, $b: derB};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.minimum($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -688,15 +688,15 @@ function maximum_<T extends Tensor>(
   }
 
   broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => dy.mul($a.greaterEqual($b).toFloat());
     const derB = () => dy.mul($a.less($b).toFloat());
     return {$a: derA, $b: derB};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.maximum($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -749,8 +749,8 @@ function squaredDifference_<T extends Tensor>(
   [$a, $b] = makeTypesMatch($a, $b);
 
   broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const two = scalar(2);
     const derA = () => dy.mul($a.sub($b).mul(two));
     const derB = () => dy.mul($b.sub($a).mul(two));
@@ -758,7 +758,7 @@ function squaredDifference_<T extends Tensor>(
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.squaredDifference($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }
@@ -806,8 +806,8 @@ function atan2_<T extends Tensor>(
   const outShape =
       broadcast_util.assertAndGetBroadcastShape($a.shape, $b.shape);
 
-  const der = (dy: Tensor, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const der = (dy: Tensor, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     const derA = () => {
       const d = add($a.square(), $b.square());
       let res = dy.mul($b.div(d));
@@ -830,7 +830,7 @@ function atan2_<T extends Tensor>(
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.atan2($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, der) as T;
 }

--- a/src/ops/compare.ts
+++ b/src/ops/compare.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../environment';
 import {Tensor} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {makeTypesMatch} from '../tensor_util';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
@@ -239,13 +238,13 @@ function greaterEqual_<T extends Tensor>(
   [$a, $b] = makeTypesMatch($a, $b);
   assertAndGetBroadcastShape($a.shape, $b.shape);
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$a, $b} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$a, $b] = saved;
     return {$a: () => zerosLike($a), $b: () => zerosLike($b)};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.greaterEqual($a, $b);
-    save({$a, $b});
+    save([$a, $b]);
     return res;
   }, {$a, $b}, grad) as T;
 }

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -16,11 +16,11 @@
  */
 
 import {ENV} from '../environment';
-import {Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
+import {Tensor, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
+
 import * as conv_util from './conv_util';
 import {op} from './operation';
 
@@ -189,9 +189,8 @@ function conv2d_<T extends Tensor3D|Tensor4D>(
   const convInfo = conv_util.computeConv2DInfo(
       x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
 
-  const grad = (dy: Tensor4D, saved: {x4D: Tensor4D, $filter: Tensor4D}) => {
-    const x4D = saved.x4D as Tensor4D;
-    const $filter = saved.$filter as Tensor4D;
+  const grad = (dy: Tensor4D, saved: Tensor[]) => {
+    const [$filter, x4D] = saved as [Tensor4D, Tensor4D];
     util.assert(
         conv_util.tupleValuesAreOne(dilations),
         () => 'Error in gradient of conv2D: dilation rates greater than 1 ' +
@@ -205,7 +204,8 @@ function conv2d_<T extends Tensor3D|Tensor4D>(
 
   const res = ENV.engine.runKernel((backend, save) => {
     const res = backend.conv2d(x4D, $filter, convInfo);
-    save({$filter, x4D});
+    save([$filter, x4D]);
+
     return res;
   }, {x: x4D, $filter}, grad);
 
@@ -286,9 +286,9 @@ function conv2dDerInput_<T extends Tensor3D|Tensor4D>(
 
   const dilations = 1;
 
-  const grad = (ddx: Tensor4D, saved: NamedTensorMap) => {
+  const grad = (ddx: Tensor4D, saved: Tensor[]) => {
     const dataFormat = 'NHWC';
-    const {filter, dy4D} = saved;
+    const [filter, dy4D] = saved;
     return {
       dy4D: () => conv2d(
           ddx, filter as Tensor4D, strides, pad, dataFormat, dilations,
@@ -303,7 +303,7 @@ function conv2dDerInput_<T extends Tensor3D|Tensor4D>(
       xShape4D, filter.shape, strides, dilations, pad, dimRoundingMode);
   const res = ENV.engine.runKernel((backend, save) => {
     const res = backend.conv2dDerInput(dy4D, filter, convInfo);
-    save({filter, dy4D});
+    save([filter, dy4D]);
     return res;
   }, {dy4D, filter}, grad);
   if (reshapedTo4D) {
@@ -502,13 +502,13 @@ function depthwiseConv2d_<T extends Tensor3D|Tensor4D>(
       x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode,
       true /* depthwise */);
 
-  const grad = (dy: Tensor4D, saved: NamedTensorMap) => {
+  const grad = (dy: Tensor4D, saved: Tensor[]) => {
     util.assert(
         conv_util.tupleValuesAreOne(dilations),
         () => 'Error in gradient of depthwiseConv2d: dilation rates ' +
             `greater than 1 are not yet supported. Got dilations ` +
             `'${dilations}'`);
-    const {x4D, $filter} = saved;
+    const [x4D, $filter] = saved;
     return {
       x: () => depthwiseConv2dDerInput(
           (x4D as Tensor4D).shape, dy, $filter as Tensor4D, convInfo),
@@ -519,7 +519,7 @@ function depthwiseConv2d_<T extends Tensor3D|Tensor4D>(
 
   const res = ENV.engine.runKernel((backend, save) => {
     const res = backend.depthwiseConv2D(x4D, $filter, convInfo);
-    save({x4D, $filter});
+    save([x4D, $filter]);
     return res;
   }, {x: x4D, $filter}, grad);
   if (reshapedTo4D) {
@@ -766,13 +766,13 @@ function conv3d_<T extends Tensor4D|Tensor5D>(
   const convInfo = conv_util.computeConv3DInfo(
       x5D.shape, $filter.shape, strides, dilations, pad);
 
-  const grad = (dy: Tensor5D, saved: NamedTensorMap) => {
+  const grad = (dy: Tensor5D, saved: Tensor[]) => {
     util.assert(
         tupleValuesAreOne(dilations),
         () =>
             'Error in gradient of conv3D: dilation rates greater than 1 are ' +
             `not yet supported in gradients. Got dilations '${dilations}'`);
-    const {x5D, $filter} = saved;
+    const [x5D, $filter] = saved;
     return {
       x: () => conv3dDerInput_(
           (x5D as Tensor5D).shape, dy, $filter as Tensor5D, strides, pad),
@@ -783,7 +783,7 @@ function conv3d_<T extends Tensor4D|Tensor5D>(
 
   const res = ENV.engine.runKernel((backend, save) => {
     const res = backend.conv3d(x5D, $filter, convInfo);
-    save({x5D, $filter});
+    save([x5D, $filter]);
     return res;
   }, {x: x5D, $filter}, grad);
   if (reshapedTo5D) {

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -189,7 +189,7 @@ function conv2d_<T extends Tensor3D|Tensor4D>(
   const convInfo = conv_util.computeConv2DInfo(
       x4D.shape, $filter.shape, strides, dilations, pad, dimRoundingMode);
 
-  const grad = (dy: Tensor4D, saved: NamedTensorMap) => {
+  const grad = (dy: Tensor4D, saved: {x4D: Tensor4D, $filter: Tensor4D}) => {
     const x4D = saved.x4D as Tensor4D;
     const $filter = saved.$filter as Tensor4D;
     util.assert(

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -18,7 +18,6 @@
 import {ENV} from '../environment';
 import {op} from '../ops/operation';
 import {Tensor, Tensor3D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {makeTypesMatch} from '../tensor_util';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
@@ -101,8 +100,8 @@ function matMul_<T extends Tensor>(
     broadcast_util.assertAndGetBroadcastShape(outShape, $bias.shape);
   }
 
-  const grad = (dy: Tensor3D, saved: NamedTensorMap) => {
-    const {y, a3D, b3D} = saved;
+  const grad = (dy: Tensor3D, saved: Tensor[]) => {
+    const [a3D, b3D, y] = saved;
 
     let dyActivation: Tensor3D;
     if (activation == null || activation === 'linear') {
@@ -172,7 +171,7 @@ function matMul_<T extends Tensor>(
   const res = ENV.engine.runKernel((backend, save) => {
     const y = backend.fusedBatchMatMul(
         a3D, b3D, transposeA, transposeB, $bias, activation);
-    save({a3D, b3D, y});
+    save([a3D, b3D, y]);
     return y;
   }, inputs, grad);
   return res.reshape(outShape) as T;

--- a/src/ops/image_ops.ts
+++ b/src/ops/image_ops.ts
@@ -18,11 +18,11 @@
 import {ForwardFunc} from '../engine';
 import {ENV} from '../environment';
 import {nonMaxSuppressionImpl} from '../kernels/non_max_suppression_impl';
-import {Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
+import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
+
 import {op} from './operation';
 
 /**
@@ -60,16 +60,16 @@ function resizeBilinear_<T extends Tensor3D|Tensor4D>(
 
   const [newHeight, newWidth] = size;
   const forward: ForwardFunc<Tensor4D> = (backend, save) => {
-    save({batchImages});
+    save([batchImages]);
     return backend.resizeBilinear(
         batchImages, newHeight, newWidth, alignCorners);
   };
 
-  const backward = (dy: Tensor4D, saved: NamedTensorMap) => {
+  const backward = (dy: Tensor4D, saved: Tensor[]) => {
     return {
       batchImages: () => ENV.engine.runKernel(
           backend => backend.resizeBilinearBackprop(
-              dy, saved.batchImages as Tensor4D, alignCorners),
+              dy, saved[0] as Tensor4D, alignCorners),
           {})
     };
   };
@@ -120,16 +120,16 @@ function resizeNearestNeighbor_<T extends Tensor3D|Tensor4D>(
   const [newHeight, newWidth] = size;
 
   const forward: ForwardFunc<Tensor4D> = (backend, save) => {
-    save({batchImages});
+    save([batchImages]);
     return backend.resizeNearestNeighbor(
         batchImages, newHeight, newWidth, alignCorners);
   };
 
-  const backward = (dy: Tensor4D, saved: NamedTensorMap) => {
+  const backward = (dy: Tensor4D, saved: Tensor[]) => {
     return {
       batchImages: () => ENV.engine.runKernel(
           backend => backend.resizeNearestNeighborBackprop(
-              dy, saved.batchImages as Tensor4D, alignCorners),
+              dy, saved[0] as Tensor4D, alignCorners),
           {})
     };
   };

--- a/src/ops/logical_ops.ts
+++ b/src/ops/logical_ops.ts
@@ -18,7 +18,6 @@
 import {ENV} from '../environment';
 import {whereImpl} from '../kernels/where_impl';
 import {Tensor, Tensor2D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import {assert, assertShapesMatch} from '../util';
@@ -154,8 +153,8 @@ function where_<T extends Tensor>(
 
   // TODO(julianoks): Return null for condition gradient
   // when backprop supports it.
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$condition} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$condition] = saved;
     return {
       $condition: () => zerosLike($condition).toFloat(),
       $a: () => dy.mul($condition.cast(dy.dtype)) as T,
@@ -165,7 +164,7 @@ function where_<T extends Tensor>(
 
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.select($condition, $a, $b);
-    save({$condition});
+    save([$condition]);
     return res;
   }, {$condition, $a, $b}, grad) as T;
 }

--- a/src/ops/loss_ops.ts
+++ b/src/ops/loss_ops.ts
@@ -17,7 +17,7 @@
 
 import {customGrad} from '../globals';
 import {Tensor} from '../tensor';
-import {GradSaveFunc, NamedTensorMap} from '../tensor_types';
+import {GradSaveFunc} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import {assertShapesMatch} from '../util';
@@ -417,13 +417,13 @@ function softmaxCrossEntropyWithLogits_<T extends Tensor, O extends Tensor>(
         const keepDims = true;
         const lse = logits.logSumExp([dim], keepDims);
         const logResult = logits.toFloat().sub(lse);
-        save({labels, logResult});
+        save([labels, logResult]);
 
         const costVector = logResult.mul(labels).neg();
         const value = costVector.sum([dim]) as O;
 
-        const gradFunc = (dy: O, saved: NamedTensorMap) => {
-          const {labels, logResult} = saved;
+        const gradFunc = (dy: O, saved: Tensor[]) => {
+          const [labels, logResult] = saved;
           const dyShape = expandShapeToKeepDim(dy.shape, [dim]);
           return [
             dy.reshape(dyShape).mul(labels.toFloat().sub(logResult.exp())),

--- a/src/ops/lrn.ts
+++ b/src/ops/lrn.ts
@@ -16,11 +16,11 @@
  */
 
 import {ENV} from '../environment';
-import {Tensor3D, Tensor4D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
+import {Tensor, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
+
 import {op} from './operation';
 
 /**
@@ -55,8 +55,8 @@ function localResponseNormalization_<T extends Tensor3D|Tensor4D>(
     reshapedTo4D = true;
     x4D = $x.as4D(1, $x.shape[0], $x.shape[1], $x.shape[2]);
   }
-  const backward = (dy: Tensor4D, saved: NamedTensorMap) => {
-    const {x4D, y} = saved;
+  const backward = (dy: Tensor4D, saved: Tensor[]) => {
+    const [x4D, y] = saved;
     return {
       x4D: () => ENV.engine.runKernel(
           backend => backend.LRNGrad(
@@ -68,7 +68,7 @@ function localResponseNormalization_<T extends Tensor3D|Tensor4D>(
   const res = ENV.engine.runKernel((backend, save) => {
     const y = backend.localResponseNormalization4D(
         x4D, depthRadius, bias, alpha, beta);
-    save({x4D, y});
+    save([x4D, y]);
     return y;
   }, {x4D}, backward);
   if (reshapedTo4D) {

--- a/src/ops/pool.ts
+++ b/src/ops/pool.ts
@@ -16,11 +16,11 @@
  */
 
 import {ENV} from '../environment';
-import {Tensor3D, Tensor4D} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
+import {Tensor, Tensor3D, Tensor4D} from '../tensor';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
+
 import {batchToSpaceND, spaceToBatchND} from './array_ops';
 import * as conv_util from './conv_util';
 import {op} from './operation';
@@ -82,8 +82,8 @@ function maxPoolImpl_<T extends Tensor3D|Tensor4D>(
   const convInfo = conv_util.computePool2DInfo(
       x4D.shape, filterSize, strides, dilations, pad, dimRoundingMode);
 
-  const grad = (dy: Tensor4D, saved: NamedTensorMap) => {
-    const {x4D, y} = saved;
+  const grad = (dy: Tensor4D, saved: Tensor[]) => {
+    const [x4D, y] = saved;
     return {
       x: () => maxPoolBackprop(
           dy, x4D as Tensor4D, y as Tensor4D, filterSize, strides, dilations,
@@ -93,7 +93,7 @@ function maxPoolImpl_<T extends Tensor3D|Tensor4D>(
 
   const res = ENV.engine.runKernel((backend, save) => {
     const y = backend.maxPool(x4D, convInfo);
-    save({x4D, y});
+    save([x4D, y]);
     return y;
   }, {x: x4D}, grad);
   if (reshapedTo4D) {

--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -18,7 +18,6 @@
 import {ENV} from '../environment';
 import {customGrad} from '../globals';
 import {Tensor} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
@@ -319,11 +318,11 @@ function min_<T extends Tensor>(
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
 
-  const grad = (dy: T, saved: NamedTensorMap) =>
-      gradForMinAndMax(dy, saved.y, saved.xOrig, origAxes, permutedAxes);
+  const grad = (dy: T, saved: Tensor[]) =>
+      gradForMinAndMax(dy, saved[1], saved[0], origAxes, permutedAxes);
   let res = ENV.engine.runKernel((backend, save) => {
     const y = backend.min($x, axes);
-    save({xOrig, y});
+    save([xOrig, y]);
     return y as T;
   }, {$x}, grad);
   if (keepDims) {
@@ -374,11 +373,11 @@ function max_<T extends Tensor>(
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
 
-  const grad = (dy: T, saved: NamedTensorMap) =>
-      gradForMinAndMax(dy, saved.y, saved.xOrig, origAxes, permutedAxes);
+  const grad = (dy: T, saved: Tensor[]) =>
+      gradForMinAndMax(dy, saved[1], saved[0], origAxes, permutedAxes);
   let res = ENV.engine.runKernel((backend, save) => {
     const y = backend.max($x, axes);
-    save({xOrig, y});
+    save([xOrig, y]);
     return y;
   }, {$x}, grad);
   if (keepDims) {
@@ -424,13 +423,13 @@ function argMin_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     $x = $x.transpose(permutedAxes);
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => zerosLike($x)};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.argMin($x, axes[0]);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad) as T;
 }
@@ -470,13 +469,13 @@ function argMax_<T extends Tensor>(x: Tensor|TensorLike, axis = 0): T {
     $x = $x.transpose(permutedAxes);
     axes = axis_util.getInnerMostAxes(axes.length, $x.rank);
   }
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => zerosLike($x)};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.argMax($x, axes[0]);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad) as T;
 }

--- a/src/ops/softmax.ts
+++ b/src/ops/softmax.ts
@@ -17,7 +17,7 @@
 
 import {customGrad} from '../gradients';
 import {Tensor} from '../tensor';
-import {GradSaveFunc, NamedTensorMap} from '../tensor_types';
+import {GradSaveFunc} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import {op} from './operation';
@@ -61,9 +61,9 @@ function softmax_<T extends Tensor>(logits: T|TensorLike, dim = -1): T {
     const lse = logits.logSumExp([dim], keepDims);
     const logResult = logits.toFloat().sub(lse);
     const y = logResult.exp() as T;
-    save({y});
-    const gradFunc = (dy: T, saved: NamedTensorMap) => {
-      const {y} = saved;
+    save([y]);
+    const gradFunc = (dy: T, saved: Tensor[]) => {
+      const [y] = saved;
       const dyTimesY = dy.mul(y);
       const keepDims = true;
       return dyTimesY.sub(dyTimesY.sum([dim], keepDims).mul(y));
@@ -113,9 +113,9 @@ function logSoftmax_<T extends Tensor>(logits: T|TensorLike, axis = -1): T {
     const shifted = logits.sub(xMax);
     const value =
         shifted.toFloat().sub(shifted.exp().sum(axis, keepDims).log()) as T;
-    save({value});
-    const gradFunc = (dy: T, saved: NamedTensorMap) => {
-      const {value} = saved;
+    save([value]);
+    const gradFunc = (dy: T, saved: Tensor[]) => {
+      const [value] = saved;
       const softmax = value.exp();
       return dy.sub(dy.sum(axis, keepDims).mul(softmax));
     };

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../environment';
 import {Tensor} from '../tensor';
-import {NamedTensorMap} from '../tensor_types';
 import {convertToTensor} from '../tensor_util_env';
 import {TensorLike} from '../types';
 import * as util from '../util';
@@ -145,12 +144,12 @@ function round_<T extends Tensor>(x: T|TensorLike): T {
 function exp_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'exp');
 
-  const bck = (dy: T, saved: NamedTensorMap) => {
-    return {$x: () => dy.mulStrict(saved.y as T)};
+  const bck = (dy: T, saved: Tensor[]) => {
+    return {$x: () => dy.mulStrict(saved[0] as T)};
   };
   return ENV.engine.runKernel((backend, save) => {
     const y = backend.exp($x);
-    save({y});
+    save([y]);
     return y;
   }, {$x}, bck);
 }
@@ -170,13 +169,13 @@ function exp_<T extends Tensor>(x: T|TensorLike): T {
 function expm1_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'expm1');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.mul($x.exp()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.expm1($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -195,13 +194,13 @@ function expm1_<T extends Tensor>(x: T|TensorLike): T {
 function log_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'log');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.toFloat()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.log($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -221,13 +220,13 @@ function log_<T extends Tensor>(x: T|TensorLike): T {
 function log1p_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'log1p');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.add(1)) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.log1p($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -246,13 +245,13 @@ function log1p_<T extends Tensor>(x: T|TensorLike): T {
 function sqrt_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'sqrt');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.toFloat().sqrt().mul(2)) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.sqrt($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -272,13 +271,13 @@ function sqrt_<T extends Tensor>(x: T|TensorLike): T {
 function rsqrt_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'rsqrt');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.pow(1.5).mul(2)).neg() as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.rsqrt($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -297,11 +296,12 @@ function rsqrt_<T extends Tensor>(x: T|TensorLike): T {
 function square_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'square');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    return {$x: () => dy.mul(saved.$x.toFloat().mul(2)) as T};
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
+    return {$x: () => dy.mul($x.toFloat().mul(2)) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
-    save({$x});
+    save([$x]);
     return backend.square($x);
   }, {$x}, grad);
 }
@@ -320,13 +320,13 @@ function square_<T extends Tensor>(x: T|TensorLike): T {
 function reciprocal_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'reciprocal');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.square().neg()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.reciprocal($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -349,13 +349,13 @@ function abs_<T extends Tensor>(x: T|TensorLike): T {
     return ENV.engine.runKernel(backend => backend.complexAbs($x), {$x});
   }
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.mul($x.toFloat().step(-1)) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.abs($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -381,8 +381,8 @@ function clipByValue_<T extends Tensor>(
       () => `Error in clip: min (${clipValueMin}) must be ` +
           `less than or equal to max (${clipValueMax}).`);
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {
       $x: () => dy.where(
                     $x.greaterEqual(clipValueMin)
@@ -392,7 +392,7 @@ function clipByValue_<T extends Tensor>(
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.clip($x, clipValueMin, clipValueMax);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -411,13 +411,13 @@ function clipByValue_<T extends Tensor>(
 function sigmoid_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'sigmoid');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const y = saved.y;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [y] = saved;
     return {$x: () => dy.mul(y.mul(scalar(1).sub(y))) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const y = backend.sigmoid($x);
-    save({y});
+    save([y]);
     return y;
   }, {$x}, grad);
 }
@@ -437,13 +437,13 @@ function sigmoid_<T extends Tensor>(x: T|TensorLike): T {
 function logSigmoid_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'logSigmoid');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.mul($x.neg().sigmoid()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.softplus($x.neg()).neg();
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -462,13 +462,13 @@ function logSigmoid_<T extends Tensor>(x: T|TensorLike): T {
 function softplus_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'softplus');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.mul($x.sigmoid()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.softplus($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -487,13 +487,13 @@ function softplus_<T extends Tensor>(x: T|TensorLike): T {
 function sin_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'sin');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => $x.toFloat().cos().mul(dy) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.sin($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -512,13 +512,13 @@ function sin_<T extends Tensor>(x: T|TensorLike): T {
 function cos_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'cos');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => $x.toFloat().sin().neg().mul(dy) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.cos($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -537,13 +537,13 @@ function cos_<T extends Tensor>(x: T|TensorLike): T {
 function tan_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'tan');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.cos().square()) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.tan($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -562,15 +562,15 @@ function tan_<T extends Tensor>(x: T|TensorLike): T {
 function asin_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'asin');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {
       $x: () => dy.divStrict(scalar(1).sub($x.toFloat().square()).sqrt() as T)
     };
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.asin($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -589,8 +589,8 @@ function asin_<T extends Tensor>(x: T|TensorLike): T {
 function acos_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'acos');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {
       $x: () =>
           dy.divStrict(scalar(1).sub($x.toFloat().square()).sqrt() as T).neg()
@@ -598,7 +598,7 @@ function acos_<T extends Tensor>(x: T|TensorLike): T {
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.acos($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -617,13 +617,13 @@ function acos_<T extends Tensor>(x: T|TensorLike): T {
 function atan_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'atan');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div($x.toFloat().square().add(1)) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.atan($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -642,13 +642,13 @@ function atan_<T extends Tensor>(x: T|TensorLike): T {
 function sinh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'sinh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => $x.toFloat().cosh().mulStrict(dy) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.sinh($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -667,13 +667,13 @@ function sinh_<T extends Tensor>(x: T|TensorLike): T {
 function cosh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'cosh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => $x.toFloat().sinh().mulStrict(dy) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.cosh($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -692,13 +692,13 @@ function cosh_<T extends Tensor>(x: T|TensorLike): T {
 function tanh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'tanh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const y = saved.y;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [y] = saved;
     return {$x: () => scalar(1).sub(y.square()).mulStrict(dy) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const y = backend.tanh($x);
-    save({y});
+    save([y]);
     return y;
   }, {$x}, grad);
 }
@@ -718,15 +718,15 @@ function tanh_<T extends Tensor>(x: T|TensorLike): T {
 function asinh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'asinh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {
       $x: () => dy.divStrict(scalar(1).add($x.toFloat().square()).sqrt() as T)
     };
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.asinh($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -746,13 +746,13 @@ function asinh_<T extends Tensor>(x: T|TensorLike): T {
 function acosh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'acosh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.divStrict($x.toFloat().square().sub(1).sqrt() as T)};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.acosh($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -772,13 +772,13 @@ function acosh_<T extends Tensor>(x: T|TensorLike): T {
 function atanh_<T extends Tensor>(x: T|TensorLike): T {
   const $x = convertToTensor(x, 'x', 'atanh');
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {$x: () => dy.div(scalar(1).sub($x.toFloat().square())) as T};
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.atanh($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }
@@ -805,15 +805,15 @@ function erf_<T extends Tensor>(x: T|TensorLike): T {
     $x = $x.toFloat();
   }
 
-  const grad = (dy: T, saved: NamedTensorMap) => {
-    const {$x} = saved;
+  const grad = (dy: T, saved: Tensor[]) => {
+    const [$x] = saved;
     return {
       $x: () => dy.mul($x.square().neg().exp().mul(2 / Math.sqrt(Math.PI))) as T
     };
   };
   return ENV.engine.runKernel((backend, save) => {
     const res = backend.erf($x);
-    save({$x});
+    save([$x]);
     return res;
   }, {$x}, grad);
 }

--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -110,16 +110,16 @@ export class AdadeltaOptimizer extends Optimizer {
   }
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      rho: this.rho,
-      epsilon: this.epsilon
+      'learningRate': this.learningRate,
+      'rho': this.rho,
+      'epsilon': this.epsilon
     };
   }
 
   /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
-    return new cls(config.learningRate, config.rho, config.epsilon);
+    return new cls(config['learningRate'], config['rho'], config['epsilon']);
   }
 }
 registerClass(AdadeltaOptimizer);

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -78,15 +78,15 @@ export class AdagradOptimizer extends Optimizer {
   }
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      initialAccumulatorValue: this.initialAccumulatorValue,
+      'learningRate': this.learningRate,
+      'initialAccumulatorValue': this.initialAccumulatorValue,
     };
   }
 
   /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
-    return new cls(config.learningRate, config.initialAccumulatorValue);
+    return new cls(config['learningRate'], config['initialAccumulatorValue']);
   }
 }
 registerClass(AdagradOptimizer);

--- a/src/optimizers/adam_optimizer.ts
+++ b/src/optimizers/adam_optimizer.ts
@@ -133,10 +133,10 @@ export class AdamOptimizer extends Optimizer {
   }
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      beta1: this.beta1,
-      beta2: this.beta2,
-      epsilon: this.epsilon,
+      'learningRate': this.learningRate,
+      'beta1': this.beta1,
+      'beta2': this.beta2,
+      'epsilon': this.epsilon,
     };
   }
 
@@ -144,7 +144,8 @@ export class AdamOptimizer extends Optimizer {
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(
-        config.learningRate, config.beta1, config.beta2, config.epsilon);
+        config['learningRate'], config['beta1'], config['beta2'],
+        config['epsilon']);
   }
 }
 registerClass(AdamOptimizer);

--- a/src/optimizers/adamax_optimizer.ts
+++ b/src/optimizers/adamax_optimizer.ts
@@ -139,11 +139,11 @@ export class AdamaxOptimizer extends Optimizer {
   }
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      beta1: this.beta1,
-      beta2: this.beta2,
-      epsilon: this.epsilon,
-      decay: this.decay
+      'learningRate': this.learningRate,
+      'beta1': this.beta1,
+      'beta2': this.beta2,
+      'epsilon': this.epsilon,
+      'decay': this.decay
     };
   }
 
@@ -151,8 +151,8 @@ export class AdamaxOptimizer extends Optimizer {
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(
-        config.learningRate, config.beta1, config.beta2, config.epsilon,
-        config.decay);
+        config['learningRate'], config['beta1'], config['beta2'],
+        config['epsilon'], config['decay']);
   }
 }
 registerClass(AdamaxOptimizer);

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -88,16 +88,17 @@ export class MomentumOptimizer extends SGDOptimizer {
 
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      momentum: this.momentum,
-      useNesterov: this.useNesterov
+      'learningRate': this.learningRate,
+      'momentum': this.momentum,
+      'useNesterov': this.useNesterov
     };
   }
 
   /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
-    return new cls(config.learningRate, config.momentum, config.useNesterov);
+    return new cls(
+        config['learningRate'], config['momentum'], config['useNesterov']);
   }
 }
 registerClass(MomentumOptimizer);

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -158,11 +158,11 @@ export class RMSPropOptimizer extends Optimizer {
 
   getConfig(): ConfigDict {
     return {
-      learningRate: this.learningRate,
-      decay: this.decay,
-      momentum: this.momentum,
-      epsilon: this.epsilon,
-      centered: this.centered
+      'learningRate': this.learningRate,
+      'decay': this.decay,
+      'momentum': this.momentum,
+      'epsilon': this.epsilon,
+      'centered': this.centered
     };
   }
 
@@ -170,8 +170,8 @@ export class RMSPropOptimizer extends Optimizer {
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
     return new cls(
-        config.learningRate, config.decay, config.momentum, config.epsilon,
-        config.centered);
+        config['learningRate'], config['decay'], config['momentum'],
+        config['epsilon'], config['centered']);
   }
 }
 registerClass(RMSPropOptimizer);

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -63,13 +63,13 @@ export class SGDOptimizer extends Optimizer {
   }
 
   getConfig(): ConfigDict {
-    return {learningRate: this.learningRate};
+    return {'learningRate': this.learningRate};
   }
 
   /** @nocollapse */
   static fromConfig<T extends Serializable>(
       cls: SerializableConstructor<T>, config: ConfigDict): T {
-    return new cls(config.learningRate);
+    return new cls(config['learningRate']);
   }
 }
 registerClass(SGDOptimizer);

--- a/src/tape.ts
+++ b/src/tape.ts
@@ -26,7 +26,7 @@ export interface TapeNode {
   inputs: NamedTensorMap;
   // Optional params, defined only for ops with gradient impl.
   gradient?: (dy: Tensor|Tensor[]) => NamedGradientMap;
-  saved?: NamedTensorMap;
+  saved?: Tensor[];
 }
 
 export type NamedGradientMap = {

--- a/src/tensor_types.ts
+++ b/src/tensor_types.ts
@@ -27,7 +27,7 @@ export type NamedVariableMap = {
   [name: string]: Variable;
 };
 
-export type GradSaveFunc = (map: NamedTensorMap) => void;
+export type GradSaveFunc = (save: Tensor[]) => void;
 
 /**
  * @docalias void|number|string|TypedArray|Tensor|Tensor[]|{[key:

--- a/src/tensor_types.ts
+++ b/src/tensor_types.ts
@@ -20,7 +20,7 @@ import {DataType} from './types';
 
 /** @docalias {[name: string]: Tensor} */
 export type NamedTensorMap = {
-  [name: string]: Tensor
+  [name: string]: Tensor;
 };
 
 export type NamedVariableMap = {


### PR DESCRIPTION
This makes Google Closure happy because index types cannot be accessed with a property accessor.

Also update property accessor that have string index types to use string indexing (also to make closure happy).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1644)
<!-- Reviewable:end -->
