### PR TITLE
Optimize WebGPU ArgMinMax reduction factor

### DIFF
--- a/src/backends/webgpu/src/kernels/argminmax_webgpu.ts
+++ b/src/backends/webgpu/src/kernels/argminmax_webgpu.ts
@@ -51,7 +51,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
     const reduceSize = util.sizeFromShape(reduceShape);
 
     // The number of comparisons each thread will do
-    const reductionFactor = 16;
+    const reductionFactor = 2;
     const xMaxThreads = 1024;  // gl_MaxComputeWorkGroupSize
     const xThreads =
         Math.min(Math.ceil(reduceSize / reductionFactor), xMaxThreads);
@@ -75,7 +75,7 @@ export class ArgMinMaxProgram implements WebGPUProgram {
 
       uint currentSize = WorkGroupSize;
       while (currentSize > 1) {
-        memoryBarrier();
+        barrier();
 
         for (uint w = 0; w < ${reductionFactor}; ++w) {
           uint i = gl_LocalInvocationID.x * ${reductionFactor} + w;


### PR DESCRIPTION
This PR adds a benchmark for ArgMinMax and optimizes it based on those results.
I believe the reduction is slow on WebGPU if you're not reducing the last dimension because the transpose is slow.

per-argmax times of 5 trials of 50 consecutive `argMax` for a 100x100x100 matrix:

|       | WebGL  |  WebGPU |
| --- | --- | --- |
| axis=0 | 1.13 ms | 10.87 ms |
| axis=1 | 1.15 ms | 10.87 ms |
| axis=2 |0.92 ms | 0.34 ms |

This PR also updates the `memoryBarrier()` in the WebGPU shader to a `barrier()` which should be more correct.

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1748)
<!-- Reviewable:end -->
