### PR TITLE
Publish .js files with test_snippets so that ts-node doesn't choke in dependent packages.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,8 +3,8 @@
 src/**/*_test.ts
 integration_tests/
 src/backends/webgpu/
-dist/backends/webgpu/
-dist/backends/**/*_test.js
+dist/src/backends/webgpu/
+dist/src/backends/**/*_test.js
 models/
 coverage/
 package/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,7 +56,7 @@ $ yarn test --backend cpu
 
 ```bash
 $ yarn build-npm
-> Stored standalone library at dist/tf-core(.min).js
+> Stored standalone library at dist/src/tf-core(.min).js
 > Stored also tensorflow-tf-core-VERSION.tgz
 ```
 

--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -166,9 +166,9 @@
       <tbody></tbody>
     </table>
   </div>
-  <script src="https://unpkg.com/@tensorflow/tfjs-core/dist/tf-core.js"></script>
-  <script src="https://unpkg.com/@tensorflow/tfjs-layers/dist/tf-layers.js"></script>
-  <script src="https://unpkg.com/@tensorflow/tfjs-converter/dist/tf-converter.js"></script>
+  <script src="https://unpkg.com/@tensorflow/tfjs-core/dist/src/tf-core.js"></script>
+  <script src="https://unpkg.com/@tensorflow/tfjs-layers/dist/src/tf-layers.js"></script>
+  <script src="https://unpkg.com/@tensorflow/tfjs-converter/dist/src/tf-converter.js"></script>
   <script>
     'use strict';
     async function load() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -48,8 +48,8 @@ const browserstackConfig = {
   frameworks: ['browserify', 'jasmine'],
   files: [{pattern: 'dist/**/*_test.js'}],
   exclude: [
-    'dist/test_node.js',
-    'dist/test_async_backends.js',
+    'dist/src/test_node.js',
+    'dist/src/test_async_backends.js',
   ],
   preprocessors: {'dist/**/*_test.js': ['browserify']},
   browserify: {debug: false},

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.2.0",
   "description": "Hardware-accelerated JavaScript library for machine intelligence",
   "private": false,
-  "main": "dist/index.js",
-  "jsdelivr": "dist/tf-core.min.js",
-  "unpkg": "dist/tf-core.min.js",
-  "types": "dist/index.d.ts",
-  "jsnext:main": "dist/tf-core.esm.js",
-  "module": "dist/tf-core.esm.js",
+  "main": "dist/src/index.js",
+  "jsdelivr": "dist/src/tf-core.min.js",
+  "unpkg": "dist/src/tf-core.min.js",
+  "types": "dist/src/index.d.ts",
+  "jsnext:main": "dist/src/tf-core.esm.js",
+  "module": "dist/src/tf-core.esm.js",
   "engines": {
     "yarn": ">= 1.3.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "allowUnreachableCode": false
   },
   "include": [
+    "scripts/test_snippets/",
     "src/"
   ],
   "exclude": [


### PR DESCRIPTION
This will put test_snippets.js and test_snippets.d.ts in dist.

The slightly weird thing about this PR is the *new* file structure of dist, but making dist only contain files as part of the public API means we need a new tsconfig for scripts.

```
./dist/src/index.js
./dist/src/ops/...
./dist/scripts/test_snippets/...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1756)
<!-- Reviewable:end -->
