### PR TITLE
[webgpu] Account for scalars in uniform base alignment logic.

### DIFF
--- a/src/backends/webgpu/src/backend_webgpu.ts
+++ b/src/backends/webgpu/src/backend_webgpu.ts
@@ -199,8 +199,11 @@ export class WebGPUBackend extends KernelBackend {
       // Complete std140 layout rules are documented here:
       // tslint:disable-next-line:max-line-length
       // https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159
-      let baseAlignment = 0;
+      let baseAlignment: number;
       switch (d.length) {
+        case 0:
+          baseAlignment = 0;
+          break;
         case 1:
           baseAlignment = 1;
           break;
@@ -357,7 +360,7 @@ export class WebGPUBackend extends KernelBackend {
   argMax(x: Tensor, axis: number): Tensor {
     return this.argMinMaxReduce(x, axis, 'max');
   }
-  
+
   concat(tensors: Tensor[], axis: number): Tensor {
     if (tensors.length === 1) {
       return tensors[0];


### PR DESCRIPTION
Scalars should not be offset.

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1766)
<!-- Reviewable:end -->
