### PR TITLE
Rn webgl readfix

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,7 @@ const devConfig = {
   frameworks: ['jasmine', 'karma-typescript'],
   files: ['src/setup_test.ts', {pattern: 'src/**/*.ts'}],
   exclude: [
+    'src/tests.ts',
     'src/worker_node_test.ts',
     'src/worker_test.ts',
     'src/test_node.ts',


### PR DESCRIPTION
Fix for backend.read being override. Note that I had to an an explicit flag setting because `getBufferSubData` exists but throws a not implemented yet exception

I somehow accidentally merged the prev PR before pushing this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1865)
<!-- Reviewable:end -->
