### PR TITLE
webgpu: change matmul_webgpu tile size back to 16

### DIFF
--- a/src/backends/webgpu/src/kernels/matmul_webgpu.ts
+++ b/src/backends/webgpu/src/kernels/matmul_webgpu.ts
@@ -23,7 +23,7 @@ export class MatMulProgram implements WebGPUProgram {
   dispatch: [number, number, number];
   variableNames = ['A', 'B'];
   uniforms = 'uint dimAOuter, dimInner, dimBOuter, batch;';
-  tileSize: [number, number] = [32, 32];  // Must be square.
+  tileSize: [number, number] = [16, 16];  // Must be square.
 
   constructor(outputShape: [number, number, number]) {
     this.outputShape = outputShape;


### PR DESCRIPTION
A tile size of 32 is causing failures (and possibly other weird behavior) on Mac.

This is untested because WEBGPU_MATMUL_WORK_PER_THREAD defaults to 2
(and uses the packed version instead).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1711)
<!-- Reviewable:end -->
