### PR TITLE
Disable packed depthwiseConv.

### DIFF
--- a/src/backends/webgl/flags_webgl.ts
+++ b/src/backends/webgl/flags_webgl.ts
@@ -54,7 +54,8 @@ ENV.registerFlag('WEBGL_PACK_NORMALIZATION', () => ENV.getBool('WEBGL_PACK'));
 ENV.registerFlag('WEBGL_PACK_CLIP', () => ENV.getBool('WEBGL_PACK'));
 
 /** Whether we will pack the depthwise conv op. */
-ENV.registerFlag('WEBGL_PACK_DEPTHWISECONV', () => ENV.getBool('WEBGL_PACK'));
+// TODO: https://github.com/tensorflow/tfjs/issues/1679
+ENV.registerFlag('WEBGL_PACK_DEPTHWISECONV', () => false);
 
 /** Whether we will pack binary ops. */
 ENV.registerFlag(

--- a/src/backends/webgl/flags_webgl_test.ts
+++ b/src/backends/webgl/flags_webgl_test.ts
@@ -86,6 +86,7 @@ describe('WEBGL_PACK_CLIP', () => {
   });
 });
 
+// TODO: https://github.com/tensorflow/tfjs/issues/1679
 // describe('WEBGL_PACK_DEPTHWISECONV', () => {
 //   beforeEach(() => ENV.reset());
 //   afterAll(() => ENV.reset());

--- a/src/backends/webgl/flags_webgl_test.ts
+++ b/src/backends/webgl/flags_webgl_test.ts
@@ -86,20 +86,20 @@ describe('WEBGL_PACK_CLIP', () => {
   });
 });
 
-describe('WEBGL_PACK_DEPTHWISECONV', () => {
-  beforeEach(() => ENV.reset());
-  afterAll(() => ENV.reset());
+// describe('WEBGL_PACK_DEPTHWISECONV', () => {
+//   beforeEach(() => ENV.reset());
+//   afterAll(() => ENV.reset());
 
-  it('true when WEBGL_PACK is true', () => {
-    ENV.set('WEBGL_PACK', true);
-    expect(ENV.getBool('WEBGL_PACK_DEPTHWISECONV')).toBe(true);
-  });
+//   it('true when WEBGL_PACK is true', () => {
+//     ENV.set('WEBGL_PACK', true);
+//     expect(ENV.getBool('WEBGL_PACK_DEPTHWISECONV')).toBe(true);
+//   });
 
-  it('false when WEBGL_PACK is false', () => {
-    ENV.set('WEBGL_PACK', false);
-    expect(ENV.getBool('WEBGL_PACK_DEPTHWISECONV')).toBe(false);
-  });
-});
+//   it('false when WEBGL_PACK is false', () => {
+//     ENV.set('WEBGL_PACK', false);
+//     expect(ENV.getBool('WEBGL_PACK_DEPTHWISECONV')).toBe(false);
+//   });
+// });
 
 describe('WEBGL_PACK_BINARY_OPERATIONS', () => {
   beforeEach(() => ENV.reset());


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/1673

It turns out our current version of packed depthwise conv is only optimal for certain ratios of input size / input depth / filter size. 

I think it makes sense to disable for now while I figure out how to make a more generally optimal kernel: https://github.com/tensorflow/tfjs/issues/1679

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1796)
<!-- Reviewable:end -->
