### PR TITLE
Slice the result of read and readSync to avoid mutating internal state.

### DIFF
--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -166,7 +166,7 @@
       <tbody></tbody>
     </table>
   </div>
-  <script src="https://unpkg.com/@tensorflow/tfjs-core/dist/tf-core.js"></script>
+  <script src="../dist/tf-core.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-layers/dist/tf-layers.js"></script>
   <script src="https://unpkg.com/@tensorflow/tfjs-converter/dist/tf-converter.js"></script>
   <script>
@@ -175,9 +175,9 @@
       //////////////////////////////////
       // Place model loading code here.
       //////////////////////////////////
-      return await tf.loadFrozenModel(
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/tensorflowjs_model.pb',
-        'https://storage.googleapis.com/tfjs-models/savedmodel/mobilenet_v2_1.0_224/weights_manifest.json');
+      return await tf.loadGraphModel(
+        'https://tfhub.dev/google/imagenet/mobilenet_v2_100_224/classification/2',
+        {fromTFHub: true});
     }
 
     const zeros = tf.zeros([1, 224, 224, 3]);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -753,12 +753,18 @@ export class Engine implements TensorManager, TensorTracker, DataMover {
   readSync(dataId: DataId): DataValues {
     // Route the read to the correct backend.
     const info = this.state.tensorInfo.get(dataId);
-    return info.backend.readSync(dataId);
+    const result = info.backend.readSync(dataId);
+
+    // Shallow copy the result so the user cannot mutate tensor state.
+    return result.slice();
   }
-  read(dataId: DataId): Promise<DataValues> {
+  async read(dataId: DataId): Promise<DataValues> {
     // Route the read to the correct backend.
     const info = this.state.tensorInfo.get(dataId);
-    return info.backend.read(dataId);
+    const result = await info.backend.read(dataId);
+
+    // Shallow copy the result so the user cannot mutate tensor state.
+    return result.slice();
   }
   fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,

--- a/src/engine_test.ts
+++ b/src/engine_test.ts
@@ -155,6 +155,28 @@ describe('Backend registration', () => {
   });
 });
 
+describeWithFlags('readbacks return shallow copies', ALL_ENVS, () => {
+  it('dataSync returns shallow copy of data', () => {
+    const x = tf.tensor([1, 2, 3]);
+    x.square();
+
+    const xData = x.dataSync();
+    xData[1] = 10;
+
+    expectArraysClose(x, [1, 2, 3]);
+  });
+
+  it('data returns shallow copy of data', async () => {
+    const x = tf.tensor([1, 2, 3]);
+    x.square();
+
+    const xData = await x.data();
+    xData[1] = 10;
+
+    expectArraysClose(x, [1, 2, 3]);
+  });
+});
+
 describeWithFlags('fromPixels + regular math op', WEBGL_ENVS, () => {
   it('debug mode does not error when no nans', () => {
     const pixels = new ImageData(2, 2);

--- a/src/kernels/cpu/backend_cpu.ts
+++ b/src/kernels/cpu/backend_cpu.ts
@@ -547,7 +547,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = sum;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   prod(x: Tensor, axes: number[]): Tensor {
@@ -569,7 +569,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = prod;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   unsortedSegmentSum<T extends Tensor>(
@@ -620,7 +620,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = minIndex;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   argMax(x: Tensor, axis: number): Tensor {
@@ -648,7 +648,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = maxIndex;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   cumsum(x: Tensor, axis: number, exclusive: boolean, reverse: boolean):
@@ -681,7 +681,7 @@ export class MathBackendCPU implements KernelBackend {
         }
       }
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   equal(a: Tensor, b: Tensor): Tensor {
@@ -781,7 +781,7 @@ export class MathBackendCPU implements KernelBackend {
         }
       }
     }
-    return result;
+    return tensor(newValues, result.shape);
   }
 
   where(condition: Tensor): Tensor2D {
@@ -820,7 +820,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = min;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   minimum(a: Tensor, b: Tensor): Tensor {
@@ -865,7 +865,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = max;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   maximum(a: Tensor, b: Tensor): Tensor {
@@ -895,7 +895,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = all;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   any(x: Tensor, axes: number[]): Tensor {
@@ -918,7 +918,7 @@ export class MathBackendCPU implements KernelBackend {
       }
       vals[i] = anyVal;
     }
-    return result;
+    return tensor(vals, result.shape);
   }
 
   squaredDifference(a: Tensor, b: Tensor): Tensor {
@@ -1137,7 +1137,7 @@ export class MathBackendCPU implements KernelBackend {
     for (let i = 0; i < inVals.length; ++i) {
       resVals[i] = Math.max(0, inVals[i]);
     }
-    return res as T;
+    return tensor(resVals, res.shape) as T;
   }
 
   prelu<T extends Tensor>(x: T, a: T): T {
@@ -2879,7 +2879,7 @@ export class MathBackendCPU implements KernelBackend {
         }
       }
     }
-    return res;
+    return tensor(resVals, res.shape);
   }
 
   oneHot(indices: Tensor1D, depth: number, onValue: number, offValue: number):

--- a/test.html
+++ b/test.html
@@ -1,0 +1,8 @@
+<script src="dist/tf-core.js"></script>
+
+<script>
+tf.setBackend('cpu');
+const a = tf.tensor2d([1, 2, 3, 1, 0, 1], [3, 2]);
+const res = tf.prod(a, [0], true /* keepDims */);
+console.log(res.dataSync());
+</script>


### PR DESCRIPTION
See: https://github.com/shiffman/Tensorflow-JS-Examples/issues/7

This avoid users dataSyncing and mutating internal state. Slice is shallow so is very cheap. I ran the benchmarks to make sure, there is no change.

I also updated the benchmarks script to use 1.0 code and hit TF Hub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1670)
<!-- Reviewable:end -->
