### PR TITLE
Fix environment flag URL parsing when the value is false.

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -143,7 +143,7 @@ function decodeParam(
 function parseValue(flagName: string, value: string): FlagValue {
   value = value.toLowerCase();
   if (value === 'true' || value === 'false') {
-    return Boolean(value) === true;
+    return value === 'true';
   } else if (`${+ value}` === value) {
     return +value;
   }

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -41,12 +41,20 @@ describe('initializes flags from the url', () => {
     expect(env.features).toEqual({});
   });
 
-  it('one registered flag', () => {
+  it('one registered flag true', () => {
     const global = {location: {search: '?tfjsflags=FLAG1:true'}};
     const env = new Environment(global);
     env.registerFlag('FLAG1', () => false);
 
     expect(env.get('FLAG1')).toBe(true);
+  });
+
+  it('one registered flag false', () => {
+    const global = {location: {search: '?tfjsflags=FLAG1:false'}};
+    const env = new Environment(global);
+    env.registerFlag('FLAG1', () => true);
+
+    expect(env.get('FLAG1')).toBe(false);
   });
 
   it('two registered flags', () => {


### PR DESCRIPTION
Currently if you pass a false in the URL we parse it as true.

Turns out `Boolean('false') === true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1705)
<!-- Reviewable:end -->
