### PR TITLE
WebGPU updates for latest Chromium

### DIFF
--- a/src/backends/webgpu/src/backend_webgpu.ts
+++ b/src/backends/webgpu/src/backend_webgpu.ts
@@ -80,8 +80,7 @@ export class WebGPUBackend extends KernelBackend {
   private setBufferData(
       buffer: GPUBuffer,
       data: Float32Array|Int32Array|Uint8Array) {
-    // TODO: remove '.slice().buffer as any', once on newer Chromium.
-    buffer.setSubData(0, data.slice().buffer as any);
+    buffer.setSubData(0, data);
   }
 
   register(dataId: object, shape: number[], dtype: DataType): void {

--- a/src/backends/webgpu/src/kernels/multiply_webgpu.ts
+++ b/src/backends/webgpu/src/kernels/multiply_webgpu.ts
@@ -29,13 +29,13 @@ export class MultiplyProgram implements WebGPUProgram {
 
     this.userCode = `
       #version 450
-      layout(std140, set = 0, binding = 0) buffer ssbA {
+      layout(std430, set = 0, binding = 0) readonly buffer ssbA {
         float A[];
       };
-      layout(std140, set = 0, binding = 1) buffer ssbB {
+      layout(std430, set = 0, binding = 1) readonly buffer ssbB {
         float B[];
       };
-      layout(std140, set = 0, binding = 2) buffer ssbOut {
+      layout(std430, set = 0, binding = 2) writeonly buffer ssbOut {
         float result[];
       };
 

--- a/src/backends/webgpu/src/kernels/webgpu_program.ts
+++ b/src/backends/webgpu/src/kernels/webgpu_program.ts
@@ -43,8 +43,7 @@ export const compileProgram =
       if (error.length) {
         throw new Error(`Shader compilation failed: ${error}`);
       }
-      // TODO: remove '.slice().buffer as any', once on newer Chromium.
-      const code = result.GetBinary().slice().buffer as any;
+      const code = result.GetBinary();
       const bindGroupLayout = device.createBindGroupLayout({bindings});
       const layout =
           device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]});


### PR DESCRIPTION
- Change ArrayBuffers to ArrayBufferViews
- Fix bug where buffer was std140 but should have been std430
  (my bad; possibly broke due to Chromium updating its spirv-cross)

Top-of-tree Chromium now has enough support landed for tfjs to start
using it:
https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2F650834%2Fchrome-mac.zip?generation=1555351825827150&alt=media

These changes, which also remove some huge excessive copies, are necessary to
use the newer build of Chromium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1680)
<!-- Reviewable:end -->
