### PR TITLE
Add entry for Miniprogram for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/tf-core.esm.js",
   "module": "dist/tf-core.esm.js",
+  "miniprogram": "miniprogram",
   "engines": {
     "yarn": ">= 1.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/tf-core.esm.js",
   "module": "dist/tf-core.esm.js",
-  "miniprogram": "miniprogram",
+  "miniprogram": "dist/miniprogram",
   "engines": {
     "yarn": ">= 1.3.2"
   },

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -25,6 +25,7 @@ yarn rollup -c --visualize
 
 # Use minified files for miniprogram
 mkdir dist/miniprogram
-cp dist/tf-core.min.js* dist/miniprogram
+cp dist/tf-core.min.js dist/miniprogram/index.js
+cp dist/tf-core.min.js.map dist/miniprogram/index.js.map
 
 echo "Stored standalone library at dist/tf-core(.min).js"

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -22,4 +22,9 @@ yarn
 yarn build
 yarn build-test-snippets
 yarn rollup -c --visualize
+
+# Use minified files for miniprogram
+mkdir dist/miniprogram
+cp dist/tf-core.min.js* dist/miniprogram
+
 echo "Stored standalone library at dist/tf-core(.min).js"


### PR DESCRIPTION
Wechat mini app has a size limit, and their minification can not reduce the size as good as ours.
create a dist/miniprogram directory and copy the minified version of tf-core there.

ref https://github.com/tensorflow/tfjs-wechat/issues/13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1849)
<!-- Reviewable:end -->
