### PR TITLE
Upgrade rollup-plugin-visualizer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "optionalDependencies": {
-    "rollup-plugin-visualizer": "~1.1.0"
+    "rollup-plugin-visualizer": "~1.1.1"
   },
   "scripts": {
     "build": "tsc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3586,10 +3586,10 @@ rollup-plugin-typescript2@~0.20.1:
     rollup-pluginutils "2.4.1"
     tslib "1.9.3"
 
-rollup-plugin-visualizer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-1.1.0.tgz#56b7c340a66acfae4ae6476fddca5754907655c6"
-  integrity sha512-K+TbgK3ds5gpIH5dgM39qD+txbWL/gRbws4Kq0b/Bg2IZpMlB7YwAgo97KmBvWN5tCQdFhsBVtzSQ0NzL9uKZg==
+rollup-plugin-visualizer@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-1.1.1.tgz#454ae0aed23845407ebfb81cc52114af308d6d90"
+  integrity sha512-7xkSKp+dyJmSC7jg2LXqViaHuOnF1VvIFCnsZEKjrgT5ZVyiLLSbeszxFcQSfNJILphqgAEmWAUz0Z4xYScrRw==
   dependencies:
     mkdirp "^0.5.1"
     opn "^5.4.0"


### PR DESCRIPTION
Upgrade rollup-plugin-visualizer version, which relaxes the node version constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1672)
<!-- Reviewable:end -->
