### PR TITLE
Fix onProgress not passed in getLoadHandlers

### DIFF
--- a/src/io/router_registry.ts
+++ b/src/io/router_registry.ts
@@ -109,4 +109,4 @@ export const registerLoadRouter = (loudRouter: IORouter) =>
 export const getSaveHandlers = (url: string|string[]) =>
     IORouterRegistry.getSaveHandlers(url);
 export const getLoadHandlers = (url: string|string[], onProgress?: Function) =>
-    IORouterRegistry.getLoadHandlers(url);
+    IORouterRegistry.getLoadHandlers(url, onProgress);


### PR DESCRIPTION
BUG

* Fixes [tensorflow/tfjs#1610](https://github.com/tensorflow/tfjs/issues/1610).
* Adds a test case to ensure `onProgress` works well with `getLoadHandlers`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1769)
<!-- Reviewable:end -->
