### PR TITLE
Fix packed 1d reverse bug

### DIFF
--- a/src/backends/webgl/reverse_packed_gpu.ts
+++ b/src/backends/webgl/reverse_packed_gpu.ts
@@ -42,9 +42,11 @@ export class ReversePackedProgram implements GPGPUProgram {
         void main(){
           int rc = getOutputCoords();
           vec4 result = vec4(0.);
-          result.r = getChannel(getX(${xShape[0]} - rc - 1), rc);
+          result.r = getChannel(getX(${xShape[0]} - rc - 1),
+            ${xShape[0]} - rc - 1);
           if(${nextColumn}){
-              result.g = getChannel(getX(${xShape[0]} - (rc  + 1) - 1), rc + 1);
+              result.g = getChannel(getX(${xShape[0]} - (rc  + 1) - 1),
+                ${xShape[0]} - (rc  + 1) - 1);
           }
           setOutput(result);
         }

--- a/src/ops/reverse_test.ts
+++ b/src/ops/reverse_test.ts
@@ -27,6 +27,13 @@ describeWithFlags('reverse1d', ALL_ENVS, () => {
     expectArraysClose(result, [5, 4, 3, 2, 1]);
   });
 
+  it('reverse a 1D array, even length', () => {
+    const input = tf.tensor1d([1, 2, 3, 4]);
+    const result = tf.reverse1d(input);
+    expect(result.shape).toEqual(input.shape);
+    expectArraysClose(result, [4, 3, 2, 1]);
+  });
+
   it('grad', () => {
     const a = tf.tensor1d([1, 2, 3]);
     const dy = tf.tensor1d([10, 20, 30]);


### PR DESCRIPTION
To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

Fixes https://github.com/tensorflow/tfjs/issues/1518.

Root cause: Passing the wrong inner dims to the `getChannel` function.  As an example to demonstrate the problem suppose we have `tf.tensor1d([0, 1, 2, 3])` and we're trying to find the value that goes at coordinate 0 on the output texture.  The input tensor will get stored on a packed texture as follows:
```
0|1  2|3
---  ---
x|x  x|x
```
The reversed coordinates were being incorrectly calculate as:
```
          result.r = getChannel(getX(4 - 0 - 1), 0);
          if(0 + 1 < 4){
              result.g = getChannel(getX(4 - (0  + 1) - 1), (0  + 1));
          }
```
For the r channel this would sample from the first column of the second texel and return 2 instead of 3.  After this fix is applied `result.r` would be `getChannel(getX(4 - 0 - 1), 4 - 0 - 1)` which will sample 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1683)
<!-- Reviewable:end -->
