### PR TITLE
When testing bundle size in CI, build only the umd min.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -99,6 +99,7 @@ module.exports = cmdOptions => {
     }));
   }
 
+  // tf-core.min.js
   bundles.push(config({
     plugins: [terser({output: {preamble: PREAMBLE}})],
     output: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -84,35 +84,41 @@ function config({plugins = [], output = {}, external = [], visualize = false}) {
   };
 }
 
-module.exports = cmdOptions => [
+module.exports = cmdOptions => {
+  const bundles = [];
+
+  if (!cmdOptions.ci) {
     // tf-core.js
-    config({
+    bundles.push(config({
       output: {
         format: 'umd',
         name: 'tf',
         extend: true,
         file: 'dist/tf-core.js',
       }
-    }),
+    }));
+  }
 
-    // tf-core.min.js
-    config({
-      plugins: [terser({output: {preamble: PREAMBLE}})],
-      output: {
-        format: 'umd',
-        name: 'tf',
-        extend: true,
-        file: 'dist/tf-core.min.js',
-      },
-      visualize: cmdOptions.visualize
-    }),
+  bundles.push(config({
+    plugins: [terser({output: {preamble: PREAMBLE}})],
+    output: {
+      format: 'umd',
+      name: 'tf',
+      extend: true,
+      file: 'dist/tf-core.min.js',
+    },
+    visualize: cmdOptions.visualize
+  }));
 
+  if (!cmdOptions.ci) {
     // tf-core.esm.js
-    config({
+    bundles.push(config({
       plugins: [terser({output: {preamble: PREAMBLE}})],
       output: {
         format: 'es',
         file: 'dist/tf-core.esm.js',
       }
-    }),
-];
+    }));
+  }
+  return bundles;
+};

--- a/scripts/test-bundle-size.js
+++ b/scripts/test-bundle-size.js
@@ -28,7 +28,7 @@ function getFileSizeBytes(filename) {
 }
 
 // Get the bundle sizes from this change.
-exec(`yarn rollup -c`, {silent: true});
+exec(`yarn rollup -c --ci`, {silent: true});
 const minSize = getFileSizeBytes('dist/tf-core.min.js');
 
 // Clone master and get the bundle size from master.
@@ -39,7 +39,7 @@ exec(
     {silent: true});
 
 shell.cd(dirName);
-exec(`yarn && yarn rollup -c`, {silent: true});
+exec(`yarn && yarn rollup -c --ci`, {silent: true});
 
 const masterMinSize = getFileSizeBytes('dist/tf-core.min.js');
 


### PR DESCRIPTION
When testing bundle size in CI, build only the umd min.js.

Done by adding a `--ci` flag to rollup which ignores the other 2 bundles when set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1732)
<!-- Reviewable:end -->
