### PR TITLE
Build test snippets when running integration tests.

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -24,7 +24,7 @@ echo '######################'
 echo 'Nightly build or version.ts was modified.'
 echo 'Testing layers/converter/node/data against tfjs-core@master.'
 echo '######################'
-yarn build && && yarn build-test-snippets && yarn yalc publish
+yarn build && yarn build-test-snippets && yarn yalc publish
 
 echo 'Cloning layers'
 git clone https://github.com/tensorflow/tfjs-layers.git --depth 1

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -24,7 +24,7 @@ echo '######################'
 echo 'Nightly build or version.ts was modified.'
 echo 'Testing layers/converter/node/data against tfjs-core@master.'
 echo '######################'
-yarn build && yarn yalc publish
+yarn build && && yarn build-test-snippets && yarn yalc publish
 
 echo 'Cloning layers'
 git clone https://github.com/tensorflow/tfjs-layers.git --depth 1


### PR DESCRIPTION
Converter fails because it includes it's own scripts in its build process (this is a separate issue I will fix).

I didn't call build-npm because it calls rollup which will slow down the integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1814)
<!-- Reviewable:end -->
