### PR TITLE
Fix build-npm.sh script

### DIFF
--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -16,9 +16,9 @@
 
 set -e
 
-rimraf dist/
+yarn run rimraf dist/
 yarn
 
 yarn build
-rollup -c --visualize
+yarn run rollup -c --visualize
 echo "Stored standalone library at dist/tf-core(.min).js"

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -16,9 +16,9 @@
 
 set -e
 
-yarn run rimraf dist/
+yarn rimraf dist/
 yarn
 
 yarn build
-yarn run rollup -c --visualize
+yarn rollup -c --visualize
 echo "Stored standalone library at dist/tf-core(.min).js"


### PR DESCRIPTION
MISC

Fix command not found error in `build-npm.sh`. As they are installed via npm, the path should be resolved by `yarn run` or `npx`. 

```
./scripts/build-npm.sh: line 19: rimraf: command not found
./scripts/build-npm.sh: line 23: rollup: command not found
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1692)
<!-- Reviewable:end -->
