### PR TITLE
Fix a bug when splitting and splicing zero-sized tensors

### DIFF
--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -706,6 +706,10 @@ export class MathBackendWebGL implements KernelBackend {
     if (this.shouldExecuteOnCPU([x])) {
       return this.cpuBackend.slice(x, begin, size);
     }
+    // Short-circuit computation if the slice is zero-sized.
+    if (util.sizeFromShape(size) === 0) {
+      return tensor([], size, x.dtype) as T;
+    }
     const {isPacked} = this.texData.get(x.dataId);
     const isContinous = isSliceContinous(x.shape, begin, size);
     if (isPacked || !isContinous) {

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -922,8 +922,7 @@ describeWithFlags('eye', ALL_ENVS, () => {
     const r = tf.eye(2, 2, [2, 3]);
     expect(r.shape).toEqual([2, 3, 2, 2]);
     expectArraysClose(await r.data(), [
-      1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
-      1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1
+      1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1
     ]);
   });
 
@@ -1464,7 +1463,7 @@ describeWithFlags('fromPixels', BROWSER_ENVS, () => {
     expect(res.dtype).toBe('float32');
     expectArraysClose(await res.data(), [260, 9, 11]);
   });
-  it('fromPixels for PixelData type', async() => {
+  it('fromPixels for PixelData type', async () => {
     const dataA = new Uint8Array([255, 3, 4, 255]);
     const pixelsA = {width: 1, height: 1, data: dataA};
 
@@ -3349,6 +3348,38 @@ describeWithFlags('split', ALL_ENVS, () => {
     const x = tf.tensor2d([1, 2, 3, 4, 5, 6, 7, 8], [2, 4]);
     const f = () => tf.split(x, 3, 1);
     expect(f).toThrowError();
+  });
+
+  it('can split a zero-sized tensor, axis=0', async () => {
+    const a = tf.zeros([4, 0]);
+    const numSplits = 4;
+    const axis = 0;
+    const res = tf.split(a, numSplits, axis);
+    expect(res.length).toBe(4);
+    expect(res[0].shape).toEqual([1, 0]);
+    expect(res[1].shape).toEqual([1, 0]);
+    expect(res[2].shape).toEqual([1, 0]);
+    expect(res[3].shape).toEqual([1, 0]);
+    expectArraysClose(await res[0].data(), []);
+    expectArraysClose(await res[1].data(), []);
+    expectArraysClose(await res[2].data(), []);
+    expectArraysClose(await res[3].data(), []);
+  });
+
+  it('can split a zero-sized tensor, axis=1', async () => {
+    const a = tf.zeros([0, 4]);
+    const numSplits = 4;
+    const axis = 1;
+    const res = tf.split(a, numSplits, axis);
+    expect(res.length).toBe(4);
+    expect(res[0].shape).toEqual([0, 1]);
+    expect(res[1].shape).toEqual([0, 1]);
+    expect(res[2].shape).toEqual([0, 1]);
+    expect(res[3].shape).toEqual([0, 1]);
+    expectArraysClose(await res[0].data(), []);
+    expectArraysClose(await res[1].data(), []);
+    expectArraysClose(await res[2].data(), []);
+    expectArraysClose(await res[3].data(), []);
   });
 
   it('throws when passed a non-tensor', () => {

--- a/src/ops/slice_test.ts
+++ b/src/ops/slice_test.ts
@@ -260,6 +260,20 @@ describeWithFlags('slice2d', ALL_ENVS, () => {
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(await c.data(), [3, 4, 7, 8]);
   });
+
+  it('zero-sized slice out of a non-zero sized tensor', async () => {
+    const a = tf.zeros([4, 2]);
+    const res = tf.slice(a, [0, 0], [0, 2]);
+    expect(res.shape).toEqual([0, 2]);
+    expectArraysClose(await res.data(), []);
+  });
+
+  it('zero-sized slice out of a zero-sized tensor', async () => {
+    const a = tf.zeros([0, 4]);
+    const res = tf.slice(a, [0, 1], [0, 3]);
+    expect(res.shape).toEqual([0, 3]);
+    expectArraysClose(await res.data(), []);
+  });
 });
 
 describeWithFlags('slice3d', ALL_ENVS, () => {


### PR DESCRIPTION
Repro:
```js
a = tf.zeros([0, 4]);
y = tf.split(a, 4, /* numSlices */, 1 /* axis */);
```
Expected: y[0] through y[4] to be a tensor of shape `[0, 1]`
Actual: `Requested texture size [4x0] is invalid`.

Fixes https://github.com/tensorflow/tfjs/issues/1588

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1759)
<!-- Reviewable:end -->
