### PR TITLE
webgpu: matmul_packed: fix WPT so it doesn't do unused work

### DIFF
--- a/src/backends/webgpu/src/flags_webgpu.ts
+++ b/src/backends/webgpu/src/flags_webgpu.ts
@@ -24,4 +24,4 @@ ENV.registerFlag('WEBGPU_IMMEDIATE_EXECUTION_ENABLED', () => true);
  * Thread register block size for matmul kernel. If 0, we use the version of
  * matMul without register blocking.
  */
-ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 2);
+ENV.registerFlag('WEBGPU_MATMUL_WORK_PER_THREAD', () => 4);

--- a/src/backends/webgpu/src/kernels/webgpu_program.ts
+++ b/src/backends/webgpu/src/kernels/webgpu_program.ts
@@ -31,10 +31,10 @@ export interface WebGPUProgram {
   // Each thread writes to workPerThread * workPerThread locations in the output
   // buffer.
   workPerThread?: number;
-  // tileSize.x * tileSize.y * tileSize.z = the number of threads in a thread
-  // group.
-  // Individual dimensions determines thread layout within the group.
-  tileSize?: [number, number?, number?];
+  // workGroupSize.x * workGroupSize.y * workGroupSize.z = the number of threads
+  // in a thread group. Individual dimensions determines thread layout within
+  // the group.
+  workGroupSize?: [number, number, number];
 }
 
 export interface WebGPUBinary {
@@ -112,7 +112,7 @@ export const compileProgram =
     };
 
 export function makeShaderKey(program: WebGPUProgram): string {
-  const key =
-      (program.tileSize ? program.tileSize.join(',') : '') + program.userCode;
+  const key = (program.workGroupSize ? program.workGroupSize.join(',') : '') +
+      program.userCode;
   return key;
 }

--- a/src/backends/webgpu/src/shader_preprocessor.ts
+++ b/src/backends/webgpu/src/shader_preprocessor.ts
@@ -43,7 +43,7 @@ function mapToGlslTypes(type: DataType): GLSLDataType|DataType {
 }
 
 interface ProgramParams {
-  tileSize?: [number, number?, number?];
+  workGroupSize?: [number, number, number];
   variableNames: string[];
   uniforms?: string;
   userCode: string;
@@ -55,16 +55,11 @@ export function makeShader(
     program: ProgramParams): string {
   const prefixSnippets: string[] = [];
 
-  if (program.tileSize != null) {
-    const ts = program.tileSize;
-
-    ts[1] = ts[1] || 1;
-    ts[2] = ts[2] || 1;
+  if (program.workGroupSize != null) {
     prefixSnippets.push(`
-      const uvec3 TileSize = uvec3(${ts[0]}, ${ts[1]}, ${ts[2]});
-      layout (local_size_x = TileSize.x,
-              local_size_y = TileSize.y,
-              local_size_z = TileSize.z) in;
+      layout (local_size_x = ${program.workGroupSize[0]},
+              local_size_y = ${program.workGroupSize[1]},
+              local_size_z = ${program.workGroupSize[2]}) in;
     `);
   }
 

--- a/src/backends/webgpu/src/webgpu_util.ts
+++ b/src/backends/webgpu/src/webgpu_util.ts
@@ -26,13 +26,22 @@ const arrayProduct = (arr: number[]) => {
   return product;
 };
 
-// Computes dispatch geometry based on layout of output dimensions and tileSize.
+// Computes dispatch geometry based on layout of output dimensions and
+// workGroupSize.
 export function computeDispatch(
     layout: {x: number[], y: number[], z: number[]}, outputShape: number[],
-    tileSize: [number, number, number] = [1, 1, 1]): [number, number, number] {
+    workGroupSize: [number, number, number] = [1, 1, 1],
+    elementsPerThread: [number, number, number] =
+        [1, 1, 1]): [number, number, number] {
   return [
-    Math.ceil(arrayProduct(layout.x.map(d => outputShape[d])) / tileSize[0]),
-    Math.ceil(arrayProduct(layout.y.map(d => outputShape[d])) / tileSize[1]),
-    Math.ceil(arrayProduct(layout.z.map(d => outputShape[d])) / tileSize[2])
+    Math.ceil(
+        arrayProduct(layout.x.map(d => outputShape[d])) /
+        (workGroupSize[0] * elementsPerThread[0])),
+    Math.ceil(
+        arrayProduct(layout.y.map(d => outputShape[d])) /
+        (workGroupSize[1] * elementsPerThread[1])),
+    Math.ceil(
+        arrayProduct(layout.z.map(d => outputShape[d])) /
+        (workGroupSize[2] * elementsPerThread[2]))
   ];
 }

--- a/src/backends/webgpu/src/webgpu_util_test.ts
+++ b/src/backends/webgpu/src/webgpu_util_test.ts
@@ -19,14 +19,28 @@ import {computeDispatch} from './webgpu_util';
 
 describe('webgpu util', () => {
   it('computeDispatch returns dispatch dimensions based on layout of ' +
-         'output dimensions and tileSize.',
+         'output dimensions and workGroupSize.',
      () => {
        const layout = {x: [0], y: [1], z: [2, 3]};
        const outputShape = [1, 2, 3, 2];
 
-       const tileSize = [2, 2, 1] as [number, number, number];
+       const workGroupSize = [2, 2, 1] as [number, number, number];
 
-       const dispatch = computeDispatch(layout, outputShape, tileSize);
+       const dispatch = computeDispatch(layout, outputShape, workGroupSize);
        expect(dispatch).toEqual([1, 1, 6]);
+     });
+
+  it('computeDispatch returns dispatch dimensions based on layout of ' +
+         'output dimensions, workGroupSize, and elementsPerThread.',
+     () => {
+       const layout = {x: [0], y: [1], z: [2, 3]};
+       const outputShape = [4, 8, 12, 2];
+
+       const workGroupSize = [2, 1, 1] as [number, number, number];
+       const elementsPerThread = [2, 2, 3] as [number, number, number];
+
+       const dispatch = computeDispatch(
+           layout, outputShape, workGroupSize, elementsPerThread);
+       expect(dispatch).toEqual([1, 4, 8]);
      });
 });


### PR DESCRIPTION
When WPT was >1, we were dispatching WPT*WPT times as many threads as we
should have been.

This fixes the strange performance characteristics of WPT, so WPT is now
defaulted to 4. (4 is fastest on my machine, but 8 crashes.)

I did a lot of renames throughout the code to make the naming less
muddy.

The only other functional change here is that, in matmul_webgpu,
localRow and localCol are transposed (y,x instead of x,y) to match
matmul_packed_webgpu. This makes it much faster and brings all
of the performance results more in line with expectations:

Naive: 5.1ms
Packed, WPT=1: 5.0ms
Packed, WPT=2: 3.1ms
Packed, WPT=4: 2.5ms
WebGL: 1.7ms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1731)
<!-- Reviewable:end -->
