### PR TITLE
Only cleanup canvas if it exists.

### DIFF
--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -678,9 +678,6 @@ export class MathBackendWebGL implements KernelBackend {
   getGPGPUContext(): GPGPUContext {
     return this.gpgpu;
   }
-  getCanvas(): HTMLCanvasElement {
-    return this.canvas;
-  }
 
   complex<T extends Tensor>(real: T, imag: T): T {
     const result = this.makeOutputArray(real.shape, 'complex64') as T;
@@ -2489,7 +2486,7 @@ export class MathBackendWebGL implements KernelBackend {
       return;
     }
     this.textureManager.dispose();
-    if (this.canvas.remove != null) {
+    if (this.canvas !== null && this.canvas.remove !== null) {
       this.canvas.remove();
     } else {
       this.canvas = null;

--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -2486,7 +2486,7 @@ export class MathBackendWebGL implements KernelBackend {
       return;
     }
     this.textureManager.dispose();
-    if (this.canvas !== null && this.canvas.remove !== null) {
+    if (this.canvas !== null && this.canvas.remove != null) {
       this.canvas.remove();
     } else {
       this.canvas = null;

--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -2486,7 +2486,7 @@ export class MathBackendWebGL implements KernelBackend {
       return;
     }
     this.textureManager.dispose();
-    if (this.canvas !== null && this.canvas.remove != null) {
+    if (this.canvas != null && this.canvas.remove != null) {
       this.canvas.remove();
     } else {
       this.canvas = null;


### PR DESCRIPTION
This helps for platforms using the WebGL env without actually having a
DOM canvas to use. Offscreen usage will fail on unit tests without this
check on this.canvas.

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1811)
<!-- Reviewable:end -->
