### PR TITLE
Fix windows tests and enable browserstack on windows

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -105,6 +105,13 @@ module.exports = function(config) {
         os_version: '11.0',
         real_mobile: true
       },
+      win_10_chrome: {
+        base: 'BrowserStack',
+        browser: 'chrome',
+        browser_version: 'latest',
+        os: 'Windows',
+        os_version: '10'
+      },
       chrome_with_swift_shader: {
         base: 'Chrome',
         flags: ['--blacklist-accelerated-compositing', '--blacklist-webgl']

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -24,7 +24,8 @@ yarn test-node
 if [[ $(node -v) = *v10* ]]; then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  #yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  yarn run-browserstack --browsers=win_10_chrome --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -24,8 +24,9 @@ yarn test-node
 if [[ $(node -v) = *v10* ]]; then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-  #yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+
   yarn run-browserstack --browsers=win_10_chrome --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+  yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -24,14 +24,13 @@ yarn test-node
 if [[ $(node -v) = *v10* ]]; then
   # Run the first karma separately so it can download the BrowserStack binary
   # without conflicting with others.
-
-  yarn run-browserstack --browsers=win_10_chrome --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
   yarn run-browserstack --browsers=bs_safari_mac --backend webgl --features '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
   # Run the rest of the karma tests in parallel. These runs will reuse the
   # already downloaded binary.
   npm-run-all -p -c --aggregate-output \
     "run-browserstack --browsers=bs_safari_mac --features '{\"HAS_WEBGL\": false}' --backend cpu" \
+    "run-browserstack --browsers=win_10_chrome --backend webgl --features '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
     "run-browserstack --browsers=bs_ios_11 --backend webgl --features '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
     "run-browserstack --browsers=bs_ios_11 --features '{\"HAS_WEBGL\": false}' --backend cpu" \
     "run-browserstack --browsers=bs_firefox_mac" \

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -24,10 +24,10 @@ import {TensorContainer} from './tensor_types';
 import {getTensorsInContainer} from './tensor_util';
 
 export const EPSILON_FLOAT16 = 1e-4;
-const TEST_EPSILON_FLOAT16 = 1e-1;
+export const TEST_EPSILON_FLOAT16 = 1e-1;
 
 export const EPSILON_FLOAT32 = 1e-7;
-const TEST_EPSILON_FLOAT32 = 1e-3;
+export const TEST_EPSILON_FLOAT32 = 1e-3;
 
 export class Environment {
   private features: Features = {};

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import { GPGPUContext } from './gpgpu_context';
-import { GPGPUProgram } from './gpgpu_math';
+import {GPGPUContext} from './gpgpu_context';
+import {GPGPUProgram} from './gpgpu_math';
 
 export class ClipPackedProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/clip_packed_gpu.ts
+++ b/src/kernels/webgl/clip_packed_gpu.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
-import {GPGPUContext} from './gpgpu_context';
-import {GPGPUProgram} from './gpgpu_math';
+import { GPGPUContext } from './gpgpu_context';
+import { GPGPUProgram } from './gpgpu_math';
 
 export class ClipPackedProgram implements GPGPUProgram {
   variableNames = ['A'];

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {ENV} from '../../environment';
+import { ENV } from '../../environment';
 
 export type GLSL = {
   version: string,
@@ -52,6 +52,13 @@ export function getGlslDifferences(): GLSL {
     defineOutput = 'out vec4 outputColor;';
     defineSpecialNaN = `
       const float NAN = uintBitsToFloat(uint(0x7fc00000));
+      #define isnan(value) newIsNan(value)
+      bool newIsNan(float val) {
+        return (val > 0. || val < 0. || val == 0.) ? false : true;
+      }
+      bvec4 newIsNan(vec4 val) {
+        return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
+      }
     `;
     defineSpecialInf = `
       const float INFINITY = uintBitsToFloat(uint(0x7f800000));

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import { ENV } from '../../environment';
+import {ENV} from '../../environment';
 
 export type GLSL = {
   version: string,

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -25,6 +25,7 @@ export type GLSL = {
   texture2D: string,
   output: string,
   defineOutput: string,
+  defineSpecialNaN: string,
   defineSpecialInf: string,
   defineRound: string
 };
@@ -37,6 +38,7 @@ export function getGlslDifferences(): GLSL {
   let texture2D: string;
   let output: string;
   let defineOutput: string;
+  let defineSpecialNaN: string;
   let defineSpecialInf: string;
   let defineRound: string;
 
@@ -48,6 +50,11 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture';
     output = 'outputColor';
     defineOutput = 'out vec4 outputColor;';
+    defineSpecialNaN = `
+      bool isnan_custom(float val) {
+        return (val > 0. || val < 0. || val == 0.) ? false : true;
+      }
+    `;
     defineSpecialInf = `
       const float INFINITY = uintBitsToFloat(uint(0x7f800000));
     `;
@@ -69,6 +76,11 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture2D';
     output = 'gl_FragColor';
     defineOutput = '';
+    defineSpecialNaN = `
+      bool isnan_custom(float val) {
+        return (val > 0. || val < 1. || val == 0.) ? false : true;
+      }
+    `;
     defineSpecialInf = `
       uniform float INFINITY;
 
@@ -98,6 +110,7 @@ export function getGlslDifferences(): GLSL {
     texture2D,
     output,
     defineOutput,
+    defineSpecialNaN,
     defineSpecialInf,
     defineRound
   };

--- a/src/kernels/webgl/glsl_version.ts
+++ b/src/kernels/webgl/glsl_version.ts
@@ -25,7 +25,6 @@ export type GLSL = {
   texture2D: string,
   output: string,
   defineOutput: string,
-  defineSpecialNaN: string,
   defineSpecialInf: string,
   defineRound: string
 };
@@ -38,7 +37,6 @@ export function getGlslDifferences(): GLSL {
   let texture2D: string;
   let output: string;
   let defineOutput: string;
-  let defineSpecialNaN: string;
   let defineSpecialInf: string;
   let defineRound: string;
 
@@ -50,16 +48,6 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture';
     output = 'outputColor';
     defineOutput = 'out vec4 outputColor;';
-    defineSpecialNaN = `
-      const float NAN = uintBitsToFloat(uint(0x7fc00000));
-      #define isnan(value) newIsNan(value)
-      bool newIsNan(float val) {
-        return (val > 0. || val < 0. || val == 0.) ? false : true;
-      }
-      bvec4 newIsNan(vec4 val) {
-        return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
-      }
-    `;
     defineSpecialInf = `
       const float INFINITY = uintBitsToFloat(uint(0x7f800000));
     `;
@@ -81,16 +69,6 @@ export function getGlslDifferences(): GLSL {
     texture2D = 'texture2D';
     output = 'gl_FragColor';
     defineOutput = '';
-    defineSpecialNaN = `
-      uniform float NAN;
-
-      bool isnan(float val) {
-        return (val < 1.0 || 0.0 < val || val == 0.0) ? false : true;
-      }
-      bvec4 isnan(vec4 val) {
-        return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
-      }
-    `;
     defineSpecialInf = `
       uniform float INFINITY;
 
@@ -120,7 +98,6 @@ export function getGlslDifferences(): GLSL {
     texture2D,
     output,
     defineOutput,
-    defineSpecialNaN,
     defineSpecialInf,
     defineRound
   };

--- a/src/kernels/webgl/gpgpu_math.ts
+++ b/src/kernels/webgl/gpgpu_math.ts
@@ -87,10 +87,9 @@ export function compileProgram<T extends Tensor, K extends Tensor>(
 
   // Add special uniforms (NAN, INFINITY)
   let infLoc: WebGLUniformLocation = null;
-  let nanLoc: WebGLUniformLocation = null;
+  const nanLoc = gpgpu.getUniformLocation(webGLProgram, 'NAN', false);
   if (ENV.get('WEBGL_VERSION') === 1) {
     infLoc = gpgpu.getUniformLocation(webGLProgram, 'INFINITY', false);
-    nanLoc = gpgpu.getUniformLocation(webGLProgram, 'NAN', false);
   }
 
   // Add user-defined uniforms
@@ -171,9 +170,9 @@ export function runProgram<T extends Tensor, K extends Tensor>(
     if (binary.infLoc !== null) {
       gpgpu.gl.uniform1f(binary.infLoc, Infinity);
     }
-    if (binary.nanLoc !== null) {
-      gpgpu.gl.uniform1f(binary.nanLoc, NaN);
-    }
+  }
+  if (binary.nanLoc !== null) {
+    gpgpu.gl.uniform1f(binary.nanLoc, NaN);
   }
 
   // Set user-defined inputs

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -244,9 +244,7 @@ function getShaderPrefix(glsl: GLSL): string {
 
     uniform float NAN;
     #define isnan(value) isnan_custom(value)
-    bool isnan_custom(float val) {
-      return (val > 0. || val < 0. || val == 0.) ? false : true;
-    }
+    ${glsl.defineSpecialNaN}
     bvec4 isnan_custom(vec4 val) {
       return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
     }

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -249,7 +249,6 @@ function getShaderPrefix(glsl: GLSL): string {
       return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
     }
 
-
     ${glsl.defineSpecialInf}
     ${glsl.defineRound}
 

--- a/src/kernels/webgl/shader_compiler.ts
+++ b/src/kernels/webgl/shader_compiler.ts
@@ -242,7 +242,16 @@ function getShaderPrefix(glsl: GLSL): string {
       int v;
     };
 
-    ${glsl.defineSpecialNaN}
+    uniform float NAN;
+    #define isnan(value) isnan_custom(value)
+    bool isnan_custom(float val) {
+      return (val > 0. || val < 0. || val == 0.) ? false : true;
+    }
+    bvec4 isnan_custom(vec4 val) {
+      return bvec4(isnan(val.x), isnan(val.y), isnan(val.z), isnan(val.w));
+    }
+
+
     ${glsl.defineSpecialInf}
     ${glsl.defineRound}
 

--- a/src/ops/arithmetic_test.ts
+++ b/src/ops/arithmetic_test.ts
@@ -674,7 +674,7 @@ describeWithFlags('pow', ALL_ENVS, () => {
 
     expect(result.shape).toEqual([3]);
     expect(result.dtype).toBe('float32');
-    expectArraysEqual(result, [1, 4, 9]);
+    expectArraysClose(result, [1, 4, 9]);
   });
 
   it('TensorLike chained', () => {
@@ -685,7 +685,7 @@ describeWithFlags('pow', ALL_ENVS, () => {
 
     expect(result.shape).toEqual([3]);
     expect(result.dtype).toBe('float32');
-    expectArraysEqual(result, [1, 4, 9]);
+    expectArraysClose(result, [1, 4, 9]);
   });
 
   it('int32^int32 returns int32', () => {
@@ -953,7 +953,7 @@ describeWithFlags('pow', ALL_ENVS, () => {
 
     expect(result.shape).toEqual([3]);
     expect(result.dtype).toBe('float32');
-    expectArraysEqual(result, [1, 4, 9]);
+    expectArraysClose(result, [1, 4, 9]);
   });
 
   it('negative base and whole exponent not NaN', () => {

--- a/src/ops/browser.ts
+++ b/src/ops/browser.ts
@@ -93,8 +93,10 @@ export async function toPixels(
 
   const minTensor = $img.min();
   const maxTensor = $img.max();
-  const min = (await minTensor.data())[0];
-  const max = (await maxTensor.data())[0];
+  const [data, minVals, maxVals] =
+      await Promise.all([$img.data(), minTensor.data(), maxTensor.data()]);
+  const min = minVals[0];
+  const max = maxVals[0];
   minTensor.dispose();
   maxTensor.dispose();
   if ($img.dtype === 'float32') {
@@ -114,8 +116,6 @@ export async function toPixels(
         `Unsupported type for toPixels: ${$img.dtype}.` +
         ` Please use float32 or int32 tensors.`);
   }
-
-  const data = await $img.data();
   const multiplier = $img.dtype === 'float32' ? 255 : 1;
   const bytes = new Uint8ClampedArray(width * height * 4);
 

--- a/src/ops/browser.ts
+++ b/src/ops/browser.ts
@@ -91,10 +91,11 @@ export async function toPixels(
         `1, 3 or 4 but got ${depth}`);
   }
 
+  const data = await $img.data();
   const minTensor = $img.min();
   const maxTensor = $img.max();
-  const [data, minVals, maxVals] =
-      await Promise.all([$img.data(), minTensor.data(), maxTensor.data()]);
+  const [minVals, maxVals] =
+      await Promise.all([minTensor.data(), maxTensor.data()]);
   const min = minVals[0];
   const max = maxVals[0];
   minTensor.dispose();

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-import { ENV } from '../environment';
+import {ENV} from '../environment';
 import * as tf from '../index';
-import { describeWithFlags } from '../jasmine_util';
-import { ALL_ENVS, expectArraysClose, PACKED_ENVS, WEBGL_ENVS } from '../test_util';
+import {describeWithFlags} from '../jasmine_util';
+import {ALL_ENVS, expectArraysClose, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
 import * as util from '../util';
 
 import * as selu_util from './selu_util';
@@ -117,7 +117,7 @@ describeWithFlags('relu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.relu({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'relu' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'relu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -127,7 +127,7 @@ describeWithFlags('relu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.relu('q'))
-      .toThrowError(/Argument 'x' passed to 'relu' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'relu' must be numeric/);
   });
 });
 
@@ -186,8 +186,8 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('complex64 rank-3', () => {
     const a = tf.complex(
-      [[[-3, -2], [-1, 0]], [[1, 2], [3, 4]]],
-      [[[4, 1], [2, 3]], [[0, -1], [-3, -4]]]);
+        [[[-3, -2], [-1, 0]], [[1, 2], [3, 4]]],
+        [[[4, 1], [2, 3]], [[0, -1], [-3, -4]]]);
     const result = tf.abs(a);
     expectArraysClose(result, [
       Math.sqrt(-3 * -3 + 4 * 4), Math.sqrt(-2 * -2 + 1 * 1),
@@ -210,17 +210,17 @@ describeWithFlags('abs', ALL_ENVS, () => {
         break;
       default:
         throw new Error(`Test not implemented for ENV.engine.floatPrecision()=${
-          floatBits}.`);
+            floatBits}.`);
     }
 
     const a = tf.complex([small, 0, small, 0], [small, small, 0, 0]);
     const result = tf.abs(a);
     expectArraysClose(
-      result,
-      [
-        Math.hypot(small, small), Math.hypot(0, small), Math.hypot(small, 0),
-        Math.hypot(0, 0)
-      ],
+        result,
+        [
+          Math.hypot(small, small), Math.hypot(0, small), Math.hypot(small, 0),
+          Math.hypot(0, 0)
+        ],
         /*tolerance=*/small / 100);
     expect(result.shape).toEqual([4]);
   });
@@ -276,7 +276,7 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.abs({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'abs' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'abs' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -286,7 +286,7 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.abs('q'))
-      .toThrowError(/Argument 'x' passed to 'abs' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'abs' must be numeric/);
   });
 });
 
@@ -362,7 +362,7 @@ describeWithFlags('step', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.step({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'step' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'step' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -372,7 +372,7 @@ describeWithFlags('step', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.step('q'))
-      .toThrowError(/Argument 'x' passed to 'step' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'step' must be numeric/);
   });
 });
 
@@ -436,7 +436,7 @@ describeWithFlags('neg', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.neg({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'neg' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'neg' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -446,7 +446,7 @@ describeWithFlags('neg', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.neg('q'))
-      .toThrowError(/Argument 'x' passed to 'neg' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'neg' must be numeric/);
   });
 });
 
@@ -517,7 +517,7 @@ describeWithFlags('sigmoid', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sigmoid({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'sigmoid' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'sigmoid' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -533,7 +533,7 @@ describeWithFlags('sigmoid', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sigmoid('q'))
-      .toThrowError(/Argument 'x' passed to 'sigmoid' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'sigmoid' must be numeric/);
   });
 });
 
@@ -663,7 +663,7 @@ describeWithFlags('logSigmoid', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.logSigmoid({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'logSigmoid' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'logSigmoid' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -674,7 +674,7 @@ describeWithFlags('logSigmoid', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.logSigmoid('q'))
-      .toThrowError(/Argument 'x' passed to 'logSigmoid' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'logSigmoid' must be numeric/);
   });
 });
 
@@ -802,7 +802,7 @@ describeWithFlags('softplus', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.softplus({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'softplus' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'softplus' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -813,7 +813,7 @@ describeWithFlags('softplus', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.softplus('q'))
-      .toThrowError(/Argument 'x' passed to 'softplus' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'softplus' must be numeric/);
   });
 });
 
@@ -861,12 +861,12 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        1 / (2 * Math.sqrt(1)), 2 / (2 * Math.sqrt(2)),
-        3 / (2 * Math.sqrt(3)), 4 / (2 * Math.sqrt(5))
-      ],
-      1e-1);
+        gradients,
+        [
+          1 / (2 * Math.sqrt(1)), 2 / (2 * Math.sqrt(2)),
+          3 / (2 * Math.sqrt(3)), 4 / (2 * Math.sqrt(5))
+        ],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -878,17 +878,17 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        1 / (2 * Math.sqrt(3)), 2 / (2 * Math.sqrt(1)),
-        3 / (2 * Math.sqrt(2)), 4 / (2 * Math.sqrt(3))
-      ],
-      1e-1);
+        gradients,
+        [
+          1 / (2 * Math.sqrt(3)), 2 / (2 * Math.sqrt(1)),
+          3 / (2 * Math.sqrt(2)), 4 / (2 * Math.sqrt(3))
+        ],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sqrt({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'sqrt' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'sqrt' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -898,7 +898,7 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sqrt('q'))
-      .toThrowError(/Argument 'x' passed to 'sqrt' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'sqrt' must be numeric/);
   });
 });
 
@@ -946,12 +946,12 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        -1 * 1 / (2 * Math.pow(1, 1.5)), -1 * 2 / (2 * Math.pow(2, 1.5)),
-        -1 * 3 / (2 * Math.pow(3, 1.5)), -1 * 4 / (2 * Math.pow(5, 1.5))
-      ],
-      1e-1);
+        gradients,
+        [
+          -1 * 1 / (2 * Math.pow(1, 1.5)), -1 * 2 / (2 * Math.pow(2, 1.5)),
+          -1 * 3 / (2 * Math.pow(3, 1.5)), -1 * 4 / (2 * Math.pow(5, 1.5))
+        ],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -963,17 +963,17 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        -1 * 1 / (2 * Math.pow(3, 1.5)), -1 * 2 / (2 * Math.pow(1, 1.5)),
-        -1 * 3 / (2 * Math.pow(2, 1.5)), -1 * 4 / (2 * Math.pow(3, 1.5))
-      ],
-      1e-1);
+        gradients,
+        [
+          -1 * 1 / (2 * Math.pow(3, 1.5)), -1 * 2 / (2 * Math.pow(1, 1.5)),
+          -1 * 3 / (2 * Math.pow(2, 1.5)), -1 * 4 / (2 * Math.pow(3, 1.5))
+        ],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.rsqrt({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'rsqrt' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'rsqrt' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -983,7 +983,7 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.rsqrt('q'))
-      .toThrowError(/Argument 'x' passed to 'rsqrt' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'rsqrt' must be numeric/);
   });
 });
 
@@ -1010,8 +1010,8 @@ describeWithFlags('square', ALL_ENVS, () => {
 
   it('6D array', () => {
     const a = tf.tensor6d(
-      [1, 2, Math.sqrt(2), Math.sqrt(3), 3, 4, Math.sqrt(7), Math.sqrt(13)],
-      [1, 1, 2, 2, 2, 1]);
+        [1, 2, Math.sqrt(2), Math.sqrt(3), 3, 4, Math.sqrt(7), Math.sqrt(13)],
+        [1, 1, 2, 2, 2, 1]);
     const r = tf.square(a);
     expect(r.shape).toEqual(a.shape);
     expectArraysClose(r, [1, 4, 2, 3, 9, 16, 7, 13]);
@@ -1087,13 +1087,13 @@ describeWithFlags('square', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [-6 * 1, 2 * 2, 4 * 3, 6 * 4, -8 * 5, 10 * 6, 24 * 7, 6 * 8]);
+        gradients,
+        [-6 * 1, 2 * 2, 4 * 3, 6 * 4, -8 * 5, 10 * 6, 24 * 7, 6 * 8]);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.square({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'square' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'square' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1103,7 +1103,7 @@ describeWithFlags('square', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.square('q'))
-      .toThrowError(/Argument 'x' passed to 'square' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'square' must be numeric/);
   });
 });
 
@@ -1179,7 +1179,7 @@ describeWithFlags('reciprocal', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.reciprocal({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'reciprocal' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'reciprocal' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1189,7 +1189,7 @@ describeWithFlags('reciprocal', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.reciprocal('q'))
-      .toThrowError(/Argument 'x' passed to 'reciprocal' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'reciprocal' must be numeric/);
   });
 });
 
@@ -1264,7 +1264,7 @@ describeWithFlags('log', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.log({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'log' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'log' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1274,7 +1274,7 @@ describeWithFlags('log', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.log('q'))
-      .toThrowError(/Argument 'x' passed to 'log' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'log' must be numeric/);
   });
 });
 
@@ -1319,7 +1319,7 @@ describeWithFlags('log1p', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients, [Infinity, 2 / (1 + 2), 3 / (1 + 3), 4 / (1 + -5)]);
+        gradients, [Infinity, 2 / (1 + 2), 3 / (1 + 3), 4 / (1 + -5)]);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1331,12 +1331,12 @@ describeWithFlags('log1p', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients, [1 / (1 + -3), 2 / (1 + 1), 3 / (1 + 2), 4 / (1 + 3)]);
+        gradients, [1 / (1 + -3), 2 / (1 + 1), 3 / (1 + 2), 4 / (1 + 3)]);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.log1p({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'log1p' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'log1p' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1346,7 +1346,7 @@ describeWithFlags('log1p', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.log1p('q'))
-      .toThrowError(/Argument 'x' passed to 'log1p' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'log1p' must be numeric/);
   });
 });
 
@@ -1409,7 +1409,7 @@ describeWithFlags('ceil', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.ceil({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'ceil' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'ceil' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1419,7 +1419,7 @@ describeWithFlags('ceil', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.ceil('q'))
-      .toThrowError(/Argument 'x' passed to 'ceil' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'ceil' must be numeric/);
   });
 });
 
@@ -1483,7 +1483,7 @@ describeWithFlags('floor', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.floor({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'floor' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'floor' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1493,7 +1493,7 @@ describeWithFlags('floor', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.floor('q'))
-      .toThrowError(/Argument 'x' passed to 'floor' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'floor' must be numeric/);
   });
 });
 
@@ -1556,7 +1556,7 @@ describeWithFlags('sign', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sign({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'sign' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'sign' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1566,7 +1566,7 @@ describeWithFlags('sign', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sign('q'))
-      .toThrowError(/Argument 'x' passed to 'sign' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'sign' must be numeric/);
   });
 });
 
@@ -1613,7 +1613,7 @@ describeWithFlags('isNaN', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isNaN({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'isNaN' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'isNaN' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1623,7 +1623,7 @@ describeWithFlags('isNaN', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isNaN('q'))
-      .toThrowError(/Argument 'x' passed to 'isNaN' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'isNaN' must be numeric/);
   });
 });
 
@@ -1670,7 +1670,7 @@ describeWithFlags('isInf', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isInf({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'isInf' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'isInf' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1680,7 +1680,7 @@ describeWithFlags('isInf', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isInf('q'))
-      .toThrowError(/Argument 'x' passed to 'isInf' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'isInf' must be numeric/);
   });
 });
 
@@ -1727,7 +1727,7 @@ describeWithFlags('isFinite', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isFinite({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'isFinite' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'isFinite' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1737,7 +1737,7 @@ describeWithFlags('isFinite', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isFinite('q'))
-      .toThrowError(/Argument 'x' passed to 'isFinite' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'isFinite' must be numeric/);
   });
 });
 
@@ -1786,9 +1786,9 @@ describeWithFlags('exp', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
-      1e-1);
+        gradients,
+        [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1800,14 +1800,14 @@ describeWithFlags('exp', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
-      1e-1);
+        gradients,
+        [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.exp({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'exp' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'exp' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1817,7 +1817,7 @@ describeWithFlags('exp', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.exp('q'))
-      .toThrowError(/Argument 'x' passed to 'exp' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'exp' must be numeric/);
   });
 });
 
@@ -1866,9 +1866,9 @@ describeWithFlags('expm1', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
-      1e-1);
+        gradients,
+        [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1880,14 +1880,14 @@ describeWithFlags('expm1', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
-      1e-1);
+        gradients,
+        [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.expm1({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'expm1' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'expm1' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1898,7 +1898,7 @@ describeWithFlags('expm1', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.expm1('q'))
-      .toThrowError(/Argument 'x' passed to 'expm1' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'expm1' must be numeric/);
   });
 });
 
@@ -1952,9 +1952,9 @@ describeWithFlags('sin', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.cos(-1), 2 * Math.cos(2), 3 * Math.cos(3), 4 * Math.cos(-5)],
-      1e-1);
+        gradients,
+        [1 * Math.cos(-1), 2 * Math.cos(2), 3 * Math.cos(3), 4 * Math.cos(-5)],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1966,14 +1966,14 @@ describeWithFlags('sin', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [1 * Math.cos(-3), 2 * Math.cos(1), 3 * Math.cos(2), 4 * Math.cos(3)],
-      1e-1);
+        gradients,
+        [1 * Math.cos(-3), 2 * Math.cos(1), 3 * Math.cos(2), 4 * Math.cos(3)],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sin({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'sin' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'sin' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1989,7 +1989,7 @@ describeWithFlags('sin', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sin('q'))
-      .toThrowError(/Argument 'x' passed to 'sin' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'sin' must be numeric/);
   });
 });
 
@@ -2043,12 +2043,12 @@ describeWithFlags('cos', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        1 * Math.sin(-1) * -1, 2 * Math.sin(2) * -1, 3 * Math.sin(3) * -1,
-        4 * Math.sin(-5) * -1
-      ],
-      1e-1);
+        gradients,
+        [
+          1 * Math.sin(-1) * -1, 2 * Math.sin(2) * -1, 3 * Math.sin(3) * -1,
+          4 * Math.sin(-5) * -1
+        ],
+        1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -2060,17 +2060,17 @@ describeWithFlags('cos', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients,
-      [
-        1 * Math.sin(-3) * -1, 2 * Math.sin(1) * -1, 3 * Math.sin(2) * -1,
-        4 * Math.sin(3) * -1
-      ],
-      1e-1);
+        gradients,
+        [
+          1 * Math.sin(-3) * -1, 2 * Math.sin(1) * -1, 3 * Math.sin(2) * -1,
+          4 * Math.sin(3) * -1
+        ],
+        1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.cos({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'cos' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'cos' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2086,7 +2086,7 @@ describeWithFlags('cos', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.cos('q'))
-      .toThrowError(/Argument 'x' passed to 'cos' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'cos' must be numeric/);
   });
 });
 
@@ -2131,7 +2131,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
     expectArraysClose(gradients, [8 / (Math.cos(0.5) * Math.cos(0.5))]);
   });
 
-  fit('gradients: Tensor1D', () => {
+  it('gradients: Tensor1D', () => {
     const aValues = [-1, 2, 3, -5];
     const dyValues = [1, 2, 3, 4];
     const a = tf.tensor1d(aValues);
@@ -2169,7 +2169,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.tan({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'tan' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'tan' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2185,7 +2185,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.tan('q'))
-      .toThrowError(/Argument 'x' passed to 'tan' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'tan' must be numeric/);
   });
 });
 
@@ -2268,7 +2268,7 @@ describeWithFlags('asin', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.asin({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'asin' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'asin' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2284,7 +2284,7 @@ describeWithFlags('asin', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.asin('q'))
-      .toThrowError(/Argument 'x' passed to 'asin' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'asin' must be numeric/);
   });
 });
 
@@ -2340,7 +2340,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-        (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
+          (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2359,7 +2359,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-        (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
+          (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2369,7 +2369,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.acos({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'acos' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'acos' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2385,7 +2385,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.acos('q'))
-      .toThrowError(/Argument 'x' passed to 'acos' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'acos' must be numeric/);
   });
 });
 
@@ -2479,7 +2479,7 @@ describeWithFlags('atan', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.atan({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'atan' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'atan' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2495,7 +2495,7 @@ describeWithFlags('atan', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.atan('q'))
-      .toThrowError(/Argument 'x' passed to 'atan' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'atan' must be numeric/);
   });
 });
 
@@ -2578,7 +2578,7 @@ describeWithFlags('sinh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sinh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'sinh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'sinh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2594,7 +2594,7 @@ describeWithFlags('sinh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sinh('q'))
-      .toThrowError(/Argument 'x' passed to 'sinh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'sinh' must be numeric/);
   });
 });
 
@@ -2678,7 +2678,7 @@ describeWithFlags('cosh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.cosh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'cosh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'cosh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2695,7 +2695,7 @@ describeWithFlags('cosh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.cosh('q'))
-      .toThrowError(/Argument 'x' passed to 'cosh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'cosh' must be numeric/);
   });
 });
 
@@ -2751,7 +2751,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-        dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
+          dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2770,7 +2770,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-        dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
+          dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2780,7 +2780,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.tanh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'tanh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'tanh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2796,7 +2796,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.tanh('q'))
-      .toThrowError(/Argument 'x' passed to 'tanh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'tanh' must be numeric/);
   });
 });
 
@@ -2835,7 +2835,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
     const alpha = 0.1;
 
     const gradients =
-      tf.grad((a) => tf.leakyRelu(a.clone(), alpha).clone())(a, dy);
+        tf.grad((a) => tf.leakyRelu(a.clone(), alpha).clone())(a, dy);
 
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -2876,7 +2876,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.leakyRelu({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'leakyRelu' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'leakyRelu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2888,7 +2888,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.leakyRelu('q'))
-      .toThrowError(/Argument 'x' passed to 'leakyRelu' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'leakyRelu' must be numeric/);
   });
 });
 
@@ -2930,7 +2930,7 @@ describeWithFlags('elu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.elu({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'elu' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'elu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2941,7 +2941,7 @@ describeWithFlags('elu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.elu('q'))
-      .toThrowError(/Argument 'x' passed to 'elu' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'elu' must be numeric/);
   });
 });
 
@@ -3047,7 +3047,7 @@ describeWithFlags('selu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.selu({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'selu' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'selu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3058,7 +3058,7 @@ describeWithFlags('selu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.selu('q'))
-      .toThrowError(/Argument 'x' passed to 'selu' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'selu' must be numeric/);
   });
 });
 
@@ -3091,13 +3091,13 @@ describeWithFlags('packed clip', PACKED_ENVS, () => {
   it('using extreme values', () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2]);
     let result =
-      tf.clipByValue(a, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+        tf.clipByValue(a, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
     expectArraysClose(result, [3, -1, 0, 100, -7, 2]);
 
     result = tf.clipByValue(a, Number.MIN_VALUE, Number.MAX_VALUE);
     expectArraysClose(
-      result,
-      [3, Number.MIN_VALUE, Number.MIN_VALUE, 100, Number.MIN_VALUE, 2]);
+        result,
+        [3, Number.MIN_VALUE, Number.MIN_VALUE, 100, Number.MIN_VALUE, 2]);
   });
 
   it('should work for scalars', () => {
@@ -3197,7 +3197,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
     const x = tf.scalar(-10);  // Clipped.
     const dy = tf.scalar(5);
     const gradients =
-      tf.grad(x => x.clone().clipByValue(min, max).clone())(x, dy);
+        tf.grad(x => x.clone().clipByValue(min, max).clone())(x, dy);
 
     expect(gradients.shape).toEqual(x.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3217,7 +3217,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.clipByValue({} as tf.Tensor, 0, 1))
-      .toThrowError(/Argument 'x' passed to 'clipByValue' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'clipByValue' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3237,7 +3237,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.clipByValue('q', 0, 1))
-      .toThrowError(/Argument 'x' passed to 'clipByValue' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'clipByValue' must be numeric/);
   });
 });
 
@@ -3301,7 +3301,7 @@ describeWithFlags('round', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.round({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'round' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'round' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3311,7 +3311,7 @@ describeWithFlags('round', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.round('q'))
-      .toThrowError(/Argument 'x' passed to 'round' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'round' must be numeric/);
   });
 });
 
@@ -3414,7 +3414,7 @@ describeWithFlags('asinh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.asinh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'asinh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'asinh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3430,7 +3430,7 @@ describeWithFlags('asinh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.asinh('q'))
-      .toThrowError(/Argument 'x' passed to 'asinh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'asinh' must be numeric/);
   });
 });
 
@@ -3540,7 +3540,7 @@ describeWithFlags('acosh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.acosh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'acosh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'acosh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3556,7 +3556,7 @@ describeWithFlags('acosh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.acosh('q'))
-      .toThrowError(/Argument 'x' passed to 'acosh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'acosh' must be numeric/);
   });
 });
 
@@ -3666,7 +3666,7 @@ describeWithFlags('atanh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.atanh({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'atanh' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'atanh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3676,7 +3676,7 @@ describeWithFlags('atanh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.atanh('q'))
-      .toThrowError(/Argument 'x' passed to 'atanh' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'atanh' must be numeric/);
   });
 });
 
@@ -3724,7 +3724,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
+        gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
   });
 
   it('gradient with clones', () => {
@@ -3734,7 +3734,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-      gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
+        gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
   });
 
   it('gradients: Tensor1D', () => {
@@ -3746,7 +3746,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] = dyValues[i] * 2 * Math.exp(-aValues[i] * aValues[i]) /
-        Math.sqrt(Math.PI);
+          Math.sqrt(Math.PI);
     }
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3762,7 +3762,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] = dyValues[i] * 2 * Math.exp(-aValues[i] * aValues[i]) /
-        Math.sqrt(Math.PI);
+          Math.sqrt(Math.PI);
     }
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3771,7 +3771,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.erf({} as tf.Tensor))
-      .toThrowError(/Argument 'x' passed to 'erf' must be a Tensor/);
+        .toThrowError(/Argument 'x' passed to 'erf' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3781,6 +3781,6 @@ describeWithFlags('erf', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.erf('q'))
-      .toThrowError(/Argument 'x' passed to 'erf' must be numeric/);
+        .toThrowError(/Argument 'x' passed to 'erf' must be numeric/);
   });
 });

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, TEST_EPSILON_FLOAT16} from '../environment';
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
 import {ALL_ENVS, expectArraysClose, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
@@ -2147,7 +2147,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     // The grad(tan(x)) which relies on 1/cos(x) is less precise on Windows.
-    expectArraysClose(gradients, expected, 1e-2);
+    expectArraysClose(gradients, expected, TEST_EPSILON_FLOAT16);
   });
 
   it('gradients: Tensor2D', () => {

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import { ENV } from '../environment';
 import * as tf from '../index';
-import {describeWithFlags} from '../jasmine_util';
-import {ALL_ENVS, expectArraysClose, PACKED_ENVS, WEBGL_ENVS} from '../test_util';
+import { describeWithFlags } from '../jasmine_util';
+import { ALL_ENVS, expectArraysClose, PACKED_ENVS, WEBGL_ENVS } from '../test_util';
 import * as util from '../util';
 
 import * as selu_util from './selu_util';
@@ -117,7 +117,7 @@ describeWithFlags('relu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.relu({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'relu' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'relu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -127,7 +127,7 @@ describeWithFlags('relu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.relu('q'))
-        .toThrowError(/Argument 'x' passed to 'relu' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'relu' must be numeric/);
   });
 });
 
@@ -186,8 +186,8 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('complex64 rank-3', () => {
     const a = tf.complex(
-        [[[-3, -2], [-1, 0]], [[1, 2], [3, 4]]],
-        [[[4, 1], [2, 3]], [[0, -1], [-3, -4]]]);
+      [[[-3, -2], [-1, 0]], [[1, 2], [3, 4]]],
+      [[[4, 1], [2, 3]], [[0, -1], [-3, -4]]]);
     const result = tf.abs(a);
     expectArraysClose(result, [
       Math.sqrt(-3 * -3 + 4 * 4), Math.sqrt(-2 * -2 + 1 * 1),
@@ -210,17 +210,17 @@ describeWithFlags('abs', ALL_ENVS, () => {
         break;
       default:
         throw new Error(`Test not implemented for ENV.engine.floatPrecision()=${
-            floatBits}.`);
+          floatBits}.`);
     }
 
     const a = tf.complex([small, 0, small, 0], [small, small, 0, 0]);
     const result = tf.abs(a);
     expectArraysClose(
-        result,
-        [
-          Math.hypot(small, small), Math.hypot(0, small), Math.hypot(small, 0),
-          Math.hypot(0, 0)
-        ],
+      result,
+      [
+        Math.hypot(small, small), Math.hypot(0, small), Math.hypot(small, 0),
+        Math.hypot(0, 0)
+      ],
         /*tolerance=*/small / 100);
     expect(result.shape).toEqual([4]);
   });
@@ -276,7 +276,7 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.abs({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'abs' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'abs' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -286,7 +286,7 @@ describeWithFlags('abs', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.abs('q'))
-        .toThrowError(/Argument 'x' passed to 'abs' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'abs' must be numeric/);
   });
 });
 
@@ -362,7 +362,7 @@ describeWithFlags('step', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.step({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'step' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'step' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -372,7 +372,7 @@ describeWithFlags('step', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.step('q'))
-        .toThrowError(/Argument 'x' passed to 'step' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'step' must be numeric/);
   });
 });
 
@@ -436,7 +436,7 @@ describeWithFlags('neg', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.neg({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'neg' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'neg' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -446,7 +446,7 @@ describeWithFlags('neg', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.neg('q'))
-        .toThrowError(/Argument 'x' passed to 'neg' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'neg' must be numeric/);
   });
 });
 
@@ -517,7 +517,7 @@ describeWithFlags('sigmoid', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sigmoid({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'sigmoid' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'sigmoid' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -533,7 +533,7 @@ describeWithFlags('sigmoid', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sigmoid('q'))
-        .toThrowError(/Argument 'x' passed to 'sigmoid' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'sigmoid' must be numeric/);
   });
 });
 
@@ -663,7 +663,7 @@ describeWithFlags('logSigmoid', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.logSigmoid({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'logSigmoid' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'logSigmoid' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -674,7 +674,7 @@ describeWithFlags('logSigmoid', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.logSigmoid('q'))
-        .toThrowError(/Argument 'x' passed to 'logSigmoid' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'logSigmoid' must be numeric/);
   });
 });
 
@@ -802,7 +802,7 @@ describeWithFlags('softplus', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.softplus({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'softplus' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'softplus' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -813,7 +813,7 @@ describeWithFlags('softplus', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.softplus('q'))
-        .toThrowError(/Argument 'x' passed to 'softplus' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'softplus' must be numeric/);
   });
 });
 
@@ -861,12 +861,12 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          1 / (2 * Math.sqrt(1)), 2 / (2 * Math.sqrt(2)),
-          3 / (2 * Math.sqrt(3)), 4 / (2 * Math.sqrt(5))
-        ],
-        1e-1);
+      gradients,
+      [
+        1 / (2 * Math.sqrt(1)), 2 / (2 * Math.sqrt(2)),
+        3 / (2 * Math.sqrt(3)), 4 / (2 * Math.sqrt(5))
+      ],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -878,17 +878,17 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          1 / (2 * Math.sqrt(3)), 2 / (2 * Math.sqrt(1)),
-          3 / (2 * Math.sqrt(2)), 4 / (2 * Math.sqrt(3))
-        ],
-        1e-1);
+      gradients,
+      [
+        1 / (2 * Math.sqrt(3)), 2 / (2 * Math.sqrt(1)),
+        3 / (2 * Math.sqrt(2)), 4 / (2 * Math.sqrt(3))
+      ],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sqrt({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'sqrt' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'sqrt' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -898,7 +898,7 @@ describeWithFlags('sqrt', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sqrt('q'))
-        .toThrowError(/Argument 'x' passed to 'sqrt' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'sqrt' must be numeric/);
   });
 });
 
@@ -946,12 +946,12 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          -1 * 1 / (2 * Math.pow(1, 1.5)), -1 * 2 / (2 * Math.pow(2, 1.5)),
-          -1 * 3 / (2 * Math.pow(3, 1.5)), -1 * 4 / (2 * Math.pow(5, 1.5))
-        ],
-        1e-1);
+      gradients,
+      [
+        -1 * 1 / (2 * Math.pow(1, 1.5)), -1 * 2 / (2 * Math.pow(2, 1.5)),
+        -1 * 3 / (2 * Math.pow(3, 1.5)), -1 * 4 / (2 * Math.pow(5, 1.5))
+      ],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -963,17 +963,17 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          -1 * 1 / (2 * Math.pow(3, 1.5)), -1 * 2 / (2 * Math.pow(1, 1.5)),
-          -1 * 3 / (2 * Math.pow(2, 1.5)), -1 * 4 / (2 * Math.pow(3, 1.5))
-        ],
-        1e-1);
+      gradients,
+      [
+        -1 * 1 / (2 * Math.pow(3, 1.5)), -1 * 2 / (2 * Math.pow(1, 1.5)),
+        -1 * 3 / (2 * Math.pow(2, 1.5)), -1 * 4 / (2 * Math.pow(3, 1.5))
+      ],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.rsqrt({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'rsqrt' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'rsqrt' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -983,7 +983,7 @@ describeWithFlags('rsqrt', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.rsqrt('q'))
-        .toThrowError(/Argument 'x' passed to 'rsqrt' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'rsqrt' must be numeric/);
   });
 });
 
@@ -1010,8 +1010,8 @@ describeWithFlags('square', ALL_ENVS, () => {
 
   it('6D array', () => {
     const a = tf.tensor6d(
-        [1, 2, Math.sqrt(2), Math.sqrt(3), 3, 4, Math.sqrt(7), Math.sqrt(13)],
-        [1, 1, 2, 2, 2, 1]);
+      [1, 2, Math.sqrt(2), Math.sqrt(3), 3, 4, Math.sqrt(7), Math.sqrt(13)],
+      [1, 1, 2, 2, 2, 1]);
     const r = tf.square(a);
     expect(r.shape).toEqual(a.shape);
     expectArraysClose(r, [1, 4, 2, 3, 9, 16, 7, 13]);
@@ -1087,13 +1087,13 @@ describeWithFlags('square', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [-6 * 1, 2 * 2, 4 * 3, 6 * 4, -8 * 5, 10 * 6, 24 * 7, 6 * 8]);
+      gradients,
+      [-6 * 1, 2 * 2, 4 * 3, 6 * 4, -8 * 5, 10 * 6, 24 * 7, 6 * 8]);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.square({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'square' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'square' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1103,7 +1103,7 @@ describeWithFlags('square', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.square('q'))
-        .toThrowError(/Argument 'x' passed to 'square' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'square' must be numeric/);
   });
 });
 
@@ -1179,7 +1179,7 @@ describeWithFlags('reciprocal', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.reciprocal({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'reciprocal' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'reciprocal' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1189,7 +1189,7 @@ describeWithFlags('reciprocal', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.reciprocal('q'))
-        .toThrowError(/Argument 'x' passed to 'reciprocal' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'reciprocal' must be numeric/);
   });
 });
 
@@ -1264,7 +1264,7 @@ describeWithFlags('log', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.log({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'log' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'log' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1274,7 +1274,7 @@ describeWithFlags('log', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.log('q'))
-        .toThrowError(/Argument 'x' passed to 'log' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'log' must be numeric/);
   });
 });
 
@@ -1319,7 +1319,7 @@ describeWithFlags('log1p', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients, [Infinity, 2 / (1 + 2), 3 / (1 + 3), 4 / (1 + -5)]);
+      gradients, [Infinity, 2 / (1 + 2), 3 / (1 + 3), 4 / (1 + -5)]);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1331,12 +1331,12 @@ describeWithFlags('log1p', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients, [1 / (1 + -3), 2 / (1 + 1), 3 / (1 + 2), 4 / (1 + 3)]);
+      gradients, [1 / (1 + -3), 2 / (1 + 1), 3 / (1 + 2), 4 / (1 + 3)]);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.log1p({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'log1p' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'log1p' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1346,7 +1346,7 @@ describeWithFlags('log1p', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.log1p('q'))
-        .toThrowError(/Argument 'x' passed to 'log1p' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'log1p' must be numeric/);
   });
 });
 
@@ -1409,7 +1409,7 @@ describeWithFlags('ceil', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.ceil({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'ceil' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'ceil' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1419,7 +1419,7 @@ describeWithFlags('ceil', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.ceil('q'))
-        .toThrowError(/Argument 'x' passed to 'ceil' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'ceil' must be numeric/);
   });
 });
 
@@ -1483,7 +1483,7 @@ describeWithFlags('floor', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.floor({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'floor' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'floor' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1493,7 +1493,7 @@ describeWithFlags('floor', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.floor('q'))
-        .toThrowError(/Argument 'x' passed to 'floor' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'floor' must be numeric/);
   });
 });
 
@@ -1556,7 +1556,7 @@ describeWithFlags('sign', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sign({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'sign' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'sign' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1566,7 +1566,7 @@ describeWithFlags('sign', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sign('q'))
-        .toThrowError(/Argument 'x' passed to 'sign' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'sign' must be numeric/);
   });
 });
 
@@ -1613,7 +1613,7 @@ describeWithFlags('isNaN', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isNaN({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'isNaN' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'isNaN' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1623,7 +1623,7 @@ describeWithFlags('isNaN', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isNaN('q'))
-        .toThrowError(/Argument 'x' passed to 'isNaN' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'isNaN' must be numeric/);
   });
 });
 
@@ -1670,7 +1670,7 @@ describeWithFlags('isInf', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isInf({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'isInf' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'isInf' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1680,7 +1680,7 @@ describeWithFlags('isInf', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isInf('q'))
-        .toThrowError(/Argument 'x' passed to 'isInf' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'isInf' must be numeric/);
   });
 });
 
@@ -1727,7 +1727,7 @@ describeWithFlags('isFinite', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.isFinite({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'isFinite' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'isFinite' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1737,7 +1737,7 @@ describeWithFlags('isFinite', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.isFinite('q'))
-        .toThrowError(/Argument 'x' passed to 'isFinite' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'isFinite' must be numeric/);
   });
 });
 
@@ -1786,9 +1786,9 @@ describeWithFlags('exp', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
-        1e-1);
+      gradients,
+      [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1800,14 +1800,14 @@ describeWithFlags('exp', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
-        1e-1);
+      gradients,
+      [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.exp({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'exp' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'exp' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1817,7 +1817,7 @@ describeWithFlags('exp', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.exp('q'))
-        .toThrowError(/Argument 'x' passed to 'exp' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'exp' must be numeric/);
   });
 });
 
@@ -1866,9 +1866,9 @@ describeWithFlags('expm1', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
-        1e-1);
+      gradients,
+      [1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1880,14 +1880,14 @@ describeWithFlags('expm1', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
-        1e-1);
+      gradients,
+      [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.expm1({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'expm1' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'expm1' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1898,7 +1898,7 @@ describeWithFlags('expm1', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.expm1('q'))
-        .toThrowError(/Argument 'x' passed to 'expm1' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'expm1' must be numeric/);
   });
 });
 
@@ -1952,9 +1952,9 @@ describeWithFlags('sin', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.cos(-1), 2 * Math.cos(2), 3 * Math.cos(3), 4 * Math.cos(-5)],
-        1e-1);
+      gradients,
+      [1 * Math.cos(-1), 2 * Math.cos(2), 3 * Math.cos(3), 4 * Math.cos(-5)],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -1966,14 +1966,14 @@ describeWithFlags('sin', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [1 * Math.cos(-3), 2 * Math.cos(1), 3 * Math.cos(2), 4 * Math.cos(3)],
-        1e-1);
+      gradients,
+      [1 * Math.cos(-3), 2 * Math.cos(1), 3 * Math.cos(2), 4 * Math.cos(3)],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sin({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'sin' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'sin' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -1989,7 +1989,7 @@ describeWithFlags('sin', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sin('q'))
-        .toThrowError(/Argument 'x' passed to 'sin' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'sin' must be numeric/);
   });
 });
 
@@ -2043,12 +2043,12 @@ describeWithFlags('cos', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          1 * Math.sin(-1) * -1, 2 * Math.sin(2) * -1, 3 * Math.sin(3) * -1,
-          4 * Math.sin(-5) * -1
-        ],
-        1e-1);
+      gradients,
+      [
+        1 * Math.sin(-1) * -1, 2 * Math.sin(2) * -1, 3 * Math.sin(3) * -1,
+        4 * Math.sin(-5) * -1
+      ],
+      1e-1);
   });
 
   it('gradients: Tensor2D', () => {
@@ -2060,17 +2060,17 @@ describeWithFlags('cos', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients,
-        [
-          1 * Math.sin(-3) * -1, 2 * Math.sin(1) * -1, 3 * Math.sin(2) * -1,
-          4 * Math.sin(3) * -1
-        ],
-        1e-1);
+      gradients,
+      [
+        1 * Math.sin(-3) * -1, 2 * Math.sin(1) * -1, 3 * Math.sin(2) * -1,
+        4 * Math.sin(3) * -1
+      ],
+      1e-1);
   });
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.cos({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'cos' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'cos' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2086,7 +2086,7 @@ describeWithFlags('cos', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.cos('q'))
-        .toThrowError(/Argument 'x' passed to 'cos' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'cos' must be numeric/);
   });
 });
 
@@ -2131,7 +2131,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
     expectArraysClose(gradients, [8 / (Math.cos(0.5) * Math.cos(0.5))]);
   });
 
-  it('gradients: Tensor1D', () => {
+  fit('gradients: Tensor1D', () => {
     const aValues = [-1, 2, 3, -5];
     const dyValues = [1, 2, 3, 4];
     const a = tf.tensor1d(aValues);
@@ -2146,7 +2146,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
-    expectArraysClose(gradients, expected);
+    expectArraysClose(gradients, expected, 1e-2);
   });
 
   it('gradients: Tensor2D', () => {
@@ -2169,7 +2169,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.tan({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'tan' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'tan' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2185,7 +2185,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.tan('q'))
-        .toThrowError(/Argument 'x' passed to 'tan' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'tan' must be numeric/);
   });
 });
 
@@ -2268,7 +2268,7 @@ describeWithFlags('asin', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.asin({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'asin' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'asin' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2284,7 +2284,7 @@ describeWithFlags('asin', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.asin('q'))
-        .toThrowError(/Argument 'x' passed to 'asin' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'asin' must be numeric/);
   });
 });
 
@@ -2340,7 +2340,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-          (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
+        (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2359,7 +2359,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-          (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
+        (-1 * dyValues[i]) / Math.sqrt(1 - (aValues[i] * aValues[i]));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2369,7 +2369,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.acos({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'acos' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'acos' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2385,7 +2385,7 @@ describeWithFlags('acos', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.acos('q'))
-        .toThrowError(/Argument 'x' passed to 'acos' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'acos' must be numeric/);
   });
 });
 
@@ -2479,7 +2479,7 @@ describeWithFlags('atan', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.atan({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'atan' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'atan' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2495,7 +2495,7 @@ describeWithFlags('atan', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.atan('q'))
-        .toThrowError(/Argument 'x' passed to 'atan' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'atan' must be numeric/);
   });
 });
 
@@ -2578,7 +2578,7 @@ describeWithFlags('sinh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.sinh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'sinh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'sinh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2594,7 +2594,7 @@ describeWithFlags('sinh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.sinh('q'))
-        .toThrowError(/Argument 'x' passed to 'sinh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'sinh' must be numeric/);
   });
 });
 
@@ -2678,7 +2678,7 @@ describeWithFlags('cosh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.cosh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'cosh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'cosh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2695,7 +2695,7 @@ describeWithFlags('cosh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.cosh('q'))
-        .toThrowError(/Argument 'x' passed to 'cosh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'cosh' must be numeric/);
   });
 });
 
@@ -2751,7 +2751,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-          dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
+        dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2770,7 +2770,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] =
-          dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
+        dyValues[i] * (1 - (Math.tanh(aValues[i]) * Math.tanh(aValues[i])));
     }
 
     expect(gradients.shape).toEqual(a.shape);
@@ -2780,7 +2780,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.tanh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'tanh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'tanh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2796,7 +2796,7 @@ describeWithFlags('tanh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.tanh('q'))
-        .toThrowError(/Argument 'x' passed to 'tanh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'tanh' must be numeric/);
   });
 });
 
@@ -2835,7 +2835,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
     const alpha = 0.1;
 
     const gradients =
-        tf.grad((a) => tf.leakyRelu(a.clone(), alpha).clone())(a, dy);
+      tf.grad((a) => tf.leakyRelu(a.clone(), alpha).clone())(a, dy);
 
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -2876,7 +2876,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.leakyRelu({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'leakyRelu' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'leakyRelu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2888,7 +2888,7 @@ describeWithFlags('leakyRelu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.leakyRelu('q'))
-        .toThrowError(/Argument 'x' passed to 'leakyRelu' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'leakyRelu' must be numeric/);
   });
 });
 
@@ -2930,7 +2930,7 @@ describeWithFlags('elu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.elu({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'elu' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'elu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -2941,7 +2941,7 @@ describeWithFlags('elu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.elu('q'))
-        .toThrowError(/Argument 'x' passed to 'elu' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'elu' must be numeric/);
   });
 });
 
@@ -3047,7 +3047,7 @@ describeWithFlags('selu', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.selu({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'selu' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'selu' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3058,7 +3058,7 @@ describeWithFlags('selu', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.selu('q'))
-        .toThrowError(/Argument 'x' passed to 'selu' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'selu' must be numeric/);
   });
 });
 
@@ -3091,13 +3091,13 @@ describeWithFlags('packed clip', PACKED_ENVS, () => {
   it('using extreme values', () => {
     const a = tf.tensor1d([3, -1, 0, 100, -7, 2]);
     let result =
-        tf.clipByValue(a, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+      tf.clipByValue(a, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
     expectArraysClose(result, [3, -1, 0, 100, -7, 2]);
 
     result = tf.clipByValue(a, Number.MIN_VALUE, Number.MAX_VALUE);
     expectArraysClose(
-        result,
-        [3, Number.MIN_VALUE, Number.MIN_VALUE, 100, Number.MIN_VALUE, 2]);
+      result,
+      [3, Number.MIN_VALUE, Number.MIN_VALUE, 100, Number.MIN_VALUE, 2]);
   });
 
   it('should work for scalars', () => {
@@ -3197,7 +3197,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
     const x = tf.scalar(-10);  // Clipped.
     const dy = tf.scalar(5);
     const gradients =
-        tf.grad(x => x.clone().clipByValue(min, max).clone())(x, dy);
+      tf.grad(x => x.clone().clipByValue(min, max).clone())(x, dy);
 
     expect(gradients.shape).toEqual(x.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3217,7 +3217,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.clipByValue({} as tf.Tensor, 0, 1))
-        .toThrowError(/Argument 'x' passed to 'clipByValue' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'clipByValue' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3237,7 +3237,7 @@ describeWithFlags('clip', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.clipByValue('q', 0, 1))
-        .toThrowError(/Argument 'x' passed to 'clipByValue' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'clipByValue' must be numeric/);
   });
 });
 
@@ -3301,7 +3301,7 @@ describeWithFlags('round', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.round({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'round' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'round' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3311,7 +3311,7 @@ describeWithFlags('round', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.round('q'))
-        .toThrowError(/Argument 'x' passed to 'round' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'round' must be numeric/);
   });
 });
 
@@ -3414,7 +3414,7 @@ describeWithFlags('asinh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.asinh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'asinh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'asinh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3430,7 +3430,7 @@ describeWithFlags('asinh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.asinh('q'))
-        .toThrowError(/Argument 'x' passed to 'asinh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'asinh' must be numeric/);
   });
 });
 
@@ -3540,7 +3540,7 @@ describeWithFlags('acosh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.acosh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'acosh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'acosh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3556,7 +3556,7 @@ describeWithFlags('acosh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.acosh('q'))
-        .toThrowError(/Argument 'x' passed to 'acosh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'acosh' must be numeric/);
   });
 });
 
@@ -3666,7 +3666,7 @@ describeWithFlags('atanh', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.atanh({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'atanh' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'atanh' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3676,7 +3676,7 @@ describeWithFlags('atanh', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.atanh('q'))
-        .toThrowError(/Argument 'x' passed to 'atanh' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'atanh' must be numeric/);
   });
 });
 
@@ -3724,7 +3724,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
+      gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
   });
 
   it('gradient with clones', () => {
@@ -3734,7 +3734,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
     expectArraysClose(
-        gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
+      gradients, [8 * 2 * Math.exp(-0.5 * 0.5) / Math.sqrt(Math.PI)]);
   });
 
   it('gradients: Tensor1D', () => {
@@ -3746,7 +3746,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] = dyValues[i] * 2 * Math.exp(-aValues[i] * aValues[i]) /
-          Math.sqrt(Math.PI);
+        Math.sqrt(Math.PI);
     }
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3762,7 +3762,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
     const expected = [];
     for (let i = 0; i < a.size; i++) {
       expected[i] = dyValues[i] * 2 * Math.exp(-aValues[i] * aValues[i]) /
-          Math.sqrt(Math.PI);
+        Math.sqrt(Math.PI);
     }
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
@@ -3771,7 +3771,7 @@ describeWithFlags('erf', ALL_ENVS, () => {
 
   it('throws when passed a non-tensor', () => {
     expect(() => tf.erf({} as tf.Tensor))
-        .toThrowError(/Argument 'x' passed to 'erf' must be a Tensor/);
+      .toThrowError(/Argument 'x' passed to 'erf' must be a Tensor/);
   });
 
   it('accepts a tensor-like object', () => {
@@ -3781,6 +3781,6 @@ describeWithFlags('erf', ALL_ENVS, () => {
 
   it('throws for string tensor', () => {
     expect(() => tf.erf('q'))
-        .toThrowError(/Argument 'x' passed to 'erf' must be numeric/);
+      .toThrowError(/Argument 'x' passed to 'erf' must be numeric/);
   });
 });

--- a/src/ops/unary_ops_test.ts
+++ b/src/ops/unary_ops_test.ts
@@ -2146,6 +2146,7 @@ describeWithFlags('tan', ALL_ENVS, () => {
 
     expect(gradients.shape).toEqual(a.shape);
     expect(gradients.dtype).toEqual('float32');
+    // The grad(tan(x)) which relies on 1/cos(x) is less precise on Windows.
     expectArraysClose(gradients, expected, 1e-2);
   });
 


### PR DESCRIPTION
Fix `NaN` issues on windows and enable browserstack on windows. Also fix firefox+linux which fails to compile our shaders.

**Details**
- Built-in `nan()` glsl function doesn't work properly on windows, as well as uploading `NaN` as uniform. The fix is to use a common NaN check when in WebGL 2, and a special NaN check when using WebGL 1.0 in order to make iOS happy.
- Relax a unit test with numerical precision problem.
- Firefox+Linux fails to compile with [uintBitsToFloat](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/intBitsToFloat.xhtml) due to the fact that the function is introduced in glsl 330, and we use 300. 


Towards https://github.com/tensorflow/tfjs/issues/1400

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1651)
<!-- Reviewable:end -->
