### PR TITLE
Add tf.io.http and deprecate tf.io.browserHTTPRequest

### DIFF
--- a/src/io/http.ts
+++ b/src/io/http.ts
@@ -241,7 +241,7 @@ export function isHTTPScheme(url: string): boolean {
 export const httpRouter: IORouter =
     (url: string, onProgress?: OnProgressCallback) => {
       if (typeof fetch === 'undefined') {
-        // http uses `fetch` or `node-fetch`, if one wants to use it in
+        // `http` uses `fetch` or `node-fetch`, if one wants to use it in
         // an environment that is not the browser or node they have to setup a
         // global fetch polyfill.
         return null;

--- a/src/io/http.ts
+++ b/src/io/http.ts
@@ -62,13 +62,13 @@ export class HTTPRequest implements IOHandler {
 
     assert(
         path != null && path.length > 0,
-        () => 'URL path for httpRequest must not be null, undefined or ' +
+        () => 'URL path for http must not be null, undefined or ' +
             'empty.');
 
     if (Array.isArray(path)) {
       assert(
           path.length === 2,
-          () => 'URL paths for httpRequest must have a length of 2, ' +
+          () => 'URL paths for http must have a length of 2, ' +
               `(actual length is ${path.length}).`);
     }
     this.path = path;
@@ -134,7 +134,7 @@ export class HTTPRequest implements IOHandler {
   /**
    * Load model artifacts via HTTP request(s).
    *
-   * See the documentation to `tf.io.httpRequest` for details on the saved
+   * See the documentation to `tf.io.http` for details on the saved
    * artifacts.
    *
    * @returns The loaded model artifacts (if loading succeeds).
@@ -238,10 +238,10 @@ export function isHTTPScheme(url: string): boolean {
   return url.match(HTTPRequest.URL_SCHEME_REGEX) != null;
 }
 
-export const httpRequestRouter: IORouter =
+export const httpRouter: IORouter =
     (url: string, onProgress?: OnProgressCallback) => {
       if (typeof fetch === 'undefined') {
-        // httpRequest uses `fetch` or `node-fetch`, if one wants to use it in
+        // http uses `fetch` or `node-fetch`, if one wants to use it in
         // an environment that is not the browser or node they have to setup a
         // global fetch polyfill.
         return null;
@@ -253,13 +253,13 @@ export const httpRequestRouter: IORouter =
           isHTTP = isHTTPScheme(url);
         }
         if (isHTTP) {
-          return httpRequest(url, {onProgress});
+          return http(url, {onProgress});
         }
       }
       return null;
     };
-IORouterRegistry.registerSaveRouter(httpRequestRouter);
-IORouterRegistry.registerLoadRouter(httpRequestRouter);
+IORouterRegistry.registerSaveRouter(httpRouter);
+IORouterRegistry.registerLoadRouter(httpRouter);
 
 /**
  * Creates an IOHandler subtype that sends model artifacts to HTTP server.
@@ -281,7 +281,7 @@ IORouterRegistry.registerLoadRouter(httpRequestRouter);
  * model.add(
  *     tf.layers.dense({units: 1, inputShape: [100], activation: 'sigmoid'}));
  *
- * const saveResult = await model.save(tf.io.httpRequest(
+ * const saveResult = await model.save(tf.io.http(
  *     'http://model-server:5000/upload', {method: 'PUT'}));
  * console.log(saveResult);
  * ```
@@ -325,17 +325,16 @@ IORouterRegistry.registerLoadRouter(httpRequestRouter);
  * @returns An instance of `IOHandler`.
  */
 /** @doc {heading: 'Models', subheading: 'Loading', namespace: 'io'} */
-export function httpRequest(
-    path: string, loadOptions?: LoadOptions): IOHandler {
+export function http(path: string, loadOptions?: LoadOptions): IOHandler {
   return new HTTPRequest(path, loadOptions);
 }
 
 /**
- * Deprecated. Use `tf.io.httpRequest`.
+ * Deprecated. Use `tf.io.http`.
  * @param path
  * @param loadOptions
  */
 export function browserHTTPRequest(
     path: string, loadOptions?: LoadOptions): IOHandler {
-  return httpRequest(path, loadOptions);
+  return http(path, loadOptions);
 }

--- a/src/io/http.ts
+++ b/src/io/http.ts
@@ -29,7 +29,7 @@ import {loadWeightsAsArrayBuffer} from './weights_loader';
 
 const OCTET_STREAM_MIME_TYPE = 'application/octet-stream';
 const JSON_TYPE = 'application/json';
-export class BrowserHTTPRequest implements IOHandler {
+export class HTTPRequest implements IOHandler {
   protected readonly path: string;
   protected readonly requestInit: RequestInit;
 
@@ -62,14 +62,13 @@ export class BrowserHTTPRequest implements IOHandler {
 
     assert(
         path != null && path.length > 0,
-        () =>
-            'URL path for browserHTTPRequest must not be null, undefined or ' +
+        () => 'URL path for httpRequest must not be null, undefined or ' +
             'empty.');
 
     if (Array.isArray(path)) {
       assert(
           path.length === 2,
-          () => 'URL paths for browserHTTPRequest must have a length of 2, ' +
+          () => 'URL paths for httpRequest must have a length of 2, ' +
               `(actual length is ${path.length}).`);
     }
     this.path = path;
@@ -135,7 +134,7 @@ export class BrowserHTTPRequest implements IOHandler {
   /**
    * Load model artifacts via HTTP request(s).
    *
-   * See the documentation to `browserHTTPRequest` for details on the saved
+   * See the documentation to `tf.io.httpRequest` for details on the saved
    * artifacts.
    *
    * @returns The loaded model artifacts (if loading succeeds).
@@ -236,14 +235,15 @@ export function parseUrl(url: string): [string, string] {
 }
 
 export function isHTTPScheme(url: string): boolean {
-  return url.match(BrowserHTTPRequest.URL_SCHEME_REGEX) != null;
+  return url.match(HTTPRequest.URL_SCHEME_REGEX) != null;
 }
 
 export const httpRequestRouter: IORouter =
     (url: string, onProgress?: OnProgressCallback) => {
       if (typeof fetch === 'undefined') {
-        // browserHTTPRequest uses `fetch`, if one wants to use it in node.js
-        // they have to setup a global fetch polyfill.
+        // httpRequest uses `fetch` or `node-fetch`, if one wants to use it in
+        // an environment that is not the browser or node they have to setup a
+        // global fetch polyfill.
         return null;
       } else {
         let isHTTP = true;
@@ -253,7 +253,7 @@ export const httpRequestRouter: IORouter =
           isHTTP = isHTTPScheme(url);
         }
         if (isHTTP) {
-          return browserHTTPRequest(url, {onProgress});
+          return httpRequest(url, {onProgress});
         }
       }
       return null;
@@ -281,7 +281,7 @@ IORouterRegistry.registerLoadRouter(httpRequestRouter);
  * model.add(
  *     tf.layers.dense({units: 1, inputShape: [100], activation: 'sigmoid'}));
  *
- * const saveResult = await model.save(tf.io.browserHTTPRequest(
+ * const saveResult = await model.save(tf.io.httpRequest(
  *     'http://model-server:5000/upload', {method: 'PUT'}));
  * console.log(saveResult);
  * ```
@@ -325,7 +325,17 @@ IORouterRegistry.registerLoadRouter(httpRequestRouter);
  * @returns An instance of `IOHandler`.
  */
 /** @doc {heading: 'Models', subheading: 'Loading', namespace: 'io'} */
+export function httpRequest(
+    path: string, loadOptions?: LoadOptions): IOHandler {
+  return new HTTPRequest(path, loadOptions);
+}
+
+/**
+ * Deprecated. Use `tf.io.httpRequest`.
+ * @param path
+ * @param loadOptions
+ */
 export function browserHTTPRequest(
     path: string, loadOptions?: LoadOptions): IOHandler {
-  return new BrowserHTTPRequest(path, loadOptions);
+  return httpRequest(path, loadOptions);
 }

--- a/src/io/http_test.ts
+++ b/src/io/http_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '../index';
 import {BROWSER_ENVS, CHROME_ENVS, describeWithFlags, NODE_ENVS} from '../jasmine_util';
-import {HTTPRequest, httpRequestRouter, parseUrl} from './http';
+import {HTTPRequest, httpRouter, parseUrl} from './http';
 
 // Test data.
 const modelTopology1: {} = {
@@ -94,7 +94,7 @@ const setupFakeWeightFiles =
                      });
     };
 
-describeWithFlags('httpRequest-load fetch', NODE_ENVS, () => {
+describeWithFlags('http-load fetch', NODE_ENVS, () => {
   let requestInits: {[key: string]: {headers: {[key: string]: string}}};
   // tslint:disable-next-line:no-any
   let originalFetch: any;
@@ -143,7 +143,7 @@ describeWithFlags('httpRequest-load fetch', NODE_ENVS, () => {
         },
         requestInits);
 
-    const handler = tf.io.httpRequest('./model.json');
+    const handler = tf.io.http('./model.json');
     const modelArtifacts = await handler.load();
     expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
     expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
@@ -154,7 +154,7 @@ describeWithFlags('httpRequest-load fetch', NODE_ENVS, () => {
     // tslint:disable-next-line:no-any
     delete (global as any).fetch;
     try {
-      tf.io.httpRequest('./model.json');
+      tf.io.http('./model.json');
     } catch (err) {
       expect(err.message).toMatch(/Unable to find fetch polyfill./);
     }
@@ -163,7 +163,7 @@ describeWithFlags('httpRequest-load fetch', NODE_ENVS, () => {
 
 // Turned off for other browsers due to:
 // https://github.com/tensorflow/tfjs/issues/426
-describeWithFlags('httpRequest-save', CHROME_ENVS, () => {
+describeWithFlags('http-save', CHROME_ENVS, () => {
   // Test data.
   const weightSpecs1: tf.io.WeightsManifestEntry[] = [
     {
@@ -295,7 +295,7 @@ describeWithFlags('httpRequest-save', CHROME_ENVS, () => {
 
   it('Save topology and weights, PUT method, extra headers', (done) => {
     const testStartDate = new Date();
-    const handler = tf.io.httpRequest('model-upload-test', {
+    const handler = tf.io.http('model-upload-test', {
       requestInit: {
         method: 'PUT',
         headers:
@@ -367,7 +367,7 @@ describeWithFlags('httpRequest-save', CHROME_ENVS, () => {
     handler.save(artifacts1)
         .then(saveResult => {
           done.fail(
-              'Calling httpRequest at invalid URL succeeded ' +
+              'Calling http at invalid URL succeeded ' +
               'unexpectedly');
         })
         .catch(err => {
@@ -382,29 +382,26 @@ describeWithFlags('httpRequest-save', CHROME_ENVS, () => {
   });
 
   it('Existing body leads to Error', () => {
-    expect(() => tf.io.httpRequest('model-upload-test', {
+    expect(() => tf.io.http('model-upload-test', {
       requestInit: {body: 'existing body'}
     })).toThrowError(/requestInit is expected to have no pre-existing body/);
   });
 
   it('Empty, null or undefined URL paths lead to Error', () => {
-    expect(() => tf.io.httpRequest(null))
+    expect(() => tf.io.http(null))
         .toThrowError(/must not be null, undefined or empty/);
-    expect(() => tf.io.httpRequest(undefined))
+    expect(() => tf.io.http(undefined))
         .toThrowError(/must not be null, undefined or empty/);
-    expect(() => tf.io.httpRequest(''))
+    expect(() => tf.io.http(''))
         .toThrowError(/must not be null, undefined or empty/);
   });
 
   it('router', () => {
-    expect(httpRequestRouter('http://bar/foo') instanceof HTTPRequest)
+    expect(httpRouter('http://bar/foo') instanceof HTTPRequest).toEqual(true);
+    expect(httpRouter('https://localhost:5000/upload') instanceof HTTPRequest)
         .toEqual(true);
-    expect(
-        httpRequestRouter('https://localhost:5000/upload') instanceof
-        HTTPRequest)
-        .toEqual(true);
-    expect(httpRequestRouter('localhost://foo')).toBeNull();
-    expect(httpRequestRouter('foo:5000/bar')).toBeNull();
+    expect(httpRouter('localhost://foo')).toBeNull();
+    expect(httpRouter('foo:5000/bar')).toBeNull();
   });
 });
 
@@ -429,7 +426,7 @@ describeWithFlags('parseUrl', BROWSER_ENVS, () => {
   });
 });
 
-describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
+describeWithFlags('http-load', BROWSER_ENVS, () => {
   describe('JSON model', () => {
     let requestInits: {[key: string]: {headers: {[key: string]: string}}};
 
@@ -468,7 +465,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('./model.json');
+      const handler = tf.io.http('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
@@ -509,7 +506,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest(
+      const handler = tf.io.http(
           './model.json',
           {requestInit: {headers: {'header_key_1': 'header_value_1'}}});
       const modelArtifacts = await handler.load();
@@ -560,7 +557,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('./model.json');
+      const handler = tf.io.http('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
@@ -603,7 +600,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('./model.json');
+      const handler = tf.io.http('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs)
@@ -648,7 +645,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('path1/model.json');
+      const handler = tf.io.http('path1/model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs)
@@ -670,7 +667,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('./model.json');
+      const handler = tf.io.http('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toBeUndefined();
@@ -711,7 +708,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.httpRequest('path1/model.json');
+      const handler = tf.io.http('path1/model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toBeUndefined();
       expect(modelArtifacts.weightSpecs)
@@ -731,7 +728,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
                    {data: JSON.stringify({}), contentType: 'application/json'}
              },
              requestInits);
-         const handler = tf.io.httpRequest('path1/model.json');
+         const handler = tf.io.http('path1/model.json');
          handler.load()
              .then(modelTopology1 => {
                done.fail(
@@ -752,7 +749,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
                 {data: JSON.stringify({}), contentType: 'text/html'}
           },
           requestInits);
-      const handler = tf.io.httpRequest('path2/model.json');
+      const handler = tf.io.http('path2/model.json');
       try {
         const data = await handler.load();
         expect(data).toBeDefined();
@@ -805,7 +802,7 @@ describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
       }
     }
 
-    const handler = tf.io.httpRequest(
+    const handler = tf.io.http(
         './model.json',
         {requestInit: {credentials: 'include'}, fetchFunc: customFetch});
     const modelArtifacts = await handler.load();

--- a/src/io/http_test.ts
+++ b/src/io/http_test.ts
@@ -15,13 +15,9 @@
  * =============================================================================
  */
 
-/**
- * Unit tests for browser_http.ts.
- */
-
 import * as tf from '../index';
 import {BROWSER_ENVS, CHROME_ENVS, describeWithFlags, NODE_ENVS} from '../jasmine_util';
-import {BrowserHTTPRequest, httpRequestRouter, parseUrl} from './browser_http';
+import {HTTPRequest, httpRequestRouter, parseUrl} from './http';
 
 // Test data.
 const modelTopology1: {} = {
@@ -57,7 +53,7 @@ const modelTopology1: {} = {
   'backend': 'tensorflow'
 };
 
-let windowFetchSpy: jasmine.Spy;
+let fetchSpy: jasmine.Spy;
 
 type TypedArrays = Float32Array|Int32Array|Uint8Array|Uint16Array;
 const fakeResponse =
@@ -85,22 +81,20 @@ const setupFakeWeightFiles =
       }
     },
      requestInits: {[key: string]: RequestInit}) => {
-      windowFetchSpy =
-          // tslint:disable-next-line:no-any
-          spyOn(tf.util, 'fetch')
-              .and.callFake((path: string, init: RequestInit) => {
-                if (fileBufferMap[path]) {
-                  requestInits[path] = init;
-                  return Promise.resolve(fakeResponse(
-                      fileBufferMap[path].data, fileBufferMap[path].contentType,
-                      path));
-                } else {
-                  return Promise.reject('path not found');
-                }
-              });
+      fetchSpy = spyOn(tf.util, 'fetch')
+                     .and.callFake((path: string, init: RequestInit) => {
+                       if (fileBufferMap[path]) {
+                         requestInits[path] = init;
+                         return Promise.resolve(fakeResponse(
+                             fileBufferMap[path].data,
+                             fileBufferMap[path].contentType, path));
+                       } else {
+                         return Promise.reject('path not found');
+                       }
+                     });
     };
 
-describeWithFlags('browserHTTPRequest-load fetch', NODE_ENVS, () => {
+describeWithFlags('httpRequest-load fetch', NODE_ENVS, () => {
   let requestInits: {[key: string]: {headers: {[key: string]: string}}};
   // tslint:disable-next-line:no-any
   let originalFetch: any;
@@ -149,7 +143,7 @@ describeWithFlags('browserHTTPRequest-load fetch', NODE_ENVS, () => {
         },
         requestInits);
 
-    const handler = tf.io.browserHTTPRequest('./model.json');
+    const handler = tf.io.httpRequest('./model.json');
     const modelArtifacts = await handler.load();
     expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
     expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
@@ -160,7 +154,7 @@ describeWithFlags('browserHTTPRequest-load fetch', NODE_ENVS, () => {
     // tslint:disable-next-line:no-any
     delete (global as any).fetch;
     try {
-      tf.io.browserHTTPRequest('./model.json');
+      tf.io.httpRequest('./model.json');
     } catch (err) {
       expect(err.message).toMatch(/Unable to find fetch polyfill./);
     }
@@ -169,7 +163,7 @@ describeWithFlags('browserHTTPRequest-load fetch', NODE_ENVS, () => {
 
 // Turned off for other browsers due to:
 // https://github.com/tensorflow/tfjs/issues/426
-describeWithFlags('browserHTTPRequest-save', CHROME_ENVS, () => {
+describeWithFlags('httpRequest-save', CHROME_ENVS, () => {
   // Test data.
   const weightSpecs1: tf.io.WeightsManifestEntry[] = [
     {
@@ -301,7 +295,7 @@ describeWithFlags('browserHTTPRequest-save', CHROME_ENVS, () => {
 
   it('Save topology and weights, PUT method, extra headers', (done) => {
     const testStartDate = new Date();
-    const handler = tf.io.browserHTTPRequest('model-upload-test', {
+    const handler = tf.io.httpRequest('model-upload-test', {
       requestInit: {
         method: 'PUT',
         headers:
@@ -373,7 +367,7 @@ describeWithFlags('browserHTTPRequest-save', CHROME_ENVS, () => {
     handler.save(artifacts1)
         .then(saveResult => {
           done.fail(
-              'Calling browserHTTPRequest at invalid URL succeeded ' +
+              'Calling httpRequest at invalid URL succeeded ' +
               'unexpectedly');
         })
         .catch(err => {
@@ -384,30 +378,30 @@ describeWithFlags('browserHTTPRequest-save', CHROME_ENVS, () => {
   it('getLoadHandlers with one URL string', () => {
     const handlers = tf.io.getLoadHandlers('http://foo/model.json');
     expect(handlers.length).toEqual(1);
-    expect(handlers[0] instanceof BrowserHTTPRequest).toEqual(true);
+    expect(handlers[0] instanceof HTTPRequest).toEqual(true);
   });
 
   it('Existing body leads to Error', () => {
-    expect(() => tf.io.browserHTTPRequest('model-upload-test', {
+    expect(() => tf.io.httpRequest('model-upload-test', {
       requestInit: {body: 'existing body'}
     })).toThrowError(/requestInit is expected to have no pre-existing body/);
   });
 
   it('Empty, null or undefined URL paths lead to Error', () => {
-    expect(() => tf.io.browserHTTPRequest(null))
+    expect(() => tf.io.httpRequest(null))
         .toThrowError(/must not be null, undefined or empty/);
-    expect(() => tf.io.browserHTTPRequest(undefined))
+    expect(() => tf.io.httpRequest(undefined))
         .toThrowError(/must not be null, undefined or empty/);
-    expect(() => tf.io.browserHTTPRequest(''))
+    expect(() => tf.io.httpRequest(''))
         .toThrowError(/must not be null, undefined or empty/);
   });
 
   it('router', () => {
-    expect(httpRequestRouter('http://bar/foo') instanceof BrowserHTTPRequest)
+    expect(httpRequestRouter('http://bar/foo') instanceof HTTPRequest)
         .toEqual(true);
     expect(
         httpRequestRouter('https://localhost:5000/upload') instanceof
-        BrowserHTTPRequest)
+        HTTPRequest)
         .toEqual(true);
     expect(httpRequestRouter('localhost://foo')).toBeNull();
     expect(httpRequestRouter('foo:5000/bar')).toBeNull();
@@ -435,7 +429,7 @@ describeWithFlags('parseUrl', BROWSER_ENVS, () => {
   });
 });
 
-describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
+describeWithFlags('httpRequest-load', BROWSER_ENVS, () => {
   describe('JSON model', () => {
     let requestInits: {[key: string]: {headers: {[key: string]: string}}};
 
@@ -474,14 +468,14 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('./model.json');
+      const handler = tf.io.httpRequest('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
       expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
       expect(Object.keys(requestInits).length).toEqual(2);
       // Assert that fetch is invoked with `window` as the context.
-      expect(windowFetchSpy.calls.mostRecent().object).toEqual(window);
+      expect(fetchSpy.calls.mostRecent().object).toEqual(window);
     });
 
     it('1 group, 2 weights, 1 path, with requestInit', async () => {
@@ -515,7 +509,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest(
+      const handler = tf.io.httpRequest(
           './model.json',
           {requestInit: {headers: {'header_key_1': 'header_value_1'}}});
       const modelArtifacts = await handler.load();
@@ -529,7 +523,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
       expect(requestInits['./weightfile0'].headers['header_key_1'])
           .toEqual('header_value_1');
 
-      expect(windowFetchSpy.calls.mostRecent().object).toEqual(window);
+      expect(fetchSpy.calls.mostRecent().object).toEqual(window);
     });
 
     it('1 group, 2 weight, 2 paths', async () => {
@@ -566,7 +560,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('./model.json');
+      const handler = tf.io.httpRequest('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
@@ -609,7 +603,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('./model.json');
+      const handler = tf.io.httpRequest('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs)
@@ -654,7 +648,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('path1/model.json');
+      const handler = tf.io.httpRequest('path1/model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs)
@@ -676,7 +670,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('./model.json');
+      const handler = tf.io.httpRequest('./model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
       expect(modelArtifacts.weightSpecs).toBeUndefined();
@@ -717,7 +711,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
           },
           requestInits);
 
-      const handler = tf.io.browserHTTPRequest('path1/model.json');
+      const handler = tf.io.httpRequest('path1/model.json');
       const modelArtifacts = await handler.load();
       expect(modelArtifacts.modelTopology).toBeUndefined();
       expect(modelArtifacts.weightSpecs)
@@ -737,7 +731,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
                    {data: JSON.stringify({}), contentType: 'application/json'}
              },
              requestInits);
-         const handler = tf.io.browserHTTPRequest('path1/model.json');
+         const handler = tf.io.httpRequest('path1/model.json');
          handler.load()
              .then(modelTopology1 => {
                done.fail(
@@ -758,7 +752,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
                 {data: JSON.stringify({}), contentType: 'text/html'}
           },
           requestInits);
-      const handler = tf.io.browserHTTPRequest('path2/model.json');
+      const handler = tf.io.httpRequest('path2/model.json');
       try {
         const data = await handler.load();
         expect(data).toBeDefined();
@@ -811,7 +805,7 @@ describeWithFlags('browserHTTPRequest-load', BROWSER_ENVS, () => {
       }
     }
 
-    const handler = tf.io.browserHTTPRequest(
+    const handler = tf.io.httpRequest(
         './model.json',
         {requestInit: {credentials: 'include'}, fetchFunc: customFetch});
     const modelArtifacts = await handler.load();

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -21,7 +21,7 @@ import './indexed_db';
 import './local_storage';
 
 import {browserFiles} from './browser_files';
-import {browserHTTPRequest, isHTTPScheme} from './browser_http';
+import {browserHTTPRequest, httpRequest, isHTTPScheme} from './http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, withSaveHandler} from './passthrough';
 import {getLoadHandlers, getSaveHandlers, registerLoadRouter, registerSaveRouter} from './router_registry';
@@ -39,6 +39,7 @@ export {
   getLoadHandlers,
   getModelArtifactsInfoForJSON,
   getSaveHandlers,
+  httpRequest,
   IOHandler,
   isHTTPScheme,
   LoadHandler,

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -21,7 +21,7 @@ import './indexed_db';
 import './local_storage';
 
 import {browserFiles} from './browser_files';
-import {browserHTTPRequest, httpRequest, isHTTPScheme} from './http';
+import {browserHTTPRequest, http, isHTTPScheme} from './http';
 import {concatenateArrayBuffers, decodeWeights, encodeWeights, getModelArtifactsInfoForJSON} from './io_utils';
 import {fromMemory, withSaveHandler} from './passthrough';
 import {getLoadHandlers, getSaveHandlers, registerLoadRouter, registerSaveRouter} from './router_registry';
@@ -39,7 +39,7 @@ export {
   getLoadHandlers,
   getModelArtifactsInfoForJSON,
   getSaveHandlers,
-  httpRequest,
+  http,
   IOHandler,
   isHTTPScheme,
   LoadHandler,


### PR DESCRIPTION
`tf.io.http` supports node and the browser as well as overriding the global fetch and using it.

Node will use this registry instead of registering its own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1684)
<!-- Reviewable:end -->
