### PR TITLE
Fix docs argument order for fused.matMut

### DIFF
--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -31,17 +31,17 @@ import {Activation} from './fused_util';
  * ```js
  * const a = tf.tensor2d([-1, -2], [1, 2]);
  * const b = tf.tensor2d([1, 2, 3, 4], [2, 2]);
- * const c = tf.tensor2d([1, 2], [1, 2]);
+ * const bias = tf.tensor2d([1, 2], [1, 2]);
  *
- * tf.fused.matMul(a, b, false, false, 'relu', c);
+ * tf.fused.matMul(a, b, false, false, bias, 'relu');
  * ```
  *
  * @param a First matrix in dot product operation.
  * @param b Second matrix in dot product operation.
  * @param transposeA If true, `a` is transposed before multiplication.
  * @param transposeB If true, `b` is transposed before multiplication.
- * @param activation Name of activation kernel (defaults to `linear`).
  * @param bias Matrix to be added to the result.
+ * @param activation Name of activation kernel (defaults to `linear`).
  */
 /** @doc {heading: 'Operations', subheading: 'Matrices', namespace: 'fused'} */
 function matMul_<T extends Tensor>(

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -33,7 +33,7 @@ import {Activation} from './fused_util';
  * const b = tf.tensor2d([1, 2, 3, 4], [2, 2]);
  * const bias = tf.tensor2d([1, 2], [1, 2]);
  *
- * tf.fused.matMul(a, b, false, false, bias, 'relu');
+ * tf.fused.matMul(a, b, false, false, bias, 'relu').print();
  * ```
  *
  * @param a First matrix in dot product operation.


### PR DESCRIPTION
The argument order in the comment for [`fused.matMut`](https://js.tensorflow.org/api/latest/#fused.matMul) doesn't match the argument order in the code, resulting in this error when you try to run the example code: 

```
An error occured on line: 5
Argument 'bias' passed to 'fused matMul' must be numeric tensor, but got string tensor
```

This PR fixes the argument order in the comment to match the code, and renames 'c' to 'bias' in the comment to make it clearer that that argument is the bias argument. It also adds `.print();` to the computed tensor so that we can see the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1712)
<!-- Reviewable:end -->
