### PR TITLE
Fuse prelu activation.

### DIFF
--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -133,7 +133,8 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: Activation): Tensor3D {
+      bias?: Tensor, activation?: Activation,
+      preluActivationWeights?: Tensor): Tensor3D {
     throw new Error('Not yet implemented');
   }
 
@@ -413,7 +414,7 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
 
   fusedConv2d(
       x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo, bias?: Tensor4D,
-      activation?: Activation): Tensor4D {
+      activation?: Activation, preluActivationWeights?: Tensor): Tensor4D {
     throw new Error('Not yet implemented');
   }
 

--- a/src/backends/backend.ts
+++ b/src/backends/backend.ts
@@ -16,7 +16,7 @@
  */
 
 import {Conv2DInfo, Conv3DInfo} from '../ops/conv_util';
-import {Activation} from '../ops/fused_util';
+import {Activation, FusedBatchMatMulConfig} from '../ops/fused_util';
 import {Backend, DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D} from '../tensor';
 import {BackendValues, DataType, PixelData, Rank, ShapeMap} from '../types';
 
@@ -132,9 +132,8 @@ export class KernelBackend implements TensorStorage, Backend, BackendTimer {
   }
 
   fusedBatchMatMul(
-      a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: Activation,
-      preluActivationWeights?: Tensor): Tensor3D {
+      {a, b, transposeA, transposeB, bias, activation, preluActivationWeights}:
+          FusedBatchMatMulConfig): Tensor3D {
     throw new Error('Not yet implemented');
   }
 

--- a/src/backends/cpu/backend_cpu.ts
+++ b/src/backends/cpu/backend_cpu.ts
@@ -47,11 +47,14 @@ import {topkImpl} from '../topk_impl';
 import {whereImpl} from '../where_impl';
 
 function mapActivation(
-    backend: MathBackendCPU, activation: Activation, x: Tensor): Tensor {
+    backend: MathBackendCPU, x: Tensor, activation: Activation,
+    preluActivationWeights?: Tensor): Tensor {
   if (activation === 'linear') {
     return backend.linear(x);
   } else if (activation === 'relu') {
     return backend.relu(x);
+  } else if (activation === 'prelu') {
+    return backend.prelu(x, preluActivationWeights);
   }
   throw new Error(
       `Activation ${activation} has not been implemented for the CPU backend.`);
@@ -523,13 +526,16 @@ export class MathBackendCPU implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: Activation): Tensor3D {
+      bias?: Tensor, activation?: Activation,
+      preluActivationWeights?: Tensor): Tensor3D {
     let result = this.batchMatMul(a, b, transposeA, transposeB);
     if (bias) {
       result = this.add(result, bias) as Tensor3D;
     }
     if (activation) {
-      result = mapActivation(this, activation, result) as Tensor3D;
+      result =
+          mapActivation(this, result, activation, preluActivationWeights) as
+          Tensor3D;
     }
     return result;
   }
@@ -1515,14 +1521,16 @@ export class MathBackendCPU implements KernelBackend {
 
   fusedConv2d(
       x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo, bias?: Tensor4D,
-      activation?: Activation): Tensor4D {
+      activation?: Activation, preluActivationWeights?: Tensor): Tensor4D {
     let result = this.conv2d(x, filter, convInfo);
 
     if (bias) {
       result = this.add(result, bias) as Tensor4D;
     }
     if (activation) {
-      result = mapActivation(this, activation, result) as Tensor4D;
+      result =
+          mapActivation(this, result, activation, preluActivationWeights) as
+          Tensor4D;
     }
     return result;
   }

--- a/src/backends/cpu/backend_cpu.ts
+++ b/src/backends/cpu/backend_cpu.ts
@@ -26,7 +26,7 @@ import * as broadcast_util from '../../ops/broadcast_util';
 import * as concat_util from '../../ops/concat_util';
 import {Conv2DInfo, Conv3DInfo} from '../../ops/conv_util';
 import * as erf_util from '../../ops/erf_util';
-import {Activation} from '../../ops/fused_util';
+import {Activation, FusedBatchMatMulConfig} from '../../ops/fused_util';
 import * as gather_nd_util from '../../ops/gather_nd_util';
 import * as ops from '../../ops/ops';
 import {buffer, scalar, tensor, tensor3d, tensor4d} from '../../ops/ops';
@@ -525,9 +525,8 @@ export class MathBackendCPU implements KernelBackend {
   }
 
   fusedBatchMatMul(
-      a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: Activation,
-      preluActivationWeights?: Tensor): Tensor3D {
+      {a, b, transposeA, transposeB, bias, activation, preluActivationWeights}:
+          FusedBatchMatMulConfig): Tensor3D {
     let result = this.batchMatMul(a, b, transposeA, transposeB);
     if (bias) {
       result = this.add(result, bias) as Tensor3D;

--- a/src/backends/webgl/backend_webgl.ts
+++ b/src/backends/webgl/backend_webgl.ts
@@ -174,6 +174,11 @@ function mapActivationToShaderProgram(
       return unary_packed_op.RELU;
     }
     return unary_op.RELU;
+  } else if (activation === 'prelu') {
+    if (packed) {
+      return binaryop_packed_gpu.PRELU;
+    }
+    return binaryop_gpu.PRELU;
   }
   throw new Error(`Activation ${
       activation} has not been implemented for the WebGL backend.`);
@@ -866,7 +871,8 @@ export class MathBackendWebGL implements KernelBackend {
 
   fusedBatchMatMul(
       a: Tensor3D, b: Tensor3D, transposeA: boolean, transposeB: boolean,
-      bias?: Tensor, activation?: Activation): Tensor3D {
+      bias?: Tensor, activation?: Activation,
+      preluActivationWeights?: Tensor): Tensor3D {
     const outerShapeA = transposeA ? a.shape[2] : a.shape[1];
     const outerShapeB = transposeB ? b.shape[1] : b.shape[2];
     const [batch, , ] = a.shape;
@@ -874,16 +880,20 @@ export class MathBackendWebGL implements KernelBackend {
     const dtype = upcastType(a.dtype, b.dtype);
 
     const hasBias = bias != null;
+    const hasPreluActivationWeights = preluActivationWeights != null;
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, true) : null;
     const program = new MatMulPackedProgram(
         a.shape, [batch, outerShapeA, outerShapeB], transposeA, transposeB,
-        hasBias, fusedActivation);
+        hasBias, fusedActivation, hasPreluActivationWeights);
     const output =
         this.makePackedTensor(program.outputShape, dtype) as Tensor3D;
     const inputs: TensorHandle[] = [a, b];
     if (bias) {
       inputs.push(bias);
+    }
+    if (preluActivationWeights) {
+      inputs.push(preluActivationWeights);
     }
     return this.compileAndRun<Tensor3D>(program, inputs, output);
   }
@@ -1819,7 +1829,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   private conv2dByMatMul(
       x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo, bias?: Tensor4D,
-      activation?: Activation): Tensor4D {
+      activation?: Activation, preluActivationWeights?: Tensor): Tensor4D {
     // Reshapes conv2D input to 2D tensors, uses matMul and then reshape the
     // result from 2D to 4D.
     const xShape = x.shape;
@@ -1852,7 +1862,7 @@ export class MathBackendWebGL implements KernelBackend {
       return this.reshape<Rank.R4>(
           this.fusedBatchMatMul(
               xReshaped, filterReshaped, transposeA, transposeB, bias,
-              activation),
+              activation, preluActivationWeights),
           convInfo.outShape);
     }
 
@@ -1889,7 +1899,8 @@ export class MathBackendWebGL implements KernelBackend {
         Tensor3D;
 
     const pointwiseConv = this.fusedBatchMatMul(
-        xReshaped, filterReshaped, transposeA, transposeB, bias, activation);
+        xReshaped, filterReshaped, transposeA, transposeB, bias, activation,
+        preluActivationWeights);
     const pointwiseConvTexData = this.texData.get(pointwiseConv.dataId);
     util.assert(
         pointwiseConvTexData.isPacked,
@@ -1906,7 +1917,7 @@ export class MathBackendWebGL implements KernelBackend {
 
   private conv2dWithIm2Row(
       x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo, bias?: Tensor4D,
-      activation?: Activation): Tensor4D {
+      activation?: Activation, preluActivationWeights?: Tensor): Tensor4D {
     // Rearranges conv2d input so each block to be convolved over forms the
     // column of a new matrix with shape [filterWidth * filterHeight *
     // inChannels, outHeight * outWidth]. The filter is also rearranged so each
@@ -1938,14 +1949,18 @@ export class MathBackendWebGL implements KernelBackend {
         ]) as Tensor3D;
 
     const hasBias = bias != null;
+    const hasPreluActivationWeights = preluActivationWeights != null;
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, true) : null;
     const matmulProgram = new MatMulPackedProgram(
         im2Col.shape, [1, numCols, convInfo.outChannels], transposeA,
-        transposeB, hasBias, fusedActivation);
+        transposeB, hasBias, fusedActivation, hasPreluActivationWeights);
     const inputs: TensorHandle[] = [im2Col, w2Row];
     if (bias) {
       inputs.push(bias);
+    }
+    if (hasPreluActivationWeights) {
+      inputs.push(preluActivationWeights);
     }
     const product = this.compileAndRun<Tensor4D>(matmulProgram, inputs);
 
@@ -1954,25 +1969,32 @@ export class MathBackendWebGL implements KernelBackend {
 
   fusedConv2d(
       x: Tensor4D, filter: Tensor4D, convInfo: Conv2DInfo, bias?: Tensor4D,
-      activation?: Activation): Tensor4D {
+      activation?: Activation, preluActivationWeights?: Tensor): Tensor4D {
     if (convInfo.filterHeight === 1 && convInfo.filterWidth === 1 &&
         convInfo.dilationHeight === 1 && convInfo.dilationWidth === 1 &&
         convInfo.strideHeight === 1 && convInfo.strideWidth === 1 &&
         (convInfo.padInfo.type === 'SAME' ||
          convInfo.padInfo.type === 'VALID')) {
-      return this.conv2dByMatMul(x, filter, convInfo, bias, activation);
+      return this.conv2dByMatMul(
+          x, filter, convInfo, bias, activation, preluActivationWeights);
     }
     if (ENV.getBool('WEBGL_CONV_IM2COL') && x.shape[0] === 1) {
-      return this.conv2dWithIm2Row(x, filter, convInfo, bias, activation);
+      return this.conv2dWithIm2Row(
+          x, filter, convInfo, bias, activation, preluActivationWeights);
     }
 
     const hasBias = bias != null;
+    const hasPreluActivationWeights = preluActivationWeights != null;
     const fusedActivation =
         activation ? mapActivationToShaderProgram(activation, false) : null;
-    const program = new Conv2DProgram(convInfo, hasBias, fusedActivation);
+    const program = new Conv2DProgram(
+        convInfo, hasBias, fusedActivation, hasPreluActivationWeights);
     const inputs: TensorHandle[] = [x, filter];
     if (bias) {
       inputs.push(bias);
+    }
+    if (preluActivationWeights) {
+      inputs.push(preluActivationWeights);
     }
     return this.compileAndRun(program, inputs);
   }

--- a/src/backends/webgl/mulmat_packed_gpu.ts
+++ b/src/backends/webgl/mulmat_packed_gpu.ts
@@ -23,7 +23,6 @@ export class MatMulPackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
 
-  // activationWeights
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
       transposeA = false, transposeB = false, addBias = false,

--- a/src/backends/webgl/mulmat_packed_gpu.ts
+++ b/src/backends/webgl/mulmat_packed_gpu.ts
@@ -23,10 +23,11 @@ export class MatMulPackedProgram implements GPGPUProgram {
   outputShape: number[];
   userCode: string;
 
+  // activationWeights
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
       transposeA = false, transposeB = false, addBias = false,
-      activation: string = null) {
+      activation: string = null, hasPreluActivation = false) {
     this.outputShape = outputShape;
 
     const sharedDim = transposeA ? aShape[1] : aShape[2];
@@ -39,9 +40,16 @@ export class MatMulPackedProgram implements GPGPUProgram {
 
     let activationSnippet = '', applyActivationSnippet = '';
     if (activation) {
-      activationSnippet = `vec4 activation(vec4 x) {
-        ${activation}
-      }`;
+      if (hasPreluActivation) {
+        activationSnippet = `vec4 activation(vec4 a) {
+          vec4 b = getPreluActivationWeightsAtOutCoords();
+          ${activation}
+        }`;
+      } else {
+        activationSnippet = `vec4 activation(vec4 x) {
+          ${activation}
+        }`;
+      }
 
       applyActivationSnippet = `result = activation(result);`;
     }
@@ -49,6 +57,10 @@ export class MatMulPackedProgram implements GPGPUProgram {
     const addBiasSnippet = addBias ? 'result += getBiasAtOutCoords();' : '';
     if (addBias) {
       this.variableNames.push('bias');
+    }
+
+    if (hasPreluActivation) {
+      this.variableNames.push('preluActivationWeights');
     }
 
     this.userCode = `

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -39,14 +39,14 @@ import {Activation} from './fused_util';
  * tf.fused.matMul(a, b, false, false, bias, 'relu').print();
  * ```
  *
- * @param obj Configuration
- *  a First matrix in dot product operation.
- *  b Second matrix in dot product operation.
- *  transposeA If true, `a` is transposed before multiplication.
- *  transposeB If true, `b` is transposed before multiplication.
- *  bias Matrix to be added to the result.
- *  activation Name of activation kernel (defaults to `linear`).
- *  preluActivationWeights Tensor of prelu weights.
+ * @param obj An object with the following properties:
+ * - `a` First matrix in dot product operation.
+ * - `b` Second matrix in dot product operation.
+ * - `transposeA` If true, `a` is transposed before multiplication.
+ * - `transposeB` If true, `b` is transposed before multiplication.
+ * - `bias` Matrix to be added to the result.
+ * - `activation` Name of activation kernel (defaults to `linear`).
+ * - `preluActivationWeights` Tensor of prelu weights.
  */
 /** @doc {heading: 'Operations', subheading: 'Matrices', namespace: 'fused'} */
 function matMul_<T extends Tensor>({
@@ -221,15 +221,15 @@ function matMul_<T extends Tensor>({
  * Computes a 2D convolution over the input x, optionally fused with adding a
  * bias and applying an activation.
  *
- * @param obj Configuration
- *   x The input tensor, of rank 4 or rank 3, of shape
+ * @param obj An object with the following properties:
+ * - `x` The input tensor, of rank 4 or rank 3, of shape
  *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
  * assumed.
- *   filter The filter, rank 4, of shape
+ * - `filter` The filter, rank 4, of shape
  *     `[filterHeight, filterWidth, inDepth, outDepth]`.
- *   strides The strides of the convolution: `[strideHeight,
+ * - `strides` The strides of the convolution: `[strideHeight,
  * strideWidth]`.
- *   pad The type of padding algorithm.
+ * - `pad` The type of padding algorithm.
  *    - `same` and stride 1: output will be of same size as input,
  *       regardless of filter size.
  *    - `valid`: output will be smaller than input if filter is larger
@@ -237,21 +237,23 @@ function matMul_<T extends Tensor>({
  *   - For more info, see this guide:
  *     [https://www.tensorflow.org/api_guides/python/nn#Convolution](
  *          https://www.tensorflow.org/api_guides/python/nn#Convolution)
- *   dataFormat: An optional string from: "NHWC", "NCHW". Defaults to
+ * - `dataFormat` An optional string from: "NHWC", "NCHW". Defaults to
  *     "NHWC". Specify the data format of the input and output data. With the
  *     default format "NHWC", the data is stored in the order of: [batch,
  *     height, width, channels]. Only "NHWC" is currently supported.
- *   dilations The dilation rates: `[dilationHeight, dilationWidth]`
+ * - `dilations` The dilation rates: `[dilationHeight, dilationWidth]`
  *     in which we sample input values across the height and width dimensions
  *     in atrous convolution. Defaults to `[1, 1]`. If `dilations` is a single
  *     number, then `dilationHeight == dilationWidth`. If it is greater than
  *     1, then all values of `strides` must be 1.
- *   dimRoundingMode The rounding mode used when computing output
+ * - `dimRoundingMode` The rounding mode used when computing output
  *     dimensions if pad is a number. If none is provided, it will not round
  *     and error if the output is of fractional size.
- *   bias Tensor to be added to the result.
- *   activation Name of activation kernel (defaults to `linear`).
- *   preluActivationWeights Tensor of prelu weights.
+ * - `bias` Tensor to be added to the result.
+ * - `activation` Name of activation kernel (defaults to `linear`) to be applied
+ *      after biasAdd.
+ * - `preluActivationWeights` Tensor of prelu weights to be applied as part of a
+ *     `prelu` activation, typically the same shape as `x`.
  */
 /** @doc {heading: 'Operations', subheading: 'Convolution'} */
 function conv2d_<T extends Tensor3D|Tensor4D>({

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -39,13 +39,14 @@ import {Activation} from './fused_util';
  * tf.fused.matMul(a, b, false, false, bias, 'relu').print();
  * ```
  *
- * @param a First matrix in dot product operation.
- * @param b Second matrix in dot product operation.
- * @param transposeA If true, `a` is transposed before multiplication.
- * @param transposeB If true, `b` is transposed before multiplication.
- * @param bias Matrix to be added to the result.
- * @param activation Name of activation kernel (defaults to `linear`).
- * @param preluActivationWeights Tensor of prelu weights.
+ * @param obj Configuration
+ *  a First matrix in dot product operation.
+ *  b Second matrix in dot product operation.
+ *  transposeA If true, `a` is transposed before multiplication.
+ *  transposeB If true, `b` is transposed before multiplication.
+ *  bias Matrix to be added to the result.
+ *  activation Name of activation kernel (defaults to `linear`).
+ *  preluActivationWeights Tensor of prelu weights.
  */
 /** @doc {heading: 'Operations', subheading: 'Matrices', namespace: 'fused'} */
 function matMul_<T extends Tensor>({
@@ -220,14 +221,15 @@ function matMul_<T extends Tensor>({
  * Computes a 2D convolution over the input x, optionally fused with adding a
  * bias and applying an activation.
  *
- * @param x The input tensor, of rank 4 or rank 3, of shape
+ * @param obj Configuration
+ *   x The input tensor, of rank 4 or rank 3, of shape
  *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
  * assumed.
- * @param filter The filter, rank 4, of shape
+ *   filter The filter, rank 4, of shape
  *     `[filterHeight, filterWidth, inDepth, outDepth]`.
- * @param strides The strides of the convolution: `[strideHeight,
+ *   strides The strides of the convolution: `[strideHeight,
  * strideWidth]`.
- * @param pad The type of padding algorithm.
+ *   pad The type of padding algorithm.
  *    - `same` and stride 1: output will be of same size as input,
  *       regardless of filter size.
  *    - `valid`: output will be smaller than input if filter is larger
@@ -235,30 +237,46 @@ function matMul_<T extends Tensor>({
  *   - For more info, see this guide:
  *     [https://www.tensorflow.org/api_guides/python/nn#Convolution](
  *          https://www.tensorflow.org/api_guides/python/nn#Convolution)
- * @param dataFormat: An optional string from: "NHWC", "NCHW". Defaults to
+ *   dataFormat: An optional string from: "NHWC", "NCHW". Defaults to
  *     "NHWC". Specify the data format of the input and output data. With the
  *     default format "NHWC", the data is stored in the order of: [batch,
  *     height, width, channels]. Only "NHWC" is currently supported.
- * @param dilations The dilation rates: `[dilationHeight, dilationWidth]`
+ *   dilations The dilation rates: `[dilationHeight, dilationWidth]`
  *     in which we sample input values across the height and width dimensions
  *     in atrous convolution. Defaults to `[1, 1]`. If `dilations` is a single
  *     number, then `dilationHeight == dilationWidth`. If it is greater than
  *     1, then all values of `strides` must be 1.
- * @param dimRoundingMode The rounding mode used when computing output
+ *   dimRoundingMode The rounding mode used when computing output
  *     dimensions if pad is a number. If none is provided, it will not round
  *     and error if the output is of fractional size.
- * @param bias Tensor to be added to the result.
- * @param activation Name of activation kernel (defaults to `linear`).
- * @param preluActivationWeights Tensor of prelu weights.
+ *   bias Tensor to be added to the result.
+ *   activation Name of activation kernel (defaults to `linear`).
+ *   preluActivationWeights Tensor of prelu weights.
  */
 /** @doc {heading: 'Operations', subheading: 'Convolution'} */
-function conv2d_<T extends Tensor3D|Tensor4D>(
-    x: T|TensorLike, filter: Tensor4D|TensorLike,
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dataFormat: 'NHWC'|'NCHW' = 'NHWC',
-    dilations: [number, number]|number = [1, 1],
-    dimRoundingMode?: 'floor'|'round'|'ceil', bias?: Tensor|TensorLike,
-    activation: Activation = 'linear', preluActivationWeights?: Tensor): T {
+function conv2d_<T extends Tensor3D|Tensor4D>({
+  x,
+  filter,
+  strides,
+  pad,
+  dataFormat = 'NHWC',
+  dilations = [1, 1],
+  dimRoundingMode,
+  bias,
+  activation = 'linear',
+  preluActivationWeights
+}: {
+  x: T|TensorLike,
+  filter: Tensor4D|TensorLike,
+  strides: [number, number]|number,
+  pad: 'valid'|'same'|number,
+  dataFormat?: 'NHWC'|'NCHW',
+  dilations?: [number, number]|number,
+  dimRoundingMode?: 'floor'|'round'|'ceil',
+  bias?: Tensor|TensorLike,
+  activation?: Activation,
+  preluActivationWeights?: Tensor
+}): T {
   const $x = convertToTensor(x, 'x', 'conv2d');
   const $filter = convertToTensor(filter, 'filter', 'conv2d');
 

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -36,7 +36,7 @@ import {Activation} from './fused_util';
  * const b = tf.tensor2d([1, 2, 3, 4], [2, 2]);
  * const bias = tf.tensor2d([1, 2], [1, 2]);
  *
- * tf.fused.matMul(a, b, false, false, bias, 'relu').print();
+ * tf.fused.matMul({a, b, bias, activation: 'relu'}).print();
  * ```
  *
  * @param obj An object with the following properties:
@@ -220,6 +220,23 @@ function matMul_<T extends Tensor>({
 /**
  * Computes a 2D convolution over the input x, optionally fused with adding a
  * bias and applying an activation.
+ *
+ * ```js
+ * const inputDepth = 2;
+ * const inShape = [2, 2, 2, inputDepth];
+ * const outputDepth = 2;
+ * const fSize = 1;
+ * const pad = 0;
+ * const strides = 1;
+ *
+ * const x = tf.tensor4d( [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+ * 16], inShape);
+ * const w = tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth,
+ * outputDepth]);
+ *
+ * tf.fused.conv2d({ x, filter: w, strides, pad, dataFormat: 'NHWC',
+ * dilations: [1, 1], bias: tf.scalar(5), activation: 'relu' }).print();
+ * ```
  *
  * @param obj An object with the following properties:
  * - `x` The input tensor, of rank 4 or rank 3, of shape

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -188,9 +188,15 @@ function matMul_<T extends Tensor>(
   }
 
   const res = ENGINE.runKernel((backend, save) => {
-    const y = backend.fusedBatchMatMul(
-        a3D, b3D, transposeA, transposeB, $bias, activation,
-        $preluActivationWeights);
+    const y = backend.fusedBatchMatMul({
+      a: a3D,
+      b: b3D,
+      transposeA,
+      transposeB,
+      bias: $bias,
+      activation,
+      preluActivationWeights: $preluActivationWeights
+    });
     save([a3D, b3D, y]);
     return y;
   }, inputs, grad);

--- a/src/ops/fused_ops.ts
+++ b/src/ops/fused_ops.ts
@@ -48,10 +48,23 @@ import {Activation} from './fused_util';
  * @param preluActivationWeights Tensor of prelu weights.
  */
 /** @doc {heading: 'Operations', subheading: 'Matrices', namespace: 'fused'} */
-function matMul_<T extends Tensor>(
-    a: T|TensorLike, b: T|TensorLike, transposeA = false, transposeB = false,
-    bias?: Tensor|TensorLike, activation: Activation = 'linear',
-    preluActivationWeights?: Tensor): T {
+function matMul_<T extends Tensor>({
+  a,
+  b,
+  transposeA = false,
+  transposeB = false,
+  bias,
+  activation = 'linear',
+  preluActivationWeights
+}: {
+  a: T|TensorLike,
+  b: T|TensorLike,
+  transposeA?: boolean,
+  transposeB?: boolean,
+  bias?: Tensor|TensorLike,
+  activation?: Activation,
+  preluActivationWeights?: Tensor
+}): T {
   let $a = convertToTensor(a, 'a', 'fused matMul');
   let $b = convertToTensor(b, 'b', 'fused matMul');
   [$a, $b] = makeTypesMatch($a, $b);

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -273,6 +273,31 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     expectArraysClose(await result.data(), expected);
   });
 
+  it('basic with prelu', async () => {
+    const inputDepth = 2;
+    const inShape: [number, number, number, number] = [2, 2, 2, inputDepth];
+    const outputDepth = 2;
+    const fSize = 1;
+    const pad = 0;
+    const stride = 1;
+
+    const x = tf.tensor4d(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], inShape);
+    const alpha = tf.tensor3d([0.25, 0.75], [1, 1, 2]);
+    const w =
+        tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
+
+    const result = tf.fused.conv2d(
+        x, w, stride, pad, 'NHWC', [1, 1], null, null, 'prelu', alpha);
+    expect(result.shape).toEqual([2, 2, 2, 2]);
+    const expected = [
+      -1.25, 2, -2.75, 5, -4.25, 8, -5.75, 11, -7.25, 14, -8.75, 17, -10.25, 20,
+      -11.75, 23
+    ];
+
+    expectArraysClose(await result.data(), expected);
+  });
+
   it('basic with bias and relu', async () => {
     const inputDepth = 2;
     const inShape: [number, number, number, number] = [2, 2, 2, inputDepth];

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -282,7 +282,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w =
         tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result = tf.fused.conv2d(x, w, stride, pad);
+    const result = tf.fused.conv2d({x, filter: w, strides: stride, pad});
     expect(result.shape).toEqual([2, 2, 2, 2]);
     const expected =
         [-5, 2, -11, 5, -17, 8, -23, 11, -29, 14, -35, 17, -41, 20, -47, 23];
@@ -303,8 +303,15 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w =
         tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result =
-        tf.fused.conv2d(x, w, stride, pad, 'NHWC', [1, 1], null, null, 'relu');
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides: stride,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'relu'
+    });
     expect(result.shape).toEqual([2, 2, 2, 2]);
     const expected = [0, 2, 0, 5, 0, 8, 0, 11, 0, 14, 0, 17, 0, 20, 0, 23];
 
@@ -325,8 +332,16 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w =
         tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result = tf.fused.conv2d(
-        x, w, stride, pad, 'NHWC', [1, 1], null, null, 'prelu', alpha);
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides: stride,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'prelu',
+      preluActivationWeights: alpha
+    });
     expect(result.shape).toEqual([2, 2, 2, 2]);
     const expected = [
       -1.25, 2, -2.75, 5, -4.25, 8, -5.75, 11, -7.25, 14, -8.75, 17, -10.25, 20,
@@ -349,8 +364,16 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w =
         tf.tensor4d([-1, 1, -2, 0.5], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result = tf.fused.conv2d(
-        x, w, stride, pad, 'NHWC', [1, 1], null, tf.scalar(5), 'relu');
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides: stride,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      bias: tf.scalar(5),
+      activation: 'relu'
+    });
     expect(result.shape).toEqual([2, 2, 2, 2]);
     const expected = [0, 7, 0, 10, 0, 13, 0, 16, 0, 19, 0, 22, 0, 25, 0, 28];
 
@@ -363,7 +386,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 3;
     const fSize = 1;
     const pad = 'same';
-    const stride: [number, number] = [2, 2];
+    const strides: [number, number] = [2, 2];
 
     const x = tf.tensor3d(
         [
@@ -372,7 +395,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
         inputShape);
     const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result = tf.fused.conv2d(x, w, stride, pad);
+    const result = tf.fused.conv2d({x, filter: w, strides, pad});
 
     expectArraysClose(
         await result.data(),
@@ -385,7 +408,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 3;
     const fSize = 1;
     const pad = 'same';
-    const stride: [number, number] = [2, 2];
+    const strides: [number, number] = [2, 2];
 
     const x = tf.tensor3d(
         [
@@ -394,8 +417,15 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
         inputShape);
     const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result =
-        tf.fused.conv2d(x, w, stride, pad, 'NHWC', [1, 1], null, null, 'relu');
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'relu'
+    });
 
     expectArraysClose(
         await result.data(), [10, 5, 10, 50, 25, 50, 0, 0, 0, 0, 0, 0]);
@@ -407,7 +437,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 3;
     const fSize = 1;
     const pad = 'same';
-    const stride: [number, number] = [2, 2];
+    const strides: [number, number] = [2, 2];
 
     const x = tf.tensor3d(
         [
@@ -417,8 +447,16 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
     const alpha = tf.tensor3d([0.5], [1, 1, inputDepth]);
 
-    const result = tf.fused.conv2d(
-        x, w, stride, pad, 'NHWC', [1, 1], null, null, 'prelu', alpha);
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'prelu',
+      preluActivationWeights: alpha
+    });
 
     expectArraysClose(
         await result.data(),
@@ -431,7 +469,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 3;
     const fSize = 1;
     const pad = 'same';
-    const stride: [number, number] = [1, 1];
+    const strides: [number, number] = [1, 1];
 
     const x = tf.tensor3d(
         [
@@ -441,8 +479,16 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
     const alpha = tf.tensor3d([0.5], [1, 1, inputDepth]);
 
-    const result = tf.fused.conv2d(
-        x, w, stride, pad, 'NHWC', [1, 1], null, null, 'prelu', alpha);
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      activation: 'prelu',
+      preluActivationWeights: alpha
+    });
 
     expectArraysClose(await result.data(), [
       10,  5,    10,  30,  15,   30,  50,  25,    50,  70,  35,    70,
@@ -458,7 +504,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 3;
     const fSize = 1;
     const pad = 'same';
-    const stride: [number, number] = [2, 2];
+    const strides: [number, number] = [2, 2];
 
     const x = tf.tensor3d(
         [
@@ -467,8 +513,16 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
         inputShape);
     const w = tf.tensor4d([1, 0.5, 1], [fSize, fSize, inputDepth, outputDepth]);
 
-    const result = tf.fused.conv2d(
-        x, w, stride, pad, 'NHWC', [1, 1], null, tf.scalar(5), 'relu');
+    const result = tf.fused.conv2d({
+      x,
+      filter: w,
+      strides,
+      pad,
+      dataFormat: 'NHWC',
+      dilations: [1, 1],
+      bias: tf.scalar(5),
+      activation: 'relu'
+    });
 
     expectArraysClose(
         await result.data(), [15, 10, 15, 55, 30, 55, 0, 0, 0, 0, 0, 0]);
@@ -479,7 +533,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 1;
     const inputShape: [number, number, number, number] = [2, 3, 3, inputDepth];
     const filterSize = 2;
-    const stride = 1;
+    const strides = 1;
     const pad = 0;
 
     const filterShape: [number, number, number, number] =
@@ -492,7 +546,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
 
     const grads = tf.grads(
         (x: tf.Tensor4D, filter: tf.Tensor4D) =>
-            tf.fused.conv2d(x, filter, stride, pad));
+            tf.fused.conv2d({x, filter, strides, pad}));
     const [dx, dfilter] = grads([x, filter], dy);
 
     expect(dx.shape).toEqual(x.shape);
@@ -509,7 +563,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
     const outputDepth = 1;
     const inputShape: [number, number, number, number] = [2, 3, 3, inputDepth];
     const filterSize = 2;
-    const stride = 1;
+    const strides = 1;
     const pad = 0;
 
     const filterShape: [number, number, number, number] =
@@ -521,14 +575,21 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9], inputShape);
     const dy = tf.tensor4d([3, 1, 2, 0, 3, 1, 2, 0], [2, 2, 2, 1]);
 
-    const fusedGrads = tf.grads(
-        (x: tf.Tensor4D, w: tf.Tensor4D, b) =>
-            tf.fused.conv2d(x, w, stride, pad, 'NHWC', [1, 1], null, b));
+    const fusedGrads =
+        tf.grads((x: tf.Tensor4D, w: tf.Tensor4D, b) => tf.fused.conv2d({
+          x,
+          filter: w,
+          strides,
+          pad,
+          dataFormat: 'NHWC',
+          dilations: [1, 1],
+          bias: b
+        }));
     const [dxFused, dfilterFused, dbiasFused] =
         fusedGrads([x, filter, bias], dy);
 
     const grads = tf.grads((x: tf.Tensor4D, filter: tf.Tensor4D, bias) => {
-      const conv = tf.conv2d(x, filter, stride, pad);
+      const conv = tf.conv2d(x, filter, strides, pad);
       const sum = tf.add(conv, bias);
       return sum;
     });
@@ -546,7 +607,7 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
        const inputShape: [number, number, number, number] =
            [2, 3, 3, inputDepth];
        const filterSize = 2;
-       const stride = 1;
+       const strides = 1;
        const pad = 0;
 
        const filterShape: [number, number, number, number] =
@@ -558,14 +619,22 @@ describeWithFlags('fused conv2d', ALL_ENVS, () => {
            [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9], inputShape);
        const dy = tf.tensor4d([3, 1, 2, 0, 3, 1, 2, 0], [2, 2, 2, 1]);
 
-       const fusedGrads = tf.grads(
-           (x: tf.Tensor4D, w: tf.Tensor4D, b) => tf.fused.conv2d(
-               x, w, stride, pad, 'NHWC', [1, 1], null, b, 'relu'));
+       const fusedGrads =
+           tf.grads((x: tf.Tensor4D, w: tf.Tensor4D, b) => tf.fused.conv2d({
+             x,
+             filter: w,
+             strides,
+             pad,
+             dataFormat: 'NHWC',
+             dilations: [1, 1],
+             bias: b,
+             activation: 'relu'
+           }));
        const [dxFused, dfilterFused, dbiasFused] =
            fusedGrads([x, filter, bias], dy);
 
        const grads = tf.grads((x: tf.Tensor4D, filter: tf.Tensor4D, bias) => {
-         const conv = tf.conv2d(x, filter, stride, pad);
+         const conv = tf.conv2d(x, filter, strides, pad);
          const sum = tf.add(conv, bias);
          return tf.relu(sum);
        });

--- a/src/ops/fused_test.ts
+++ b/src/ops/fused_test.ts
@@ -24,7 +24,7 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const a = tf.tensor2d([1, 2, 3, 4, 5, 6], [2, 3]);
     const b = tf.tensor2d([0, 1, -3, 2, 2, 1], [3, 2]);
 
-    const c = tf.fused.matMul(a, b);
+    const c = tf.fused.matMul({a, b});
 
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(await c.data(), [0, 8, -3, 20]);
@@ -36,7 +36,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const c = tf.fused.matMul(a, b, transposeA, transposeB, null, 'relu');
+    const c = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: null, activation: 'relu'});
 
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(await c.data(), [0, 8, 0, 20]);
@@ -49,8 +50,15 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const c =
-        tf.fused.matMul(a, b, transposeA, transposeB, null, 'prelu', alpha);
+    const c = tf.fused.matMul({
+      a,
+      b,
+      transposeA,
+      transposeB,
+      bias: null,
+      activation: 'prelu',
+      preluActivationWeights: alpha
+    });
 
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(await c.data(), [0, 8, -1.5, 20]);
@@ -62,7 +70,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = true;
 
-    const c = tf.fused.matMul(a, b, transposeA, transposeB, null, 'relu');
+    const c = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: null, activation: 'relu'});
 
     expect(c.shape).toEqual([2, 2]);
     expectArraysClose(await c.data(), [0, 9, 0, 24]);
@@ -75,7 +84,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const d = tf.fused.matMul(a, b, transposeA, transposeB, c, 'relu');
+    const d = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: c, activation: 'relu'});
 
     expect(d.shape).toEqual([2, 2]);
     expectArraysClose(await d.data(), [1, 9, 0, 21]);
@@ -89,7 +99,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const d = tf.fused.matMul(a, b, transposeA, transposeB, c, act);
+    const d = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: c, activation: act});
 
     expect(d.shape).toEqual([2, 2]);
     expectArraysClose(await d.data(), [1, 9, 0, 21]);
@@ -103,7 +114,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const d = tf.fused.matMul(a, b, transposeA, transposeB, c, act);
+    const d = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: c, activation: act});
 
     expect(d.shape).toEqual([2, 2, 2]);
     expectArraysClose(await d.data(), [2, 6, 0, 18, 0, 30, 0, 42]);
@@ -116,7 +128,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     const transposeA = false;
     const transposeB = false;
 
-    const d = tf.fused.matMul(a, b, transposeA, transposeB, c, 'linear');
+    const d = tf.fused.matMul(
+        {a, b, transposeA, transposeB, bias: c, activation: 'linear'});
 
     expect(d.shape).toEqual([2, 2]);
     expectArraysClose(await d.data(), [1, 9, -2, 21]);
@@ -135,7 +148,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     });
 
     const fusedGrads = tf.grads((a, b) => {
-      return tf.fused.matMul(a, b, transposeA, transposeB, null, 'relu');
+      return tf.fused.matMul(
+          {a, b, transposeA, transposeB, bias: null, activation: 'relu'});
     });
 
     const [da, db] = grads([a, b], dy);
@@ -153,7 +167,14 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
 
     const fusedGrads = tf.grads((a, b) => {
       return tf.fused
-          .matMul(a.clone(), b.clone(), transposeA, transposeB, null, 'relu')
+          .matMul({
+            a: a.clone(),
+            b: b.clone(),
+            transposeA,
+            transposeB,
+            bias: null,
+            activation: 'relu'
+          })
           .clone();
     });
 
@@ -178,7 +199,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     });
 
     const fusedGrads = tf.grads((a, b, c) => {
-      return tf.fused.matMul(a, b, transposeA, transposeB, c, 'relu');
+      return tf.fused.matMul(
+          {a, b, transposeA, transposeB, bias: c, activation: 'relu'});
     });
 
     const [da, db, dc] = grads([a, b, c], dy);
@@ -205,7 +227,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     });
 
     const fusedGrads = tf.grads((a, b, c) => {
-      return tf.fused.matMul(a, b, transposeA, transposeB, c, 'relu');
+      return tf.fused.matMul(
+          {a, b, transposeA, transposeB, bias: c, activation: 'relu'});
     });
 
     const [da, db, dc] = grads([a, b, c], dy);
@@ -232,7 +255,8 @@ describeWithFlags('fused matmul', ALL_ENVS, () => {
     });
 
     const fusedGrads = tf.grads((a, b, c) => {
-      return tf.fused.matMul(a, b, transposeA, transposeB, c, 'relu');
+      return tf.fused.matMul(
+          {a, b, transposeA, transposeB, bias: c, activation: 'relu'});
     });
 
     const [da, db, dc] = grads([a, b, c], dy);

--- a/src/ops/fused_util.ts
+++ b/src/ops/fused_util.ts
@@ -15,4 +15,4 @@
  * =============================================================================
  */
 
-export type Activation = 'linear'|'relu';
+export type Activation = 'linear'|'relu'|'prelu';

--- a/src/ops/fused_util.ts
+++ b/src/ops/fused_util.ts
@@ -15,4 +15,16 @@
  * =============================================================================
  */
 
+import {Tensor, Tensor3D} from '../tensor';
+
 export type Activation = 'linear'|'relu'|'prelu';
+
+export type FusedBatchMatMulConfig = {
+  a: Tensor3D,
+  b: Tensor3D,
+  transposeA: boolean,
+  transposeB: boolean,
+  bias?: Tensor,
+  activation?: Activation,
+  preluActivationWeights?: Tensor
+};


### PR DESCRIPTION
#### Changes

- Add `preluActivationWeights` to conv and matMul fused kernels

Prelu weights are typically broadcasted from final dimension of `x`.

E.g. some typical inputs:
`x.shape`: [1, 64, 64, 16]
`a.shape`: [1, 1, 16]

Holding off on implementing gradients for fused prelu because the alpha gradient needs access to an intermediate tensor that's buried in the fused kernel.

To see the logs from the Cloud Build CI, please join either
our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs)
or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1867)
<!-- Reviewable:end -->
