### PR TITLE
No need outDepth when compute output shape in conv_util.computeOutputShape3D

### DIFF
--- a/src/ops/conv_util.ts
+++ b/src/ops/conv_util.ts
@@ -254,10 +254,10 @@ export function computeConv3DInfo(
   };
 }
 
-function computeOutputShape3D(
-    inShape: [number, number, number], fieldSize: number, outDepth: number,
+function computeOutputShape2D(
+    inShape: [number, number], fieldSize: number,
     stride: number, zeroPad?: number,
-    roundingMode?: 'floor'|'round'|'ceil'): [number, number, number] {
+    roundingMode?: 'floor'|'round'|'ceil'): [number, number] {
   if (zeroPad == null) {
     zeroPad = computeDefaultPad(inShape, fieldSize, stride);
   }
@@ -278,11 +278,11 @@ function computeOutputShape3D(
       () => `The output # of columns (${outputCols}) must be an integer. ` +
           `Change the stride and/or zero pad parameters`);
 
-  return [outputRows, outputCols, outDepth];
+  return [outputRows, outputCols];
 }
 
 export function computeDefaultPad(
-    inputShape: [number, number, number], fieldSize: number, stride: number,
+    inputShape: [number, number], fieldSize: number, stride: number,
     dilation = 1): number {
   const effectiveFieldSize = getEffectiveFilterSize(fieldSize, dilation);
   return Math.floor(
@@ -329,9 +329,8 @@ function getPadAndOutInfo(
   if (typeof pad === 'number') {
     const padType = (pad === 0) ? 'VALID' : 'NUMBER';
     padInfo = {top: pad, bottom: pad, left: pad, right: pad, type: padType};
-    const outShape = computeOutputShape3D(
-        [inHeight, inWidth, 1], filterHeight, 1, strideHeight, pad,
-        roundingMode);
+    const outShape = computeOutputShape2D(
+        [inHeight, inWidth], filterHeight, strideHeight, pad, roundingMode);
     outHeight = outShape[0];
     outWidth = outShape[1];
   } else if (pad === 'same') {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1812)
<!-- Reviewable:end -->
