### PR TITLE
EncodeBase64 and DecodeBase64 ops

### DIFF
--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -17,7 +17,7 @@
 
 import {Conv2DInfo, Conv3DInfo} from '../ops/conv_util';
 import {Activation} from '../ops/fused_util';
-import {Backend, DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
+import {Backend, DataId, Scalar, StringTensor, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
 import {DataType, DataValues, PixelData, Rank, ShapeMap} from '../types';
 
 export const EPSILON_FLOAT32 = 1e-7;
@@ -621,6 +621,15 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   }
 
   dispose(): void {
+    throw new Error('Not yet implemented');
+  }
+
+  encodeBase64<T extends StringTensor>(str: StringTensor|Tensor, pad = false):
+      T {
+    throw new Error('Not yet implemented');
+  }
+
+  decodeBase64<T extends StringTensor>(str: StringTensor|Tensor): T {
     throw new Error('Not yet implemented');
   }
 }

--- a/src/backends/cpu/backend_cpu.ts
+++ b/src/backends/cpu/backend_cpu.ts
@@ -33,7 +33,7 @@ import {buffer, scalar, tensor, tensor3d, tensor4d} from '../../ops/ops';
 import * as scatter_nd_util from '../../ops/scatter_nd_util';
 import * as selu_util from '../../ops/selu_util';
 import {computeFlatOffset, getStridedSlicedInfo, isSliceContinous} from '../../ops/slice_util';
-import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer} from '../../tensor';
+import {DataId, Scalar, StringTensor, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, TensorBuffer} from '../../tensor';
 import {DataType, DataTypeMap, DataValues, NumericDataType, PixelData, Rank, ShapeMap, TypedArray, upcastType} from '../../types';
 import * as util from '../../util';
 import {getArrayFromDType, inferDtype, now, sizeFromShape} from '../../util';
@@ -42,6 +42,7 @@ import * as backend_util from '../backend_util';
 import * as complex_util from '../complex_util';
 import {nonMaxSuppressionImpl} from '../non_max_suppression_impl';
 import {split} from '../split_shared';
+import {decodeBase64, encodeBase64} from '../string_shared';
 import {topkImpl} from '../topk_impl';
 import {whereImpl} from '../where_impl';
 
@@ -3182,6 +3183,15 @@ export class MathBackendCPU implements KernelBackend {
   }
 
   dispose() {}
+
+  encodeBase64<T extends StringTensor>(str: StringTensor|Tensor, pad = false):
+      T {
+    return encodeBase64(str, pad);
+  }
+
+  decodeBase64<T extends StringTensor>(str: StringTensor|Tensor): T {
+    return decodeBase64(str);
+  }
 
   floatPrecision(): 16|32 {
     return 32;

--- a/src/backends/string_shared.ts
+++ b/src/backends/string_shared.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {arrayBufferToBase64String, arrayBufferToString, base64StringToArrayBuffer, stringToArrayBuffer, urlSafeBase64, urlUnsafeBase64} from '../io/io_utils';
+import {StringTensor, Tensor} from '../tensor';
+
+/** Shared implementation of the encodeBase64 kernel across WebGL and CPU. */
+export function encodeBase64<T extends StringTensor>(
+    str: StringTensor|Tensor, pad = false): T {
+  const resultValues = new Array(str.size);
+  const values = str.dataSync();
+
+  for (let i = 0; i < values.length; ++i) {
+    // Convert from string to ArrayBuffer of UTF-8 multibyte sequence
+    // tslint:disable-next-line: max-line-length
+    // https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
+    const aBuff = stringToArrayBuffer(values[i].toString());
+
+    // Encode to Base64 and make URL safe
+    const bVal = urlSafeBase64(arrayBufferToBase64String(aBuff));
+
+    // Remove padding
+    resultValues[i] = pad ? bVal : bVal.replace(/=/g, '');
+  }
+
+  return Tensor.make(str.shape, {values: resultValues}, str.dtype) as T;
+}
+
+/** Shared implementation of the decodeBase64 kernel across WebGL and CPU. */
+export function decodeBase64<T extends StringTensor>(str: StringTensor|
+                                                     Tensor): T {
+  const resultValues = new Array(str.size);
+  const values = str.dataSync();
+
+  for (let i = 0; i < values.length; ++i) {
+    // Undo URL safe and decode from Base64 to ArrayBuffer
+    const aBuff =
+        base64StringToArrayBuffer(urlUnsafeBase64(values[i].toString()));
+
+    // Convert from ArrayBuffer of UTF-8 multibyte sequence to string
+    resultValues[i] = arrayBufferToString(aBuff);
+  }
+
+  return Tensor.make(str.shape, {values: resultValues}, str.dtype) as T;
+}

--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -35,7 +35,7 @@ import * as segment_util from '../../ops/segment_util';
 import {computeFlatOffset, getStridedSlicedInfo, isSliceContinous} from '../../ops/slice_util';
 import {softmax} from '../../ops/softmax';
 import {range, scalar, tensor} from '../../ops/tensor_ops';
-import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../../tensor';
+import {DataId, Scalar, StringTensor, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../../tensor';
 import {DataType, DataTypeMap, DataValues, NumericDataType, PixelData, Rank, RecursiveArray, ShapeMap, sumOutType, TypedArray, upcastType} from '../../types';
 import * as util from '../../util';
 import {getArrayFromDType, getTypedArrayFromDType, inferDtype, sizeFromShape} from '../../util';
@@ -44,6 +44,7 @@ import * as backend_util from '../backend_util';
 import {mergeRealAndImagArrays} from '../complex_util';
 import {nonMaxSuppressionImpl} from '../non_max_suppression_impl';
 import {split} from '../split_shared';
+import {decodeBase64, encodeBase64} from '../string_shared';
 import {topkImpl} from '../topk_impl';
 import {whereImpl} from '../where_impl';
 
@@ -2156,6 +2157,15 @@ export class MathBackendWebGL implements KernelBackend {
 
   split<T extends Tensor>(x: T, sizeSplits: number[], axis: number): T[] {
     return split(x, sizeSplits, axis);
+  }
+
+  encodeBase64<T extends StringTensor>(str: StringTensor|Tensor, pad = false):
+      T {
+    return encodeBase64(str, pad);
+  }
+
+  decodeBase64<T extends StringTensor>(str: StringTensor|Tensor): T {
+    return decodeBase64(str);
   }
 
   scatterND<R extends Rank>(

--- a/src/io/io_utils_test.ts
+++ b/src/io/io_utils_test.ts
@@ -22,7 +22,7 @@ import {NamedTensor, NamedTensorMap} from '../tensor_types';
 import {expectArraysEqual} from '../test_util';
 import {expectArraysClose} from '../test_util';
 
-import {arrayBufferToBase64String, base64StringToArrayBuffer, basename, concatenateArrayBuffers, concatenateTypedArrays, stringByteLength} from './io_utils';
+import {arrayBufferToBase64String, arrayBufferToString, base64StringToArrayBuffer, basename, concatenateArrayBuffers, concatenateTypedArrays, stringByteLength, stringToArrayBuffer} from './io_utils';
 import {WeightsManifestEntry} from './types';
 
 describe('concatenateTypedArrays', () => {
@@ -540,5 +540,29 @@ describe('basename', () => {
     expect(basename('/foo/bar/baz')).toEqual('baz');
     expect(basename('foo/bar/baz/')).toEqual('baz');
     expect(basename('foo/bar/baz//')).toEqual('baz');
+  });
+});
+
+describe('stringToArrayBuffer-arrayBufferToString', () => {
+  it('round-trip', () => {
+    const len = Math.floor((Math.random() * 200) + 10);
+    const arr = new Array();
+
+    // Generate some random unicode code points
+    for (let i = 0; i < len; i++) {
+      const cp = Math.floor((Math.random() * 500) + 32);
+      if (cp > 126 && cp < 161) {
+        continue;
+      }
+      arr.push(cp);
+    }
+
+    // turn code points into a string
+    const str = String.fromCodePoint(...arr);
+
+    const aBuff = stringToArrayBuffer(str);
+    const str2 = arrayBufferToString(aBuff);
+
+    expect(str2).toEqual(str);
   });
 });

--- a/src/ops/ops.ts
+++ b/src/ops/ops.ts
@@ -46,6 +46,7 @@ export * from './sparse_to_dense';
 export * from './gather_nd';
 export * from './dropout';
 export * from './signal_ops';
+export * from './string_ops';
 
 export {op} from './operation';
 

--- a/src/ops/string_ops.ts
+++ b/src/ops/string_ops.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {ENGINE} from '../engine';
+import {StringTensor, Tensor} from '../tensor';
+import {convertToTensor} from '../tensor_util_env';
+
+import {op} from './operation';
+
+/**
+ * Encodes the values of a `tf.Tensor` (of dtype `string`) to Base64.
+ *
+ * Given a String tensor, returns a new tensor with the values encoded into
+ * web-safe base64 format.
+ *
+ * Web-safe means that the encoder uses `-` and `_` instead of `+` and `/`:
+ *
+ * en.wikipedia.org/wiki/Base64
+ *
+ * ```js
+ * const x = tf.tensor1d(['Hello world!'], 'string');
+ *
+ * x.encodeBase64().print();
+ * ```
+ * @param str The input `tf.Tensor` of dtype `string` to encode.
+ * @param pad Whether to add padding (`=`) to the end of the encoded string.
+ */
+/** @doc {heading: 'Operations', subheading: 'String'} */
+function encodeBase64_<T extends StringTensor>(
+    str: StringTensor|Tensor, pad = false): T {
+  const $str = convertToTensor(str, 'str', 'encodeBase64', 'string');
+
+  const backwardsFunc = (dy: T) => ({$str: () => decodeBase64(dy)});
+
+  return ENGINE.runKernel(
+      backend => backend.encodeBase64($str, pad), {$str}, backwardsFunc);
+}
+
+/**
+ * Decodes the values of a `tf.Tensor` (of dtype `string`) from Base64.
+ *
+ * Given a String tensor of Base64 encoded values, returns a new tensor with the
+ * decoded values.
+ *
+ * en.wikipedia.org/wiki/Base64
+ *
+ * ```js
+ * const y = tf.scalar('SGVsbG8gd29ybGQh', 'string');
+ *
+ * y.decodeBase64().print();
+ * ```
+ * @param str The input `tf.Tensor` of dtype `string` to decode.
+ */
+/** @doc {heading: 'Operations', subheading: 'String'} */
+function decodeBase64_<T extends StringTensor>(str: StringTensor|Tensor): T {
+  const $str = convertToTensor(str, 'str', 'decodeBase64', 'string');
+
+  const backwardsFunc = (dy: T) => ({$str: () => encodeBase64(dy)});
+
+  return ENGINE.runKernel(
+      backend => backend.decodeBase64($str), {$str}, backwardsFunc);
+}
+
+export const encodeBase64 = op({encodeBase64_});
+export const decodeBase64 = op({decodeBase64_});

--- a/src/ops/string_ops_test.ts
+++ b/src/ops/string_ops_test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '../index';
+import {ALL_ENVS, describeWithFlags} from '../jasmine_util';
+import {expectArraysEqual} from '../test_util';
+
+const txtArr = [
+  'Hello TensorFlow.js!', '𝌆', 'Pre\u2014trained models with Base64 ops\u002e',
+  'how about these? 🌍💻🍕', 'https://www.tensorflow.org/js', 'àβÇdéf',
+  '你好, 世界', `Build, train, & deploy
+ML models in JS`
+];
+const urlSafeB64 = [
+  'SGVsbG8gVGVuc29yRmxvdy5qcyE', '8J2Mhg',
+  'UHJl4oCUdHJhaW5lZCBtb2RlbHMgd2l0aCBCYXNlNjQgb3BzLg',
+  'aG93IGFib3V0IHRoZXNlPyDwn4yN8J-Su_CfjZU',
+  'aHR0cHM6Ly93d3cudGVuc29yZmxvdy5vcmcvanM', 'w6DOssOHZMOpZg',
+  '5L2g5aW9LCDkuJbnlYw', 'QnVpbGQsIHRyYWluLCAmIGRlcGxveQpNTCBtb2RlbHMgaW4gSlM'
+];
+const urlSafeB64Pad = [
+  'SGVsbG8gVGVuc29yRmxvdy5qcyE=', '8J2Mhg==',
+  'UHJl4oCUdHJhaW5lZCBtb2RlbHMgd2l0aCBCYXNlNjQgb3BzLg==',
+  'aG93IGFib3V0IHRoZXNlPyDwn4yN8J-Su_CfjZU=',
+  'aHR0cHM6Ly93d3cudGVuc29yZmxvdy5vcmcvanM=', 'w6DOssOHZMOpZg==',
+  '5L2g5aW9LCDkuJbnlYw=', 'QnVpbGQsIHRyYWluLCAmIGRlcGxveQpNTCBtb2RlbHMgaW4gSlM='
+];
+
+describeWithFlags('encodeBase64', ALL_ENVS, () => {
+  it('scalar', async () => {
+    const a = tf.scalar(txtArr[1], 'string');
+    const r = tf.encodeBase64(a);
+    expect(r.shape).toEqual([]);
+    expectArraysEqual(await r.data(), urlSafeB64[1]);
+  });
+  it('1D padded', async () => {
+    const a = tf.tensor1d([txtArr[2]], 'string');
+    const r = tf.encodeBase64(a, true);
+    expect(r.shape).toEqual([1]);
+    expectArraysEqual(await r.data(), [urlSafeB64Pad[2]]);
+  });
+  it('2D', async () => {
+    const a = tf.tensor2d(txtArr, [2, 4], 'string');
+    const r = tf.encodeBase64(a, false);
+    expect(r.shape).toEqual([2, 4]);
+    expectArraysEqual(await r.data(), urlSafeB64);
+  });
+  it('3D padded', async () => {
+    const a = tf.tensor3d(txtArr, [2, 2, 2], 'string');
+    const r = tf.encodeBase64(a, true);
+    expect(r.shape).toEqual([2, 2, 2]);
+    expectArraysEqual(await r.data(), urlSafeB64Pad);
+  });
+});
+
+describeWithFlags('decodeBase64', ALL_ENVS, () => {
+  it('scalar', async () => {
+    const a = tf.scalar(urlSafeB64[1], 'string');
+    const r = tf.decodeBase64(a);
+    expect(r.shape).toEqual([]);
+    expectArraysEqual(await r.data(), txtArr[1]);
+  });
+  it('1D padded', async () => {
+    const a = tf.tensor1d([urlSafeB64Pad[2]], 'string');
+    const r = tf.decodeBase64(a);
+    expect(r.shape).toEqual([1]);
+    expectArraysEqual(await r.data(), [txtArr[2]]);
+  });
+  it('2D', async () => {
+    const a = tf.tensor2d(urlSafeB64, [2, 4], 'string');
+    const r = tf.decodeBase64(a);
+    expect(r.shape).toEqual([2, 4]);
+    expectArraysEqual(await r.data(), txtArr);
+  });
+  it('3D padded', async () => {
+    const a = tf.tensor3d(urlSafeB64Pad, [2, 2, 2], 'string');
+    const r = tf.decodeBase64(a);
+    expect(r.shape).toEqual([2, 2, 2]);
+    expectArraysEqual(await r.data(), txtArr);
+  });
+});
+
+describeWithFlags('encodeBase64-decodeBase64', ALL_ENVS, () => {
+  it('round-trip', async () => {
+    const s = [txtArr.join('')];
+    const a = tf.tensor(s, [1], 'string');
+    const b = tf.encodeBase64(a);
+    const c = tf.decodeBase64(b);
+    expectArraysEqual(await c.data(), s);
+  });
+});

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -367,6 +367,8 @@ export interface OpHandler {
     fft(x: Tensor): Tensor; ifft(x: Tensor): Tensor; rfft(x: Tensor): Tensor;
     irfft(x: Tensor): Tensor
   };
+  encodeBase64<T extends StringTensor>(x: T, pad: boolean): T;
+  decodeBase64<T extends StringTensor>(x: T): T;
 }
 
 // For tracking tensor creation and disposal.
@@ -1387,6 +1389,16 @@ export class Tensor<R extends Rank = Rank> {
   irfft(this: Tensor): Tensor {
     this.throwIfDisposed();
     return opHandler.spectral.irfft(this);
+  }
+
+  encodeBase64<T extends StringTensor>(this: T, pad = false): T {
+    this.throwIfDisposed();
+    return opHandler.encodeBase64(this, pad);
+  }
+
+  decodeBase64<T extends StringTensor>(this: T): T {
+    this.throwIfDisposed();
+    return opHandler.decodeBase64(this);
   }
 }
 Object.defineProperty(Tensor, Symbol.hasInstance, {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -84,6 +84,7 @@ import './ops/softmax_test';
 import './ops/sparse_to_dense_test';
 import './ops/spectral_ops_test';
 import './ops/strided_slice_test';
+import './ops/string_ops_test';
 import './ops/topk_test';
 import './ops/transpose_test';
 import './ops/unary_ops_test';


### PR DESCRIPTION
the TF implementation of the pix2pix model which fails conversion because of

	`Unsupported Ops: DecodeJpeg, EncodePng, DecodeBase64`

the Open NSFW model also fails conversion with some of the same ops (https://github.com/tensorflow/tfjs/issues/433).

i wanted to try to implement some of these ops in TensorFlow.js. starting with this pull request for `DecodeBase64` and `EncodeBase64`.

along with this `tfjs-core` PR, there is a corresponding PR in `tfjs-converter` (https://github.com/tensorflow/tfjs-converter/pull/376)

---

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1779)
<!-- Reviewable:end -->
