### PR TITLE
Move rollup-plugin-visualizer as an optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "rollup-plugin-node-resolve": "~3.4.0",
     "rollup-plugin-terser": "~4.0.4",
     "rollup-plugin-typescript2": "~0.20.1",
-    "rollup-plugin-visualizer": "~1.1.0",
     "shelljs": "~0.8.3",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
@@ -47,6 +46,9 @@
     "typescript": "3.3.3333",
     "watchify": "~3.11.1",
     "yalc": "~1.0.0-pre.21"
+  },
+  "optionalDependencies": {
+    "rollup-plugin-visualizer": "~1.1.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
rollup-plugin-visualizer wants node >=10, however we allow developers of tfjs to use any node version. Thus, we have to move it as optional dep, which means `yarn install` won't fail if you are using older version of node.

https://yarnpkg.com/lang/en/docs/dependency-types/#toc-optionaldependencies

Also sent a change upstream to relax the constraint a bit (though there is >8.10 imposed by its dependency): https://github.com/btd/rollup-plugin-visualizer/pull/29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1669)
<!-- Reviewable:end -->
