### PR TITLE
Undo change where we add an arraybuffer response type to the request.

### DIFF
--- a/src/io/weights_loader.ts
+++ b/src/io/weights_loader.ts
@@ -42,16 +42,8 @@ export async function loadWeightsAsArrayBuffer(
   const fetchFunc =
       loadOptions.fetchFunc == null ? util.fetch : loadOptions.fetchFunc;
 
-  // Update the request headers without modifying the passed in
-  // loadOptions object.
-  const requestOptions = Object.assign({}, loadOptions.requestInit);
-  requestOptions.headers = Object.assign({}, requestOptions.headers, {
-    responseType: 'arraybuffer',
-  });
-
   // Create the requests for all of the weights in parallel.
-  const requests =
-      fetchURLs.map(fetchURL => fetchFunc(fetchURL, requestOptions));
+  const requests = fetchURLs.map(fetchURL => fetchFunc(fetchURL, loadOptions));
 
   const fetchStartFraction = 0;
   const fetchEndFraction = 0.5;

--- a/src/io/weights_loader.ts
+++ b/src/io/weights_loader.ts
@@ -43,7 +43,8 @@ export async function loadWeightsAsArrayBuffer(
       loadOptions.fetchFunc == null ? util.fetch : loadOptions.fetchFunc;
 
   // Create the requests for all of the weights in parallel.
-  const requests = fetchURLs.map(fetchURL => fetchFunc(fetchURL, loadOptions));
+  const requests =
+      fetchURLs.map(fetchURL => fetchFunc(fetchURL, loadOptions.requestInit));
 
   const fetchStartFraction = 0;
   const fetchEndFraction = 0.5;

--- a/src/io/weights_loader_test.ts
+++ b/src/io/weights_loader_test.ts
@@ -436,10 +436,7 @@ describeWithFlags('loadWeights', BROWSER_ENVS, () => {
         manifest, './', weightsNamesToFetch, {credentials: 'include'});
     expect((tf.util.fetch as jasmine.Spy).calls.count()).toBe(1);
     expect(tf.util.fetch).toHaveBeenCalledWith('./weightfile0', {
-      credentials: 'include',
-      headers: {
-        responseType: 'arraybuffer',
-      }
+      credentials: 'include'
     });
   });
 


### PR DESCRIPTION
TLDR: we added a request header in core which changes how CORS interacts with GCP.

Longer story:
This change added a "responseType: arrayBuffer" header so that react native would be happy:
https://github.com/tensorflow/tfjs-core/pull/1789/files#diff-5c8893bf31b1cd319675fcf3524961e8

When browsers see custom request headers they make an initial request of type OPTIONS which allows the server to respond saying that they will accept the next GET request. If the OPTIONS request fails, the GET request never happens for the weights.

It turns out you have to do some more configuration on GCP to allow OPTIONS requests through.

As a quick fix, we just changed our GCP settings for tfjs-models. However, this problem will still show up for anyone hosting their own models (without custom server config stuff). So I'm going to undo the change from the PR above as a permanent solution and we'll send the request header just for react native (which treats these things differently).

Fixes https://github.com/tensorflow/tfjs/issues/1755

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1848)
<!-- Reviewable:end -->
