### PR TITLE
Fix the result of ones with complex type

### DIFF
--- a/src/ops/tensor_ops.ts
+++ b/src/ops/tensor_ops.ts
@@ -386,7 +386,7 @@ function ones<R extends Rank>(
     shape: ShapeMap[R], dtype: DataType = 'float32'): Tensor<R> {
   if (dtype === 'complex64') {
     const real = ones(shape, 'float32');
-    const imag = ones(shape, 'float32');
+    const imag = zeros(shape, 'float32');
     return complex(real, imag);
   }
   const values = makeOnesTypedArray(sizeFromShape(shape), dtype);

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -1416,6 +1416,12 @@ describeWithFlags('tensor', ALL_ENVS, () => {
         'integers but got shape [2,-2].';
     expect(() => tf.tensor([1, 2, 3, 4], [2, -2])).toThrowError(msg);
   });
+
+  it('ones with complex type', () => {
+    // Imaginary part should be zero.
+    const a = tf.ones([2, 2], 'complex64');
+    expectArraysClose(a, [1, 0, 1, 0, 1, 0, 1, 0]);
+  });
 });
 
 describe('tensor.toString', () => {


### PR DESCRIPTION
`ones` ops should return the value with zeros in the imaginary part to be consistent with TensorFlow core.

```python
a = tf.ones([2, 2], dtype='complex64')
print(a.eval())

# [[1.+0.j 1.+0.j]
#  [1.+0.j 1.+0.j]]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1693)
<!-- Reviewable:end -->
