### PR TITLE
Reduce the size of the gramSchmidt-non-tiny test

### DIFF
--- a/src/backends/webgl/webgl_ops_test.ts
+++ b/src/backends/webgl/webgl_ops_test.ts
@@ -432,13 +432,13 @@ describeWithFlags('conv to matmul', PACKED_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  it('16x32', async () => {
+  fit('8x16', async () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
-    const xs = tf.randomUniform([16, 32]) as Tensor2D;
+    const xs = tf.randomUniform([8, 16]) as Tensor2D;
     const y = tf.linalg.gramSchmidt(xs) as Tensor2D;
     expectArraysClose(
-        await y.matMul(y.transpose()).data(), await tf.eye(16).data());
+        await y.matMul(y.transpose()).data(), await tf.eye(8).data());
   });
 });
 

--- a/src/backends/webgl/webgl_ops_test.ts
+++ b/src/backends/webgl/webgl_ops_test.ts
@@ -432,7 +432,7 @@ describeWithFlags('conv to matmul', PACKED_ENVS, () => {
 // For operations on non-trivial matrix sizes, we skip the CPU-only ENV and use
 // only WebGL ENVs.
 describeWithFlags('gramSchmidt-non-tiny', WEBGL_ENVS, () => {
-  fit('8x16', async () => {
+  it('8x16', async () => {
     // Part of this test's point is that operation on a matrix of this size
     // can complete in the timeout limit of the unit test.
     const xs = tf.randomUniform([8, 16]) as Tensor2D;


### PR DESCRIPTION
Without the change, the test prints slowness warning on my machine:

> Chrome 76.0.3809 (Linux 0.0.0) SLOW 0.708 secs: gramSchmidt-non-tiny webgl1 {"WEBGL_VERSION":1,"WEBGL_CPU_FORWARD":false,"WEBGL_SIZE_UPLOAD_UNIFORM":0} 16x32
> .
> Chrome 76.0.3809 (Linux 0.0.0) SLOW 0.641 secs: gramSchmidt-non-tiny webgl2 {"WEBGL_VERSION":2,"WEBGL_CPU_FORWARD":false,"WEBGL_SIZE_UPLOAD_UNIFORM":0} 16x32

With the change, it no longer prints the warning.

DEV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-core/1872)
<!-- Reviewable:end -->
