### PR TITLE
Make WebGPU CI wait for yarn.

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   id: 'test-webgpu'
   dir: 'src/backends/webgpu/'
   args: ['test-ci']
-  waitFor: ['-']
+  waitFor: ['yarn']
 - name: 'node:10'
   entrypoint: 'yarn'
   args: ['test-snippets']


### PR DESCRIPTION
This seems to be causing issues with some tests:

https://pantheon.corp.google.com/cloud-build/builds/de792fe6-8ffe-442c-9c3e-6208577f9a6c?project=learnjs-174218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1737)
<!-- Reviewable:end -->
