### PR TITLE
webgpu: matmul_packed: double buffer reads

### DIFF
--- a/src/backends/webgpu/src/flags_webgpu.ts
+++ b/src/backends/webgpu/src/flags_webgpu.ts
@@ -24,4 +24,4 @@ ENV.registerFlag('WEBGPU_IMMEDIATE_EXECUTION_ENABLED', () => true);
  * Thread register block size for matmul kernel. If 0, we use the version of
  * matMul without register blocking.
  */
-ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 2);
+ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);

--- a/src/backends/webgpu/src/kernels/matmul_packed_webgpu.ts
+++ b/src/backends/webgpu/src/kernels/matmul_packed_webgpu.ts
@@ -24,22 +24,23 @@ export function makeMatMulPackedSource(workPerThread: number): string {
   return `
     ${matMulHeader}
 
-    const uint TileSide = TileSize.x;  // TileSize.x == TileSize.y
+    const uint WorkGroupSize = gl_WorkGroupSize.x;  // .x == .y
     const uint WorkPerThread = ${workPerThread};
-    shared float mm_Asub[TileSide * WorkPerThread][TileSide * WorkPerThread];
-    shared float mm_Bsub[TileSide * WorkPerThread][TileSide * WorkPerThread];
+    const uint MatTileSize = WorkGroupSize * WorkPerThread;
+
+    shared float mm_Asub[MatTileSize][MatTileSize];
+    shared float mm_Bsub[MatTileSize][MatTileSize];
 
     void mm_matMul(uint dimAOuter, uint dimInner, uint dimBOuter) {
-      uint row = gl_LocalInvocationID.y;   // 0..local_size_x
-      uint col = gl_LocalInvocationID.x;   // 0..local_size_y
-      uint tileRow = row * WorkPerThread;  // 0..TileSide, stride by local_size
-      uint tileCol = col * WorkPerThread;  // 0..TileSide
+      // These are 0..MatTileSize, in increments of WorkPerThread.
+      uint tileRow = gl_LocalInvocationID.y * WorkPerThread;
+      uint tileCol = gl_LocalInvocationID.x * WorkPerThread;
 
-      // 0..AOuter, stride by tileSize
-      uint globalRow = TileSide * gl_WorkGroupID.y + tileRow;
-      uint globalCol = TileSide * gl_WorkGroupID.x + tileCol;
+      // These are 0..AOuter, in increments of WorkPerThread.
+      uint globalRow = gl_GlobalInvocationID.y * WorkPerThread;
+      uint globalCol = gl_GlobalInvocationID.x * WorkPerThread;
 
-      uint numTiles = (dimInner - 1) / TileSize.x + 1;
+      uint numTiles = (dimInner - 1) / MatTileSize + 1;
 
       float acc[WorkPerThread][WorkPerThread];
       float ACached;
@@ -62,9 +63,9 @@ export function makeMatMulPackedSource(workPerThread: number): string {
 
             mm_Asub[inputRow][inputCol] = mm_readA(
                 globalRow + innerRow,
-                t * TileSize.x + tileCol + innerCol);
+                t * MatTileSize + tileCol + innerCol);
             mm_Bsub[inputRow][inputCol] = mm_readB(
-                t * TileSize.x + tileRow + innerRow,
+                t * MatTileSize + tileRow + innerRow,
                 globalCol + innerCol);
           }
         }
@@ -72,7 +73,7 @@ export function makeMatMulPackedSource(workPerThread: number): string {
         barrier();
 
         // Compute acc values for a single thread.
-        for (uint k = 0; k < TileSize.x; k++) {
+        for (uint k = 0; k < MatTileSize; k++) {
           for (uint inner = 0; inner < WorkPerThread; inner++) {
             BCached[inner] = mm_Bsub[k][tileCol + inner];
           }
@@ -112,15 +113,20 @@ export class MatMulPackedProgram implements WebGPUProgram {
   workPerThread: number;
   variableNames = ['A', 'B'];
   uniforms = 'uint dimAOuter, dimInner, dimBOuter, batch;';
-  tileSize: [number, number, number] = [16, 16, 1];
+  workGroupSize: [number, number, number] = [16, 16, 1];
 
   constructor(outputShape: [number, number, number], workPerThread: number) {
     this.outputShape = outputShape;
     this.workPerThread = workPerThread;
 
     const dispatchLayout = {x: [1], y: [2], z: [0]};
+    const matTileSize: [number, number, number] = [
+      this.workGroupSize[0] * workPerThread,
+      this.workGroupSize[1] * workPerThread,
+      this.workGroupSize[2],
+    ];
     this.dispatch =
-        computeDispatch(dispatchLayout, this.outputShape, this.tileSize);
+        computeDispatch(dispatchLayout, this.outputShape, matTileSize);
 
     // Consider compiling a different version of the shader that doesn't care
     // about boundary conditions when loading from Asub / Bsub when tiles fit

--- a/src/backends/webgpu/src/kernels/webgpu_program.ts
+++ b/src/backends/webgpu/src/kernels/webgpu_program.ts
@@ -31,10 +31,10 @@ export interface WebGPUProgram {
   // Each thread writes to workPerThread * workPerThread locations in the output
   // buffer.
   workPerThread?: number;
-  // tileSize.x * tileSize.y * tileSize.z = the number of threads in a thread
-  // group.
-  // Individual dimensions determines thread layout within the group.
-  tileSize?: [number, number?, number?];
+  // workGroupSize.x * workGroupSize.y * workGroupSize.z = the number of threads
+  // in a thread group. Individual dimensions determines thread layout within
+  // the group.
+  workGroupSize?: [number, number, number];
 }
 
 export interface WebGPUBinary {
@@ -112,7 +112,7 @@ export const compileProgram =
     };
 
 export function makeShaderKey(program: WebGPUProgram): string {
-  const key =
-      (program.tileSize ? program.tileSize.join(',') : '') + program.userCode;
+  const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
+      program.userCode;
   return key;
 }

--- a/src/backends/webgpu/src/shader_preprocessor.ts
+++ b/src/backends/webgpu/src/shader_preprocessor.ts
@@ -43,7 +43,7 @@ function mapToGlslTypes(type: DataType): GLSLDataType|DataType {
 }
 
 interface ProgramParams {
-  tileSize?: [number, number?, number?];
+  workGroupSize?: [number, number, number];
   variableNames: string[];
   uniforms?: string;
   userCode: string;
@@ -55,16 +55,11 @@ export function makeShader(
     program: ProgramParams): string {
   const prefixSnippets: string[] = [];
 
-  if (program.tileSize != null) {
-    const ts = program.tileSize;
-
-    ts[1] = ts[1] || 1;
-    ts[2] = ts[2] || 1;
+  if (program.workGroupSize != null) {
     prefixSnippets.push(`
-      const uvec3 TileSize = uvec3(${ts[0]}, ${ts[1]}, ${ts[2]});
-      layout (local_size_x = TileSize.x,
-              local_size_y = TileSize.y,
-              local_size_z = TileSize.z) in;
+      layout (local_size_x = ${program.workGroupSize[0]},
+              local_size_y = ${program.workGroupSize[1]},
+              local_size_z = ${program.workGroupSize[2]}) in;
     `);
   }
 

--- a/src/backends/webgpu/src/webgpu_util.ts
+++ b/src/backends/webgpu/src/webgpu_util.ts
@@ -26,13 +26,15 @@ const arrayProduct = (arr: number[]) => {
   return product;
 };
 
-// Computes dispatch geometry based on layout of output dimensions and tileSize.
+// Computes dispatch geometry based on layout of output dimensions and
+// workGroupSize.
 export function computeDispatch(
     layout: {x: number[], y: number[], z: number[]}, outputShape: number[],
-    tileSize: [number, number, number] = [1, 1, 1]): [number, number, number] {
+    matTileSize: [number, number, number] =
+        [1, 1, 1]): [number, number, number] {
   return [
-    Math.ceil(arrayProduct(layout.x.map(d => outputShape[d])) / tileSize[0]),
-    Math.ceil(arrayProduct(layout.y.map(d => outputShape[d])) / tileSize[1]),
-    Math.ceil(arrayProduct(layout.z.map(d => outputShape[d])) / tileSize[2])
+    Math.ceil(arrayProduct(layout.x.map(d => outputShape[d])) / matTileSize[0]),
+    Math.ceil(arrayProduct(layout.y.map(d => outputShape[d])) / matTileSize[1]),
+    Math.ceil(arrayProduct(layout.z.map(d => outputShape[d])) / matTileSize[2])
   ];
 }

--- a/src/backends/webgpu/src/webgpu_util_test.ts
+++ b/src/backends/webgpu/src/webgpu_util_test.ts
@@ -19,14 +19,14 @@ import {computeDispatch} from './webgpu_util';
 
 describe('webgpu util', () => {
   it('computeDispatch returns dispatch dimensions based on layout of ' +
-         'output dimensions and tileSize.',
+         'output dimensions and workGroupSize.',
      () => {
        const layout = {x: [0], y: [1], z: [2, 3]};
        const outputShape = [1, 2, 3, 2];
 
-       const tileSize = [2, 2, 1] as [number, number, number];
+       const workGroupSize = [2, 2, 1] as [number, number, number];
 
-       const dispatch = computeDispatch(layout, outputShape, tileSize);
+       const dispatch = computeDispatch(layout, outputShape, workGroupSize);
        expect(dispatch).toEqual([1, 1, 6]);
      });
 });


### PR DESCRIPTION
With 16x16 tile sizes:

| version | WPT=2 | WPT=4
| --- | --- | ---
| single buffered (1 shared mem) (#1731) | 3.1ms | 2.5ms
| double buffered (2 shared mem) (#1731+#1723) | 3.1ms | 2.9ms

WebGL: 1.7ms.

MacBookPro15,2/Intel Iris Plus 655

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1723)
<!-- Reviewable:end -->
