### PR TITLE
Make node web worker test not need a bundle.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ const devConfig = {
     'src/worker_node_test.ts',
     'src/worker_test.ts',
     'src/test_node.ts',
-    'src/test_async_backends.ts'
+    'src/test_async_backends.ts',
   ],
   preprocessors: {'**/*.ts': ['karma-typescript']},
   karmaTypescriptConfig,
@@ -52,7 +52,7 @@ const browserstackConfig = {
     'dist/worker_node_test.js',
     'dist/worker_test.js',
     'dist/test_node.js',
-    'dist/test_async_backends.js'
+    'dist/test_async_backends.js',
   ],
   preprocessors: {'dist/**/*_test.js': ['browserify']},
   browserify: {debug: false},
@@ -66,8 +66,9 @@ const webworkerConfig = {
   files: [
     'dist/setup_test.js',
     'dist/worker_test.js',
-    // Serve dist/tf-core.js as a static resource, but do not include in the test runner
-    {pattern: 'dist/tf-core.js', included: false}
+    // Serve dist/tf-core.min.js as a static resource, but do not include in the
+    // test runner
+    {pattern: 'dist/tf-core.min.js', included: false},
   ],
   exclude: [],
   port: 12345

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -36,7 +36,10 @@ npm-run-all -p -c --aggregate-output \
   "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": true}'" \
   "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false}'"
 
-# Build dist/tf-core.js which is used by the webworker test
-yarn build-npm
-# Run under webworker environment
-yarn test-webworker --browsers=bs_safari_mac
+### The next section tests TF.js in a webworker.
+# Make a dist/tf-core.min.js file to be imported by the web worker.
+yarn rollup -c --ci
+# Safari doesn't have offscreen canvas so test cpu in a webworker.
+yarn test-webworker --browsers=bs_safari_mac --testEnv cpu --flags '{"HAS_WEBGL": false}'
+# Chrome has offscreen canvas, so test webgl in a webworker.
+yarn test-webworker --browsers=bs_chrome_mac --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -22,24 +22,18 @@ yarn test-node-ci
 
 # Run the first karma separately so it can download the BrowserStack binary
 # without conflicting with others.
-yarn run-browserstack --browsers=bs_safari_mac --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+yarn run-browserstack --browsers=bs_safari_mac,bs_ios_11 --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
 
 # Run the rest of the karma tests in parallel. These runs will reuse the
 # already downloaded binary.
 npm-run-all -p -c --aggregate-output \
-  "run-browserstack --browsers=bs_safari_mac --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
-  "run-browserstack --browsers=win_10_chrome --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
-  "run-browserstack --browsers=bs_ios_11 --testEnv webgl1 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'" \
-  "run-browserstack --browsers=bs_ios_11 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
-  "run-browserstack --browsers=bs_firefox_mac" \
-  "run-browserstack --browsers=bs_chrome_mac" \
-  "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": true}'" \
-  "run-browserstack --browsers=bs_chrome_mac --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false}'"
+  "run-browserstack --browsers=bs_safari_mac,bs_ios_11 --flags '{\"HAS_WEBGL\": false}' --testEnv cpu" \
+  "run-browserstack --browsers=bs_firefox_mac,bs_chrome_mac" \
+  "run-browserstack --browsers=bs_chrome_mac,win_10_chrome --testEnv webgl2 --flags '{\"WEBGL_CPU_FORWARD\": false, \"WEBGL_SIZE_UPLOAD_UNIFORM\": 0}'"
 
 ### The next section tests TF.js in a webworker.
 # Make a dist/tf-core.min.js file to be imported by the web worker.
 yarn rollup -c --ci
 # Safari doesn't have offscreen canvas so test cpu in a webworker.
-yarn test-webworker --browsers=bs_safari_mac --testEnv cpu --flags '{"HAS_WEBGL": false}'
 # Chrome has offscreen canvas, so test webgl in a webworker.
-yarn test-webworker --browsers=bs_chrome_mac --testEnv webgl1 --flags '{"WEBGL_CPU_FORWARD": false, "WEBGL_SIZE_UPLOAD_UNIFORM": 0}'
+yarn test-webworker --browsers=bs_safari_mac,bs_chrome_mac

--- a/src/worker_node_test.ts
+++ b/src/worker_node_test.ts
@@ -26,7 +26,8 @@ const fn2String = (fn: Function): string => {
 
 // The source code of a web worker.
 const workerTestNode = () => {
-  // Web workers in node are loader relative to the current working directory.
+  // Web worker scripts in node live relative to the CWD, not to the dir of the
+  // file that spawned them.
   const tf = require('./dist/index.js');
   const {parentPort} = require('worker_threads');
   let a = tf.tensor1d([1, 2, 3]);

--- a/src/worker_node_test.ts
+++ b/src/worker_node_test.ts
@@ -15,18 +15,19 @@
  * =============================================================================
  */
 
-import {HAS_NODE_WORKER, describeWithFlags} from './jasmine_util';
+import {describeWithFlags, HAS_NODE_WORKER} from './jasmine_util';
 import {expectArraysClose} from './test_util';
+// tslint:disable:no-require-imports
 
 const fn2String = (fn: Function): string => {
-  const funcStr = '('+fn.toString()+')()';
+  const funcStr = '(' + fn.toString() + ')()';
   return funcStr;
 };
 
 // The source code of a web worker.
 const workerTestNode = () => {
-  const tf = require(`${process.cwd()}/dist/tf-core.js`);
-  // tslint:disable-next-line:no-require-imports
+  // Web workers in node are loader relative to the current working directory.
+  const tf = require('./dist/index.js');
   const {parentPort} = require('worker_threads');
   let a = tf.tensor1d([1, 2, 3]);
   const b = tf.tensor1d([3, 2, 1]);
@@ -36,7 +37,6 @@ const workerTestNode = () => {
 
 describeWithFlags('computation in worker (node env)', HAS_NODE_WORKER, () => {
   it('tensor in worker', (done) => {
-    // tslint:disable-next-line:no-require-imports
     const {Worker} = require('worker_threads');
     const worker = new Worker(fn2String(workerTestNode), {eval: true});
     // tslint:disable-next-line:no-any

--- a/src/worker_test.ts
+++ b/src/worker_test.ts
@@ -15,20 +15,20 @@
  * =============================================================================
  */
 
-import {HAS_WORKER, describeWithFlags} from './jasmine_util';
-import {expectArraysClose} from './test_util';
 import * as tf from './index';
+import {describeWithFlags, HAS_WORKER} from './jasmine_util';
+import {expectArraysClose} from './test_util';
 
 const fn2workerURL = (fn: Function): string => {
   const blob =
-      new Blob(['('+fn.toString()+')()'], {type: 'application/javascript'});
+      new Blob(['(' + fn.toString() + ')()'], {type: 'application/javascript'});
   return URL.createObjectURL(blob);
 };
 
 // The source code of a web worker.
 const workerTest = () => {
   //@ts-ignore
-  importScripts('http://bs-local.com:12345/base/dist/tf-core.js');
+  importScripts('http://bs-local.com:12345/base/dist/tf-core.min.js');
   let a = tf.tensor1d([1, 2, 3]);
   const b = tf.tensor1d([3, 2, 1]);
   a = a.add(b);


### PR DESCRIPTION
Several improvements to our test infra:
- In node, a web worker doesn't need the pre-bundled `tf-core.min.js`. Shaves off 1 min.
- Speedup the browserstack tests by only producing one minified bundle instead of 3.
- Reduce browserstack API queries by combining several browsers in a single browserstack call (reduces chances of API rate limit).

To run the node webworker test, you need `node >=10.5.0` with an experimental flag:
```sh
yarn tsc && node --experimental-worker dist/test_node.js
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1857)
<!-- Reviewable:end -->
