### PR TITLE
Move rollup-plugin-visualizer from optionalDep to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "rollup-plugin-node-resolve": "~3.4.0",
     "rollup-plugin-terser": "~4.0.4",
     "rollup-plugin-typescript2": "~0.20.1",
+    "rollup-plugin-visualizer": "~1.1.1",
     "shelljs": "~0.8.3",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
@@ -48,9 +49,6 @@
     "watchify": "~3.11.1",
     "yalc": "~1.0.0-pre.21",
     "yargs": "~13.2.2"
-  },
-  "optionalDependencies": {
-    "rollup-plugin-visualizer": "~1.1.1"
   },
   "scripts": {
     "build-ci": "./scripts/enumerate-tests.js --ci && tsc",

--- a/scripts/test_snippets/util.ts
+++ b/scripts/test_snippets/util.ts
@@ -19,6 +19,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
+process.on('unhandledRejection', ex => {
+  throw ex;
+});
+
 // Used for logging the number of snippets that have been found.
 let snippetCount = 0;
 // Used for counting the number of errors that have been found.

--- a/src/backends/webgl/webgl_ops_test.ts
+++ b/src/backends/webgl/webgl_ops_test.ts
@@ -432,10 +432,10 @@ describeWithFlags('conv to matmul', PACKED_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  it('16x64', async () => {
+  it('16x32', async () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
-    const xs = tf.randomUniform([16, 64]) as Tensor2D;
+    const xs = tf.randomUniform([16, 32]) as Tensor2D;
     const y = tf.linalg.gramSchmidt(xs) as Tensor2D;
     expectArraysClose(
         await y.matMul(y.transpose()).data(), await tf.eye(16).data());

--- a/src/backends/webgl/webgl_ops_test.ts
+++ b/src/backends/webgl/webgl_ops_test.ts
@@ -432,10 +432,10 @@ describeWithFlags('conv to matmul', PACKED_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  it('16x128', async () => {
+  it('16x64', async () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
-    const xs = tf.randomUniform([16, 128]) as Tensor2D;
+    const xs = tf.randomUniform([16, 64]) as Tensor2D;
     const y = tf.linalg.gramSchmidt(xs) as Tensor2D;
     expectArraysClose(
         await y.matMul(y.transpose()).data(), await tf.eye(16).data());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "allowUnreachableCode": false
   },
   "include": [
-    "src/",
+    "src/"
   ],
   "exclude": [
     "node_modules/"


### PR DESCRIPTION
- Now that rollup-visualize works with node 8, move from optionalDep to devDep.
- Fix the typo in `tsconfig.json`, which makes it an invalid json.
- Make sure that unhandled promises in node propagate with a non-zero exit code.
- Fix a flaky gramSchmidt test which occasionally times out on windows.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1817)
<!-- Reviewable:end -->
