### PR TITLE
Fix a bug with slice in webgl backend

### DIFF
--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -17,6 +17,7 @@
 
 import * as tf from '../index';
 import {describeWithFlags} from '../jasmine_util';
+import {WebGLMemoryInfo} from '../kernels/backend_webgl';
 import {ALL_ENVS, expectArraysClose, WEBGL_ENVS} from '../test_util';
 import {Rank} from '../types';
 
@@ -257,6 +258,44 @@ describeWithFlags('slice2d', ALL_ENVS, () => {
     const c = tf.add(a, b);
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(c, [3, 4, 7, 8]);
+  });
+});
+
+describeWithFlags('slice and memory usage', WEBGL_ENVS, () => {
+  beforeAll(() => {
+    tf.ENV.set('WEBGL_CPU_FORWARD', false);
+    tf.ENV.set('WEBGL_SIZE_UPLOAD_UNIFORM', 0);
+  });
+
+  it('slice a tensor, read it and check memory', async () => {
+    const getMem = () => tf.memory() as WebGLMemoryInfo;
+    expect(getMem().numBytesInGPU).toBe(0);
+
+    // Lazy upload won't increase gpu memory.
+    const a = tf.tensor([2, 3]);
+    expect(getMem().numBytesInGPU).toBe(0);
+
+    // Upload a to the GPU by running an op.
+    a.square().dispose();
+    expect(getMem().numBytesInGPU).toBe(8);
+
+    // Slicing does not allocate new memory.
+    const b = a.slice(0);
+    expect(getMem().numBytesInGPU).toBe(8);
+
+    // Download a to the CPU but the texture remains on GPU
+    // since b points to it.
+    await a.data();
+    expect(getMem().numBytesInGPU).toBe(8);
+
+    // Dispose a, but the texture should still remain on the GPU
+    // since b points to it.
+    a.dispose();
+    expect(getMem().numBytesInGPU).toBe(8);
+
+    // Dispose b and expect 0 memory on GPU.
+    tf.dispose([b]);
+    expect(getMem().numBytesInGPU).toBe(0);
   });
 });
 

--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -294,7 +294,7 @@ describeWithFlags('slice and memory usage', WEBGL_ENVS, () => {
     expect(getMem().numBytesInGPU).toBe(8);
 
     // Dispose b and expect 0 memory on GPU.
-    tf.dispose([b]);
+    b.dispose();
     expect(getMem().numBytesInGPU).toBe(0);
   });
 });


### PR DESCRIPTION
Fixing a bug in the WebGL backend where we can release a texture upon reading it, regardless of whether it was sliced or not. In js code:

```js
const a = tf.tensor([1, 2]);
const b = a.slice([0]);
await a.read(); // Would release the texture to the manager.
await b.read(); // Would still work by chance since it holds the pointer to the `WebGLTexture` and the texture manager hasn't reused it yet.
```

The fix removes all direct calls to `this.releaseTexture()` and wraps `releaseTexture()` in a smarter `this.releaseGPUData()` which will check if there are sliced tensors depending on it before releasing.

Added a unit test that reproduced the issue and is now passing.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1655)
<!-- Reviewable:end -->
