### PR TITLE
[doc] Replace obsolete tf.loadModel() in doc and code snippets

### DIFF
--- a/src/io/browser_files.ts
+++ b/src/io/browser_files.ts
@@ -300,8 +300,8 @@ export function browserDownloads(fileNamePrefix = 'model'): IOHandler {
  *
  * This method can be used for loading from files such as user-selected files
  * in the browser.
- * When used in conjunction with `tf.loadModel`, an instance of `tf.Model`
- * (Keras-style) can be constructed from the loaded artifacts.
+ * When used in conjunction with `tf.loadLayersModel`, an instance of
+ * `tf.LayersModel` (Keras-style) can be constructed from the loaded artifacts.
  *
  * ```js
  * // Note: This code snippet won't run properly without the actual file input
@@ -311,7 +311,7 @@ export function browserDownloads(fileNamePrefix = 'model'): IOHandler {
  * // elements.
  * const uploadJSONInput = document.getElementById('upload-json');
  * const uploadWeightsInput = document.getElementById('upload-weights');
- * const model = await tfl.loadModel(tf.io.browserFiles(
+ * const model = await tf.loadLayersModel(tf.io.browserFiles(
  *     [uploadJSONInput.files[0], uploadWeightsInput.files[0]]));
  * ```
  *

--- a/src/io/passthrough.ts
+++ b/src/io/passthrough.ts
@@ -55,11 +55,11 @@ class PassthroughSaver implements IOHandler {
 /**
  * Creates an IOHandler that loads model artifacts from memory.
  *
- * When used in conjunction with `tf.loadModel`, an instance of `tf.Model`
- * (Keras-style) can be constructed from the loaded artifacts.
+ * When used in conjunction with `tf.loadLayersModel`, an instance of
+ * `tf.LayersModel` (Keras-style) can be constructed from the loaded artifacts.
  *
  * ```js
- * const model = await tf.loadModel(tf.io.fromMemory(
+ * const model = await tf.loadLayersModel(tf.io.fromMemory(
  *     modelTopology, weightSpecs, weightData));
  * ```
  *


### PR DESCRIPTION
- Replace the instances with the up-to-date tf.loadLayersModel()

Fixes https://github.com/tensorflow/tfjs/issues/1611

DOC

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1770)
<!-- Reviewable:end -->
